### PR TITLE
fixup(oidcAuth): generate state during auth call when PKCE is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 After compiling the project with npm (see previous section) simply run:
 
 ```
-docker built -t linagora/twake-calendar-front .
+docker build -t linagora/twake-calendar-front .
 ```
 
 Then edit `.env.js` in order to match your configuration then run it with:

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -1,6 +1,6 @@
 var SSO_BASE_URL = "https://example.com";
 var SSO_CLIENT_ID = "example";
-var SSO_SCOPE = "openid name email";
+var SSO_SCOPE = "openid profile email";
 var SSO_REDIRECT_URI = "https://example.com/callback";
 var SSO_RESPONSE_TYPE = "code";
 var SSO_CODE_CHALLENGE_METHOD = "S256";

--- a/src/features/User/oidcAuth.ts
+++ b/src/features/User/oidcAuth.ts
@@ -22,17 +22,14 @@ export async function Auth() {
   let code_verifier = client.randomPKCECodeVerifier();
   let code_challenge = await client.calculatePKCECodeChallenge(code_verifier);
   const openIdClientConfig = await getClientConfig();
+  let state = client.randomState();
   let parameters: Record<string, string> = {
     redirect_uri: clientConfig.redirect_uri,
     scope: clientConfig.scope!,
     code_challenge,
     code_challenge_method: clientConfig.code_challenge_method,
+    state,
   };
-  let state!: string;
-  if (!openIdClientConfig.serverMetadata().supportsPKCE()) {
-    state = client.randomState();
-    parameters.state = state;
-  }
   let redirectTo = client.buildAuthorizationUrl(openIdClientConfig, parameters);
 
   return { redirectTo, code_verifier, state };


### PR DESCRIPTION
Not sure if this is a bug or an intentional design. I ran into an issue with the Angular app when integrating with an OIDC provider — the missing state caused problems during auth.

This PR is meant as a reference for frontend developer to consider.

Ref: https://github.com/linagora/twake-calendar-side-service/pull/259/files