### PR TITLE
fix: Build issue on Mac ARM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "devDependencies": {
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.27.1",
-        "@rsbuild/core": "^1.4.3",
+        "@rsbuild/core": "^1.5.2",
         "@rsbuild/plugin-react": "^1.3.3",
         "@rsbuild/plugin-svgr": "^1.2.0",
         "@testing-library/dom": "^10.4.0",
@@ -2064,6 +2064,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "license": "MIT",
@@ -2965,50 +2999,62 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "0.16.0",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.18.0.tgz",
+      "integrity": "sha512-Woonm8ehyVIUPXChmbu80Zj6uJkC0dD9SJUZ/wOPtO8iiz/m+dkrOugAuKgoiR6qH4F+yorWila954tBz4uKsQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/runtime": {
-      "version": "0.16.0",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.18.0.tgz",
+      "integrity": "sha512-+C4YtoSztM7nHwNyZl6dQKGUVJdsPrUdaf3HIKReg/GQbrt9uvOlUWo2NXMZ8vDAnf/QRrpSYAwXHmWDn9Obaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.16.0",
-        "@module-federation/runtime-core": "0.16.0",
-        "@module-federation/sdk": "0.16.0"
+        "@module-federation/error-codes": "0.18.0",
+        "@module-federation/runtime-core": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "0.16.0",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.18.0.tgz",
+      "integrity": "sha512-ZyYhrDyVAhUzriOsVfgL6vwd+5ebYm595Y13KeMf6TKDRoUHBMTLGQ8WM4TDj8JNsy7LigncK8C03fn97of0QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "0.16.0",
-        "@module-federation/sdk": "0.16.0"
+        "@module-federation/error-codes": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "0.16.0",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.18.0.tgz",
+      "integrity": "sha512-fSga9o4t1UfXNV/Kh6qFvRyZpPp3EHSPRISNeyT8ZoTpzDNiYzhtw0BPUSSD8m6C6XQh2s/11rI4g80UY+d+hA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.16.0",
-        "@module-federation/webpack-bundler-runtime": "0.16.0"
+        "@module-federation/runtime": "0.18.0",
+        "@module-federation/webpack-bundler-runtime": "0.18.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "0.16.0",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.18.0.tgz",
+      "integrity": "sha512-Lo/Feq73tO2unjmpRfyyoUkTVoejhItXOk/h5C+4cistnHbTV8XHrW/13fD5e1Iu60heVdAhhelJd6F898Ve9A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.16.0",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.18.0.tgz",
+      "integrity": "sha512-TEvErbF+YQ+6IFimhUYKK3a5wapD90d90sLsNpcu2kB3QGT7t4nIluE25duXuZDVUKLz86tEPrza/oaaCWTpvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "0.16.0",
-        "@module-federation/sdk": "0.16.0"
+        "@module-federation/runtime": "0.18.0",
+        "@module-federation/sdk": "0.18.0"
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -3228,6 +3274,19 @@
         }
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
+      "integrity": "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.5",
+        "@emnapi/runtime": "^1.4.5",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "dev": true,
@@ -3353,21 +3412,23 @@
       }
     },
     "node_modules/@rsbuild/core": {
-      "version": "1.4.7",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-anCa6Z4c/sDB5MKDvvYfDUJX2y3E4q2SOjQWvQb2Kv8z+JdEPf7XIJpfiqARf4Q1HReJjFAyjrkwwhyESAP0EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rspack/core": "1.4.8",
+        "@rspack/core": "1.5.1",
         "@rspack/lite-tapable": "~1.0.1",
         "@swc/helpers": "^0.5.17",
-        "core-js": "~3.44.0",
-        "jiti": "^2.4.2"
+        "core-js": "~3.45.1",
+        "jiti": "^2.5.1"
       },
       "bin": {
         "rsbuild": "bin/rsbuild.js"
       },
       "engines": {
-        "node": ">=16.10.0"
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@rsbuild/plugin-react": {
@@ -3399,24 +3460,84 @@
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "1.4.8",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.5.1.tgz",
+      "integrity": "sha512-/RdQwmnXNjUG1ysf63R/tdWCyDQ5GSqbvOMsTuBd+3r3qnyCCAEPg6ed3vwI+GvnRXw1QzOXF98b+tkt0eFESA==",
       "dev": true,
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.4.8",
-        "@rspack/binding-darwin-x64": "1.4.8",
-        "@rspack/binding-linux-arm64-gnu": "1.4.8",
-        "@rspack/binding-linux-arm64-musl": "1.4.8",
-        "@rspack/binding-linux-x64-gnu": "1.4.8",
-        "@rspack/binding-linux-x64-musl": "1.4.8",
-        "@rspack/binding-wasm32-wasi": "1.4.8",
-        "@rspack/binding-win32-arm64-msvc": "1.4.8",
-        "@rspack/binding-win32-ia32-msvc": "1.4.8",
-        "@rspack/binding-win32-x64-msvc": "1.4.8"
+        "@rspack/binding-darwin-arm64": "1.5.1",
+        "@rspack/binding-darwin-x64": "1.5.1",
+        "@rspack/binding-linux-arm64-gnu": "1.5.1",
+        "@rspack/binding-linux-arm64-musl": "1.5.1",
+        "@rspack/binding-linux-x64-gnu": "1.5.1",
+        "@rspack/binding-linux-x64-musl": "1.5.1",
+        "@rspack/binding-wasm32-wasi": "1.5.1",
+        "@rspack/binding-win32-arm64-msvc": "1.5.1",
+        "@rspack/binding-win32-ia32-msvc": "1.5.1",
+        "@rspack/binding-win32-x64-msvc": "1.5.1"
       }
     },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.5.1.tgz",
+      "integrity": "sha512-iPQUqNrwmr3IH451EOrmAnADEwkxMnM83VnG3opzYMu2ipuWQdJXcnQ0m/qzoKeoNQ9zhLfdGdMQqvP5pV/Tlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.5.1.tgz",
+      "integrity": "sha512-Kcx8bTDdKqOe5sDUw+NFF+GzRgBHRYVs0NlVKlvKW59EIw0PEvcs0GKL0wDwkFuTL3+GRk4Uec+qHyIkv50SNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.5.1.tgz",
+      "integrity": "sha512-6TeGUOy9De3E/XcbmcPW9YkAK2wfB7/K6UAtXp4oWiVjueQJj3FMFnRkzatagOUDoSRASqz2JiQKiMDvQpGu+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.5.1.tgz",
+      "integrity": "sha512-qHXHDG+5z2zZ2CYYisvmLQQ6f8E1yiP/lyfGTpOF8KGz5eZEWkSdYXUdctE9PWW9lVkapWcuz9eP1Nt74KSvvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.4.8",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-ywQcyc3s0XNspkbsN+glrnSoyWJOcaLDr536kY5SoAgfiaKlg9Fmg42jAwEv9SUSx3jRxyqaFCsSjNv5/mvBsA==",
       "cpu": [
         "x64"
       ],
@@ -3428,7 +3549,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.4.8",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.5.1.tgz",
+      "integrity": "sha512-0nF959K2pZMdRQewohjHxWSD97lIXlOh/xznr0f3zpFv2M/cB1HjHqD/yvZNgU+/hDdEeXplJp7WpD+/tJzX3w==",
       "cpu": [
         "x64"
       ],
@@ -3439,17 +3562,75 @@
         "linux"
       ]
     },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.5.1.tgz",
+      "integrity": "sha512-iM+p8qIWH1uYxKh+MfNyCQ5Ia2QaGeKaGYPzikKakLAK2XaUCflmWP8fGppVUYxX0+b1a4tBOZveN8g1QeZsXw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.1"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.5.1.tgz",
+      "integrity": "sha512-vTbYk5wixqTNs7DE+HHYYol1bl1wg8vkvShdnWFV8kQ8PPwZymNuLbuLng7yp8tN2FKWaQ5YTuhmIrzF3dLuzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.5.1.tgz",
+      "integrity": "sha512-QPUy14Lu4CVpnarGhLoe0Dg+zF1bUAonVdEZSP9DttI1NOBkvl39c1WnnY33c1nwps0n/EQBoGJXDaTVuZfS+Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.5.1.tgz",
+      "integrity": "sha512-Qxl/P2NPYhKM1RqQZtSNauYIvTXb4G4gPOFRHc8iLZRnjN0cxRxJcoonz/hBX436qnv5ZYs7wEqZe2HQCBUtmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rspack/core": {
-      "version": "1.4.8",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.5.1.tgz",
+      "integrity": "sha512-/zWrSNFfdTFKyZP1X3Hhg7kcEsd5//GUABbVvr3P5z4HO+gYEnnaXP1Ciu0wlYke+c3M0b5pvnqB+ka0YbYeTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime-tools": "0.16.0",
-        "@rspack/binding": "1.4.8",
+        "@module-federation/runtime-tools": "0.18.0",
+        "@rspack/binding": "1.5.1",
         "@rspack/lite-tapable": "1.0.1"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.12.0"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.1"
@@ -3462,6 +3643,8 @@
     },
     "node_modules/@rspack/lite-tapable": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.0.1.tgz",
+      "integrity": "sha512-VynGOEsVw2s8TAlLf/uESfrgfrq2+rcXB1muPJYBWbsm1Oa6r5qVQhjA5ggM6z/coYPrsVMgovl3Ff7Q7OCp1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3756,6 +3939,8 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3891,6 +4076,17 @@
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -5355,7 +5551,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.44.0",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -9287,7 +9485,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
+      "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.27.1",
-    "@rsbuild/core": "^1.4.3",
+    "@rsbuild/core": "^1.5.2",
     "@rsbuild/plugin-react": "^1.3.3",
     "@rsbuild/plugin-svgr": "^1.2.0",
     "@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
Since the project is actually only used on Linux,
npm didn't have installed packaged needed for
Mac ARM.

I just needed to force install rspack to get the
needed packages. I took the opportunity to upgrade rspack version.

It fixes:

```
npm run start

> front@0.1.0 start
> PORT=5000 rsbuild dev

node:internal/modules/cjs/loader:1410
  const err = new Error(message);
              ^

Error: Cannot find module '@rspack/binding-darwin-arm64'
```