### PR TITLE
Fix quick search

### DIFF
--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -143,16 +143,16 @@ interface AclEntry {
 export function getCalendarVisibility(acl: AclEntry[]): "private" | "public" {
   let hasRead = false;
   let hasFreeBusy = false;
+  if (acl) {
+    for (const entry of acl) {
+      if (entry.principal !== "{DAV:}authenticated") continue;
 
-  for (const entry of acl) {
-    if (entry.principal !== "{DAV:}authenticated") continue;
-
-    if (entry.privilege === "{DAV:}read") {
-      hasRead = true;
-      break; // highest visibility, can stop
+      if (entry.privilege === "{DAV:}read") {
+        hasRead = true;
+        break; // highest visibility, can stop
+      }
     }
   }
-
   if (hasRead) return "public";
   return "private";
 }


### PR DESCRIPTION
Quick search was broken because of the visibility field making an error when no "acl" was in the fetched data. I added a check to prevent this to happen again.

related to #196 

docker image on eriikaah/twake-calendar-front:issue-196-quick-search-is-broken