### PR TITLE
[#222] removed malformed param

### DIFF
--- a/src/features/Events/eventUtils.ts
+++ b/src/features/Events/eventUtils.ts
@@ -200,7 +200,6 @@ export function makeVevent(
         event.x_openpass_videoconference ?? null,
       ],
       ["summary", {}, "text", event.title ?? ""],
-      ["dstamp", { tzid }, "date-time", formatDateToICal(new Date(), false)],
     ],
   ];
   if (event.alarm?.trigger) {


### PR DESCRIPTION
related to #222 
Removed dstamp (malformed dtstamp) as it's automatically handled by the backend

docker image on eriikaah/twake-calendar-front:issue-222-invalid-dstamp-property