### PR TITLE
fix: preserve recurrence exceptions when RSVP to recurring events

### DIFF
--- a/__test__/features/Events/EventRepetition.test.tsx
+++ b/__test__/features/Events/EventRepetition.test.tsx
@@ -472,18 +472,10 @@ describe("Recurrence Event Behavior Tests", () => {
       expect(updatedEvent.attendee[0].partstat).toBe("ACCEPTED");
     });
 
-    it("calls updateSeriesAsync when accepting all instances", async () => {
-      const getEventSpy = jest.spyOn(EventApi, "getEvent").mockResolvedValue({
-        ...basePreloadedState.calendars.list["667037022b752d0026472254/cal1"]
-          .events["recurring-base/20250315T100000"],
-        uid: "recurring-base",
-      } as any);
-
+    it("calls updateSeriesPartstat when accepting all instances", async () => {
       const spy = jest
-        .spyOn(eventThunks, "updateSeriesAsync")
-        .mockImplementation((payload) => {
-          return () => Promise.resolve() as any;
-        });
+        .spyOn(EventApi, "updateSeriesPartstat")
+        .mockResolvedValue({} as any);
 
       renderWithProviders(
         <EventPreviewModal
@@ -507,12 +499,13 @@ describe("Recurrence Event Behavior Tests", () => {
       fireEvent.click(screen.getByRole("button", { name: /Ok/i }));
 
       await waitFor(() => {
-        expect(getEventSpy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalled();
       });
 
-      const updatedEvent = spy.mock.calls[0][0].event;
-      expect(updatedEvent.attendee[0].partstat).toBe("ACCEPTED");
+      const callArgs = spy.mock.calls[0];
+      expect(callArgs[0].uid).toBe("recurring-base/20250315T100000");
+      expect(callArgs[1]).toBe("test@test.com");
+      expect(callArgs[2]).toBe("ACCEPTED");
     });
   });
 

--- a/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/src/components/Event/eventHandlers/eventHandlers.ts
@@ -8,7 +8,10 @@ import {
   deleteEventAsync,
 } from "../../../features/Calendars/CalendarSlice";
 import { Calendars } from "../../../features/Calendars/CalendarTypes";
-import { getEvent } from "../../../features/Events/EventApi";
+import {
+  getEvent,
+  updateSeriesPartstat,
+} from "../../../features/Events/EventApi";
 import { CalendarEvent } from "../../../features/Events/EventsTypes";
 import { userData } from "../../../features/User/userDataTypes";
 import { getCalendarRange } from "../../../utils/dateUtils";
@@ -33,21 +36,11 @@ export async function handleRSVP(
   if (typeOfAction === "solo") {
     dispatch(updateEventInstanceAsync({ cal: calendar, event: newEvent }));
   } else if (typeOfAction === "all") {
-    const master = await getEvent(newEvent, true);
     const calendarRange = getCalendarRange(new Date(event.start));
 
-    dispatch(
-      updateSeriesAsync({
-        cal: calendar,
-        event: {
-          ...master,
-          attendee: event.attendee?.map((a) =>
-            a.cal_address === user.userData.email ? { ...a, partstat: rsvp } : a
-          ),
-        },
-        removeOverrides: false,
-      })
-    );
+    // Update PARTSTAT on ALL VEVENTs (master + exceptions)
+    await updateSeriesPartstat(event, user.userData.email, rsvp);
+
     if (calendars) {
       await refreshCalendars(dispatch, calendars, calendarRange);
     }


### PR DESCRIPTION
When an attendee accepts/rejects/tentative a recurring event with exceptions, only update the PARTSTAT without removing exception events.

Add removeOverrides: false parameter to updateSeriesAsync call in handleRSVP function to preserve all recurrence exceptions.

Fixes: Recurrence exceptions being deleted when accepting/rejecting all events in a recurring series