### PR TITLE
[#278] fixed unprefilled calendar and added test

### DIFF
--- a/__test__/features/Events/EventModal.test.tsx
+++ b/__test__/features/Events/EventModal.test.tsx
@@ -341,4 +341,11 @@ describe("EventPopover", () => {
 
     expect(mockOnClose).toHaveBeenCalledWith({}, "backdropClick");
   });
+
+  it("BUGFIX: Prefill Calendar field", async () => {
+    renderPopover();
+    await waitFor(() =>
+      expect(screen.getByLabelText("Calendar")).toHaveTextContent("Calendar 1")
+    );
+  });
 });

--- a/src/features/Events/EventModal.tsx
+++ b/src/features/Events/EventModal.tsx
@@ -130,6 +130,12 @@ function EventPopover({
     userPersonnalCalendarsRef.current = userPersonnalCalendars;
   }, [userPersonnalCalendars]);
 
+  useEffect(() => {
+    if (!calendarid && userPersonnalCalendars.length > 0) {
+      setCalendarid(userPersonnalCalendars[0].id);
+    }
+  }, [calendarid, userPersonnalCalendars]);
+
   const resetAllStateToDefault = useCallback(() => {
     setShowMore(false);
     setShowDescription(false);


### PR DESCRIPTION
related to #278

docker image on eriikaah/twake-calendar-front:issue-278-event-creation-select-default-calendar-by-default