### PR TITLE
feat: #339 Add email notification toggle setting and update tests

### DIFF
--- a/src/features/User/userSlice.ts
+++ b/src/features/User/userSlice.ts
@@ -51,6 +51,7 @@ export const userSlice = createSlice({
         timeZone: null as string | null,
       },
     } as Record<string, any>,
+    alarmEmailsEnabled: null as boolean | null,
     loading: true,
     error: null as unknown as string | null,
   },
@@ -81,6 +82,9 @@ export const userSlice = createSlice({
       if (state.userData) {
         state.userData.timezone = action.payload;
       }
+    },
+    setAlarmEmails: (state, action) => {
+      state.alarmEmailsEnabled = action.payload;
     },
     clearError: (state) => {
       state.error = null;
@@ -153,6 +157,19 @@ export const userSlice = createSlice({
               }
             }
           }
+
+          // Extract alarmEmails from configurations.modules
+          const calendarModule = action.payload.configurations.modules.find(
+            (module: any) => module.name === "calendar"
+          );
+          if (calendarModule?.configurations) {
+            const alarmEmailsConfig = calendarModule.configurations.find(
+              (config: any) => config.name === "alarmEmails"
+            );
+            if (alarmEmailsConfig) {
+              state.alarmEmailsEnabled = alarmEmailsConfig.value === true;
+            }
+          }
         }
       })
       .addCase(getOpenPaasUserDataAsync.pending, (state) => {
@@ -181,6 +198,9 @@ export const userSlice = createSlice({
             state.userData.timezone = action.payload.timezone;
           }
         }
+        if (action.payload.alarmEmails !== undefined) {
+          state.alarmEmailsEnabled = action.payload.alarmEmails === true;
+        }
       })
       .addCase(updateUserConfigurationsAsync.rejected, (state, action) => {
         if (action.payload?.status !== 401) {
@@ -192,7 +212,13 @@ export const userSlice = createSlice({
 });
 
 // Action creators are generated for each case reducer function
-export const { setUserData, setTokens, setLanguage, setTimezone, clearError } =
-  userSlice.actions;
+export const {
+  setUserData,
+  setTokens,
+  setLanguage,
+  setTimezone,
+  setAlarmEmails,
+  clearError,
+} = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -217,6 +217,9 @@
     "timeZoneBrowserDefault": "Detect time zone automatically",
     "timeZoneUpdateError": "Failed to update time zone",
     "notifications.empty": "Notifications settings coming soon",
+    "notifications.email": "Email",
+    "notifications.deliveryMethod": "Delivery method",
+    "alarmEmailsUpdateError": "Failed to update email notifications setting",
     "sync.empty": "Sync settings coming soon",
     "back": "Back to calendar"
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -217,6 +217,9 @@
     "timeZoneBrowserDefault": "Détection automatique du fuseau horaire",
     "timeZoneUpdateError": "Échec de la mise à jour du fuseau horaire",
     "notifications.empty": "Paramètres de notifications à venir",
+    "notifications.email": "Email",
+    "notifications.deliveryMethod": "Mode de réception",
+    "alarmEmailsUpdateError": "Échec de la mise à jour du mode de notification par e-mail",
     "sync.empty": "Paramètres de synchronisation à venir",
     "back": "Retour au calendrier"
   },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -217,6 +217,9 @@
     "timeZoneBrowserDefault": "Определять часовой пояс автоматически",
     "timeZoneUpdateError": "Не удалось обновить часовой пояс",
     "notifications.empty": "Настройки уведомлений скоро появятся",
+    "notifications.email": "Email",
+    "notifications.deliveryMethod": "Способ доставки",
+    "alarmEmailsUpdateError": "Не удалось обновить настройки уведомлений по email",
     "sync.empty": "Настройки синхронизации скоро появятся",
     "back": "Вернуться к календарю"
   },

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -217,6 +217,9 @@
     "timeZoneBrowserDefault": "Tự động phát hiện múi giờ",
     "timeZoneUpdateError": "Không cập nhật được múi giờ",
     "notifications.empty": "Cài đặt thông báo sắp có",
+    "notifications.email": "Email",
+    "notifications.deliveryMethod": "Phương thức gửi",
+    "alarmEmailsUpdateError": "Cập nhật cài đặt thông báo email thất bại",
     "sync.empty": "Cài đặt đồng bộ sắp có",
     "back": "Quay lại lịch"
   },


### PR DESCRIPTION
Image: nple/twake-calendar-frontend:feat-settings-page-notifications-email-acb810e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Email notification toggle in Settings to control alarm email delivery with optimistic UI updates.
* **Bug Fixes**
  * Failed updates roll back immediately and display an error snackbar.
* **Tests**
  * Added tests for toggle presence, initial states (on/off/null), optimistic updates, API success, and rollback on failure.
* **Localization**
  * Added English, French, Russian, and Vietnamese strings for notification label, delivery method, and update error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->