### PR TITLE
[#408] added ordering priority to personnal event

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -682,6 +682,9 @@ export default function CalendarApp({
               filteredTempEvents,
               userId
             )}
+            eventOrder={(a: any, b: any) =>
+              a.extendedProps.priority - b.extendedProps.priority
+            }
             weekNumbers={
               currentView === "timeGridWeek" || currentView === "timeGridDay"
             }

--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -102,12 +102,14 @@ export const eventToFullCalendarFormat = (
     .map((e) => {
       const eventTimezone = e.timezone || "Etc/UTC";
       const isAllDay = e.allday ?? false;
+      const isPersonnalEvent = e.calId.split("/")[0] === userId;
 
       const convertedEvent: any = {
         ...e,
         title: formatEventChipTitle(e, t),
         colors: e.color,
-        editable: e.calId.split("/")[0] === userId,
+        editable: isPersonnalEvent,
+        priority: isPersonnalEvent ? 1 : 0,
       };
 
       if (!isAllDay && e.start && eventTimezone) {


### PR DESCRIPTION
related to #408 

docker image on eriikaah/twake-calendar-front:issue-408-show-personnal-agenda-over-others-event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar events are now sorted and displayed by priority level.
  * Personal and shared events are assigned distinct priority indicators for improved organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->