### PR TITLE
[#419] removed duplicate adornment and ugly padding

### DIFF
--- a/src/components/Attendees/PeopleSearch.tsx
+++ b/src/components/Attendees/PeopleSearch.tsx
@@ -274,8 +274,8 @@ export function PeopleSearch({
         }}
         slotProps={customSlotProps}
         // When render input is custom, the adornments should be handled by the custom component
-        forcePopupIcon={customRenderInput ? false : true}
-        disableClearable={customRenderInput ? true : false}
+        forcePopupIcon={!customRenderInput}
+        disableClearable={!!customRenderInput}
         renderInput={(params) =>
           customRenderInput
             ? customRenderInput(params, query, setQuery)

--- a/src/components/Menubar/EventSearchBar.tsx
+++ b/src/components/Menubar/EventSearchBar.tsx
@@ -315,6 +315,7 @@ export default function SearchBar() {
                     <InputAdornment position="end">
                       {(query || selectedContacts.length > 0) && (
                         <IconButton
+                          aria-label={t("common.clear")}
                           onClick={() => {
                             setQuery("");
                             setSearch("");
@@ -326,6 +327,7 @@ export default function SearchBar() {
                         </IconButton>
                       )}
                       <IconButton
+                        aria-label={t("search.filter.filters")}
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={() => {
                           setAnchorEl(containerRef.current);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,6 +39,7 @@
   },
   "common": {
     "cancel": "Cancel",
+    "clear": "Clear",
     "ok": "Ok",
     "link_copied": "Link copied!",
     "import_file": "File",
@@ -57,7 +58,8 @@
     "filter": {
       "allCalendar": "All calendars",
       "myCalendar": "My calendars",
-      "sharedCalendars": "Shared calendars"
+      "sharedCalendars": "Shared calendars",
+      "filters": "Filters"
     },
     "keywords": "Keywords*",
     "keywordsPlaceholder": "Enter keywords",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -39,6 +39,7 @@
   },
   "common": {
     "cancel": "Annuler",
+    "clear": "Effacer",
     "ok": "OK",
     "link_copied": "Lien copié !",
     "import_file": "Fichier",
@@ -57,7 +58,8 @@
     "filter": {
       "allCalendar": "Tous les calendriers",
       "myCalendar": "Mes calendriers",
-      "sharedCalendars": "Calendriers partagés"
+      "sharedCalendars": "Calendriers partagés",
+      "filters": "Filtres"
     },
     "keywords": "Mots-clés*",
     "keywordsPlaceholder": "Saisissez des mots-clés",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -39,6 +39,7 @@
   },
   "common": {
     "cancel": "Отмена",
+    "clear": "Очистить",
     "ok": "Ок",
     "link_copied": "Ссылка скопирована",
     "import_file": "Файл",
@@ -57,7 +58,8 @@
     "filter": {
       "allCalendar": "Все календари",
       "myCalendar": "Мои календари",
-      "sharedCalendars": "Общие календари"
+      "sharedCalendars": "Общие календари",
+      "filters": "Фильтры"
     },
     "keywords": "Ключевые слова*",
     "keywordsPlaceholder": "Введите ключевые слова",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -39,6 +39,7 @@
   },
   "common": {
     "cancel": "Hủy",
+    "clear": "Xóa",
     "ok": "OK",
     "link_copied": "Đã sao chép liên kết!",
     "import_file": "Tệp",
@@ -57,7 +58,8 @@
     "filter": {
       "allCalendar": "Tất cả lịch",
       "myCalendar": "Lịch của tôi",
-      "sharedCalendars": "Lịch được chia sẻ"
+      "sharedCalendars": "Lịch được chia sẻ",
+      "filters": "Bộ lọc"
     },
     "keywords": "Từ khóa*",
     "keywordsPlaceholder": "Nhập từ khóa",


### PR DESCRIPTION
related  to #419 

docker image on eriikaah/twake-calendar-front:issue-419-search-bar-icon-order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized event search controls: separated clear and filter actions into distinct buttons with clearer responsibilities for improved usability.
  * Adjusted search input behavior to better support custom input rendering and consistent adornment handling.

* **Localization**
  * Added "Clear" and "Filters" translations across supported languages to surface new UI labels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->