### PR TITLE
[#430] removed red from canceled event icon

### DIFF
--- a/src/components/Event/EventChip/EventChipUtils.tsx
+++ b/src/components/Event/EventChip/EventChipUtils.tsx
@@ -170,9 +170,7 @@ export function DisplayedIcons(IconDisplayed: IconDisplayConfig) {
       {IconDisplayed.needAction && (
         <HelpOutlineIcon style={{ fontSize: "15px" }} />
       )}
-      {IconDisplayed.declined && (
-        <CancelIcon color="error" style={{ fontSize: "15px" }} />
-      )}
+      {IconDisplayed.declined && <CancelIcon style={{ fontSize: "15px" }} />}
       {IconDisplayed.tentative && (
         <HelpOutlineIcon style={{ fontSize: "15px" }} />
       )}


### PR DESCRIPTION
related to #430 

docker image on eriikaah/twake-calendar-front:issue-430-repaint-the-icon-for-canceled-events-in-the-agenda-color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the declined event indicator to use default coloring instead of error-specific highlighting, providing a more consistent visual design.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->