### PR TITLE
[#469] fixed mail to attendees string

### DIFF
--- a/__test__/features/Events/EventDisplay.test.tsx
+++ b/__test__/features/Events/EventDisplay.test.tsx
@@ -663,7 +663,7 @@ describe("Event Preview Display", () => {
       preloadedState.calendars.list["667037022b752d0026472254/cal1"].events[
         "event1"
       ];
-    const expectedUrl = `test/mailto/?uri=mailto:john@test.com?subject=Test%20Event`;
+    const expectedUrl = `test/mailto/?uri=mailto:john@test.com&subject=Test%20Event`;
 
     expect(mockOpen).toHaveBeenCalledWith(expectedUrl);
   });
@@ -734,7 +734,7 @@ describe("Event Preview Display", () => {
 
     fireEvent.click(emailButton);
 
-    const expectedUrl = `test/mailto/?uri=mailto:john@test.com?subject=Meeting%20%26%20Discussion%3F%20%23Important`;
+    const expectedUrl = `test/mailto/?uri=mailto:john@test.com&subject=Meeting%20%26%20Discussion%3F%20%23Important`;
 
     expect(mockOpen).toHaveBeenCalledWith(expectedUrl);
   });

--- a/src/features/Events/EventDisplayPreview.tsx
+++ b/src/features/Events/EventDisplayPreview.tsx
@@ -359,12 +359,12 @@ export default function EventPreviewModal({
                 <MenuItem
                   onClick={() =>
                     window.open(
-                      `${mailSpaUrl}/mailto/?uri=mailto:${attendees
+                      `${mailSpaUrl}/mailto/?uri=mailto:${event.attendee
                         .map((a) => a.cal_address)
                         .filter((mail) => mail !== user.email)
                         .join(
                           ","
-                        )}?subject=${encodeURIComponent(event.title ?? "")}`
+                        )}&subject=${encodeURIComponent(event.title ?? "")}`
                     )
                   }
                 >


### PR DESCRIPTION
related to #469 
docker image on eriikaah/twake-calendar-front:issue-469-mail-to-with-utf-8-in-sumarry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email "Email attendees" now includes all relevant participants (may re-add the organizer) while still excluding the current user.
* **Tests**
  * Updated tests to reflect the new mailto URL format and subject encoding behavior for email actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->