### PR TITLE
Refactor: centralize timezone utilities in src/utils/timezone.ts

### DIFF
--- a/src/components/Calendar/TimezoneSelector.tsx
+++ b/src/components/Calendar/TimezoneSelector.tsx
@@ -1,7 +1,10 @@
-import { browserDefaultTimeZone } from "@/utils/timezone";
+import {
+  browserDefaultTimeZone,
+  getTimezoneOffset,
+  resolveTimezone,
+} from "@/utils/timezone";
 import { TIMEZONES } from "@/utils/timezone-data";
 import { Button, Popover } from "@linagora/twake-mui";
-import moment from "moment";
 import { MouseEvent, useMemo, useState } from "react";
 import { useI18n } from "twake-i18n";
 import { TimezoneAutocomplete } from "../Timezone/TimezoneAutocomplete";
@@ -98,29 +101,4 @@ export function useTimeZoneList() {
 
     return { zones, browserTz, getTimezoneOffset };
   }, []);
-}
-
-export function resolveTimezone(tzName: string): string {
-  if (TIMEZONES.zones[tzName]) {
-    return tzName;
-  }
-  if (TIMEZONES.aliases[tzName]) {
-    return TIMEZONES.aliases[tzName].aliasTo;
-  }
-  return tzName;
-}
-
-export function getTimezoneOffset(
-  tzName: string,
-  date: Date = new Date()
-): string {
-  const fmt = new Intl.DateTimeFormat(undefined, {
-    timeZone: tzName,
-    timeZoneName: "shortOffset",
-  });
-
-  const currentDate = moment(date).isValid() ? date : new Date();
-  const parts = fmt.formatToParts(currentDate);
-  const offsetPart = parts.find((p) => p.type === "timeZoneName");
-  return offsetPart?.value.replace("GMT", "UTC") ?? "";
 }

--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -1,41 +1,14 @@
-import { detectDateTimeFormat } from "@/components/Event/utils/dateTimeHelpers";
 import { refreshSingularCalendar } from "@/components/Event/utils/eventUtils";
 import { Calendar } from "@/features/Calendars/CalendarTypes";
 import { getCalendarDetailAsync } from "@/features/Calendars/services";
 import { CalendarEvent } from "@/features/Events/EventsTypes";
 import { formatDateToYYYYMMDDTHHMMSS } from "@/utils/dateUtils";
 import { extractEventBaseUuid } from "@/utils/extractEventBaseUuid";
+import { convertEventDateTimeToISO } from "@/utils/timezone";
 import { SlotLabelContentArg } from "@fullcalendar/core";
 import { ThunkDispatch } from "@reduxjs/toolkit";
 import moment from "moment-timezone";
 import { useI18n } from "twake-i18n";
-
-function convertEventDateTimeToISO(
-  datetime: string,
-  eventTimezone: string,
-  isAllDay: boolean
-): string {
-  if (!datetime || isAllDay) return datetime;
-
-  if (datetime.includes("Z") || datetime.match(/[+-]\d{2}:\d{2}$/)) {
-    return datetime;
-  }
-
-  const dateOnlyRegex = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
-  if (dateOnlyRegex.test(datetime)) {
-    return datetime;
-  }
-
-  const format = detectDateTimeFormat(datetime);
-  const momentDate = moment.tz(datetime, format, eventTimezone);
-  if (!momentDate.isValid()) {
-    console.warn(
-      `[convertEventDateTimeToISO] Invalid datetime: "${datetime}" with format "${format}" in timezone "${eventTimezone}"`
-    );
-    return datetime;
-  }
-  return momentDate.toISOString();
-}
 
 export const updateSlotLabelVisibility = (
   currentTime: Date,
@@ -114,22 +87,18 @@ export const eventToFullCalendarFormat = (
       };
 
       if (!isAllDay && e.start && eventTimezone) {
-        const startISO = convertEventDateTimeToISO(
-          e.start,
-          eventTimezone,
-          isAllDay
-        );
+        const startISO = convertEventDateTimeToISO(e.start, eventTimezone, {
+          isAllDay,
+        });
         if (startISO) {
           convertedEvent.start = startISO;
         }
       }
 
       if (!isAllDay && e.end && eventTimezone) {
-        const endISO = convertEventDateTimeToISO(
-          e.end,
-          eventTimezone,
-          isAllDay
-        );
+        const endISO = convertEventDateTimeToISO(e.end, eventTimezone, {
+          isAllDay,
+        });
         if (endISO) {
           convertedEvent.end = endISO;
         }

--- a/src/features/Events/EventDisplayPreview.tsx
+++ b/src/features/Events/EventDisplayPreview.tsx
@@ -1,6 +1,6 @@
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
 import { CalendarName } from "@/components/Calendar/CalendarName";
-import { getTimezoneOffset } from "@/components/Calendar/TimezoneSelector";
+import { getTimezoneOffset } from "@/utils/timezone";
 import { formatEventChipTitle } from "@/components/Calendar/utils/calendarUtils";
 import ResponsiveDialog from "@/components/Dialog/ResponsiveDialog";
 import { EditModeDialog } from "@/components/Event/EditModeDialog";

--- a/src/features/Events/EventModal.tsx
+++ b/src/features/Events/EventModal.tsx
@@ -1,8 +1,5 @@
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
-import {
-  getTimezoneOffset,
-  resolveTimezone,
-} from "@/components/Calendar/TimezoneSelector";
+import { getTimezoneOffset, resolveTimezone } from "@/utils/timezone";
 import { updateTempCalendar } from "@/components/Calendar/utils/calendarUtils";
 import { ResponsiveDialog } from "@/components/Dialog";
 import EventFormFields from "@/components/Event/EventFormFields";

--- a/src/features/Events/EventUpdateModal.tsx
+++ b/src/features/Events/EventUpdateModal.tsx
@@ -25,7 +25,11 @@ import {
   showErrorNotification,
 } from "@/utils/eventFormTempStorage";
 import { extractEventBaseUuid } from "@/utils/extractEventBaseUuid";
-import { browserDefaultTimeZone } from "@/utils/timezone";
+import {
+  browserDefaultTimeZone,
+  resolveTimezone,
+  getTimezoneOffset,
+} from "@/utils/timezone";
 import { TIMEZONES } from "@/utils/timezone-data";
 import { addVideoConferenceToDescription } from "@/utils/videoConferenceUtils";
 import { Box, Button } from "@linagora/twake-mui";
@@ -108,38 +112,9 @@ function EventUpdateModal({
     );
   }, [calendarsList, user.userData?.openpaasId]);
 
-  // Helper function to resolve timezone aliases
-  const resolveTimezone = (tzName: string): string => {
-    if (TIMEZONES.zones[tzName]) {
-      return tzName;
-    }
-    if (TIMEZONES.aliases[tzName]) {
-      return TIMEZONES.aliases[tzName].aliasTo;
-    }
-    return tzName;
-  };
-
   const timezoneList = useMemo(() => {
     const zones = Object.keys(TIMEZONES.zones).sort();
     const browserTz = resolveTimezone(browserDefaultTimeZone);
-
-    const getTimezoneOffset = (tzName: string): string => {
-      const resolvedTz = resolveTimezone(tzName);
-      const tzData = TIMEZONES.zones[resolvedTz];
-      if (!tzData) return "";
-
-      const icsMatch = tzData.ics.match(/TZOFFSETTO:([+-]\d{4})/);
-      if (!icsMatch) return "";
-
-      const offset = icsMatch[1];
-      const hours = parseInt(offset.slice(0, 3));
-      const minutes = parseInt(offset.slice(3));
-
-      if (minutes === 0) {
-        return `UTC${hours >= 0 ? "+" : ""}${hours}`;
-      }
-      return `UTC${hours >= 0 ? "+" : ""}${hours}:${Math.abs(minutes).toString().padStart(2, "0")}`;
-    };
 
     return { zones, browserTz, getTimezoneOffset };
   }, []);

--- a/src/features/Events/formHelpers.ts
+++ b/src/features/Events/formHelpers.ts
@@ -1,4 +1,4 @@
-import { resolveTimezone } from "@/components/Calendar/TimezoneSelector";
+import { resolveTimezone } from "@/utils/timezone";
 import { formatDateTimeInTimezone } from "@/components/Event/utils/dateTimeFormatters";
 import { extractEventBaseUuid } from "@/utils/extractEventBaseUuid";
 import { browserDefaultTimeZone } from "@/utils/timezone";

--- a/src/features/Settings/SettingsPage.tsx
+++ b/src/features/Settings/SettingsPage.tsx
@@ -1,8 +1,6 @@
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
-import {
-  getTimezoneOffset,
-  useTimeZoneList,
-} from "@/components/Calendar/TimezoneSelector";
+import { useTimeZoneList } from "@/components/Calendar/TimezoneSelector";
+import { getTimezoneOffset } from "@/utils/timezone";
 import { TimezoneAutocomplete } from "@/components/Timezone/TimezoneAutocomplete";
 import { browserDefaultTimeZone } from "@/utils/timezone";
 import {

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -2,6 +2,8 @@
 
 // Ensure ICAL is imported before using this module.
 import ICAL from "ical.js";
+import moment from "moment-timezone";
+import { detectDateTimeFormat } from "@/components/Event/utils/dateTimeHelpers";
 
 // TIMEZONES data must be imported or defined separately.
 import { TIMEZONES } from "./timezone-data";
@@ -38,4 +40,62 @@ function findTimezone(tzid: string): any {
   }
 
   throw new Error(`Unknown timezone alias: ${tzid}`);
+}
+
+export function resolveTimezone(tzName: string): string {
+  if (TIMEZONES.zones[tzName]) {
+    return tzName;
+  }
+  if (TIMEZONES.aliases[tzName]) {
+    return TIMEZONES.aliases[tzName].aliasTo;
+  }
+  return tzName;
+}
+
+export function resolveTimezoneId(tzid?: string): string | undefined {
+  if (!tzid) return undefined;
+  return resolveTimezone(tzid);
+}
+
+export function convertEventDateTimeToISO(
+  datetime: string,
+  timezone: string,
+  options?: { isAllDay?: boolean }
+): string | undefined {
+  if (!datetime || !timezone) return undefined;
+  if (options?.isAllDay) return undefined;
+
+  if (datetime.includes("Z") || datetime.match(/[+-]\d{2}:\d{2}$/)) {
+    return datetime;
+  }
+
+  const dateOnlyRegex = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+  if (dateOnlyRegex.test(datetime)) {
+    return undefined;
+  }
+
+  const format = detectDateTimeFormat(datetime);
+  const momentDate = moment.tz(datetime, format, timezone);
+  if (!momentDate.isValid()) {
+    console.warn(
+      `[convertEventDateTimeToISO] Invalid datetime: "${datetime}" with format "${format}" in timezone "${timezone}"`
+    );
+    return undefined;
+  }
+  return momentDate.toISOString();
+}
+
+export function getTimezoneOffset(
+  tzName: string,
+  date: Date = new Date()
+): string {
+  const fmt = new Intl.DateTimeFormat(undefined, {
+    timeZone: tzName,
+    timeZoneName: "shortOffset",
+  });
+
+  const currentDate = moment(date).isValid() ? date : new Date();
+  const parts = fmt.formatToParts(currentDate);
+  const offsetPart = parts.find((p) => p.type === "timeZoneName");
+  return offsetPart?.value.replace("GMT", "UTC") ?? "";
 }


### PR DESCRIPTION
Deduplicate resolveTimezone, resolveTimezoneId, convertEventDateTimeToISO, and getTimezoneOffset into a single canonical module, removing copies from EventApi, eventUtils, TimezoneSelector, EventUpdateModal, and calendarUtils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated timezone utilities into a centralized module, improving code maintainability and reducing duplication across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->