### PR TITLE
[#501] removed useless shared calendar from search

### DIFF
--- a/src/components/Menubar/EventSearchBar.tsx
+++ b/src/components/Menubar/EventSearchBar.tsx
@@ -41,9 +41,6 @@ export default function SearchBar() {
   const personnalCalendars = userId
     ? calendars.filter((c) => extractEventBaseUuid(c.id) === userId)
     : [];
-  const sharedCalendars = userId
-    ? calendars.filter((c) => extractEventBaseUuid(c.id) !== userId)
-    : calendars;
 
   const [search, setSearch] = useState("");
   const [selectedContacts, setSelectedContacts] = useState<User[]>([]);
@@ -118,8 +115,6 @@ export default function SearchBar() {
       searchInCalendars = calendars.map((c) => c.id);
     } else if (filters.searchIn === "my-calendars") {
       searchInCalendars = personnalCalendars.map((c) => c.id);
-    } else if (filters.searchIn === "shared-calendars") {
-      searchInCalendars = sharedCalendars.map((c) => c.id);
     } else {
       searchInCalendars = [filters.searchIn];
     }
@@ -434,20 +429,6 @@ export default function SearchBar() {
                     {t("search.filter.myCalendar")}
                   </MenuItem>
                   {CalendarItemList(personnalCalendars)}
-                  <Divider />
-                  <MenuItem
-                    value="shared-calendars"
-                    sx={{
-                      color: "#243B55",
-                      font: "Roboto",
-                      fontSize: "12px",
-                      weight: 400,
-                      pointerEvents: "auto",
-                    }}
-                  >
-                    {t("search.filter.sharedCalendars")}
-                  </MenuItem>
-                  {CalendarItemList(sharedCalendars)}
                 </Select>
               </Box>
 


### PR DESCRIPTION
related to #501 

docker image on eriikaah/twake-calendar-front:issue-501-search-not-on-shared-calendar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the event search functionality by removing the shared calendars option from the search filter. Search scope is now limited to personal calendars and other explicitly selected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->