### PR TITLE
[#496] changed adapterLocal to be the handled local in DateTimeFields

### DIFF
--- a/src/components/Event/components/DateTimeFields.tsx
+++ b/src/components/Event/components/DateTimeFields.tsx
@@ -81,7 +81,7 @@ export const DateTimeFields: React.FC<DateTimeFieldsProps> = ({
   onEndDateChange,
   onEndTimeChange,
 }) => {
-  const { t, lang } = useI18n();
+  const { t } = useI18n();
 
   const initialDurationRef = React.useRef<number | null>(null);
   const isUserActionRef = React.useRef(false);
@@ -334,7 +334,7 @@ export const DateTimeFields: React.FC<DateTimeFieldsProps> = ({
   return (
     <LocalizationProvider
       dateAdapter={AdapterDayjs}
-      adapterLocale={lang ?? "en"}
+      adapterLocale={t("locale") ?? "en"}
       localeText={{
         okButtonLabel: t("common.ok"),
         cancelButtonLabel: t("common.cancel"),


### PR DESCRIPTION
related to #496 

docker image on eriikaah/twake-calendar-front:issue-496-missing-translation-date-input-field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined locale handling in date-time components by consolidating localization logic through the translation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->