### PR TITLE
[#508] put back missing title field

### DIFF
--- a/src/components/Calendar/SettingsTab.tsx
+++ b/src/components/Calendar/SettingsTab.tsx
@@ -13,6 +13,7 @@ import PublicIcon from "@mui/icons-material/Public";
 import { useEffect, useState } from "react";
 import { useI18n } from "twake-i18n";
 import { AddDescButton } from "../Event/AddDescButton";
+import { FieldWithLabel } from "../Event/components/FieldWithLabel";
 import { ColorPicker } from "./CalendarColorPicker";
 
 export function SettingsTab({
@@ -49,23 +50,29 @@ export function SettingsTab({
   return (
     <>
       {/* Form group 1: Name field - first group, margin top 0 */}
-      <Box mt={0}>
-        <TextField
-          fullWidth
-          label=""
-          inputProps={{ "aria-label": t("common.name") }}
-          placeholder={t("common.name")}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          size="small"
-          sx={{
-            "&.MuiFormControl-root": {
-              marginTop: 0,
-              marginBottom: 0,
-            },
-          }}
-        />
-      </Box>
+      <FieldWithLabel
+        label={t("common.name")}
+        isExpanded={false}
+        sx={{ padding: 0, margin: 0 }}
+      >
+        <Box mt={0}>
+          <TextField
+            fullWidth
+            label=""
+            inputProps={{ "aria-label": t("common.name") }}
+            placeholder={t("common.name")}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            size="small"
+            sx={{
+              "&.MuiFormControl-root": {
+                marginTop: 0,
+                marginBottom: 0,
+              },
+            }}
+          />
+        </Box>
+      </FieldWithLabel>
 
       {/* Form group 2: Description */}
       <Box mt={2}>


### PR DESCRIPTION
related to #508 
docker image on eriikaah/twake-calendar-front:issue-508-missing-field-title-in-calendar-modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal structure of the calendar settings name field component layout. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->