### PR TITLE
[#514] fix duration being mishandled with wrong date format

### DIFF
--- a/src/features/Events/eventUtils.ts
+++ b/src/features/Events/eventUtils.ts
@@ -385,7 +385,7 @@ function formatDateToICal(date: Date, allday: Boolean, timezone?: string) {
   const hours = pad(date.getUTCHours());
   const minutes = pad(date.getUTCMinutes());
   const seconds = pad(date.getUTCSeconds());
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}Z`;
 }
 
 /**


### PR DESCRIPTION
related to #514 

docker image on eriikaah/twake-calendar-front:issue-514-calcom-invalid-date-in-event-chip---duration-handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event timestamps now properly include UTC indicator for timezone-aware events, improving calendar format compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->