### PR TITLE
[#520] fix event order flicker

### DIFF
--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -85,8 +85,7 @@ export const eventToFullCalendarFormat = (
       const isOrganiser = e.organizer
         ? e.organizer.cal_address?.toLowerCase() === userAddress?.toLowerCase()
         : true; // if there are no organizer in the event we assume it was organized by the owner
-      const isPersonnalEvent =
-        extractEventBaseUuid(e.calId) === userId && isOrganiser;
+      const isPersonnalEvent = extractEventBaseUuid(e.calId) === userId;
       const convertedEvent: CalendarEvent & {
         colors: Record<string, string> | undefined;
         editable: boolean;
@@ -95,8 +94,8 @@ export const eventToFullCalendarFormat = (
         ...e,
         title: formatEventChipTitle(e, t),
         colors: e.color,
-        editable: isPersonnalEvent,
-        priority: isPersonnalEvent && !pending ? 1 : 0,
+        editable: isPersonnalEvent && isOrganiser && !pending,
+        priority: isPersonnalEvent ? 1 : 0,
       };
 
       if (!isAllDay && e.start && eventTimezone) {


### PR DESCRIPTION
Related  to #520 

docker image on eriikaah/twake-calendar-front:issue-520-display-glitch-when-opening-event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined personal calendar event identification methodology
  * Updated event editing restrictions to require organizer status
  * Streamlined priority flag logic for personal calendar events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->