### PR TITLE
Hide timezone border

### DIFF
--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -577,6 +577,8 @@ export default function EventFormFields({
               width={220}
               size="small"
               placeholder={t("event.form.timezonePlaceholder")}
+              hideBorder
+              inputPadding="8px 65px 8px 0px"
             />
           </Box>
         </FieldWithLabel>

--- a/src/components/Timezone/TimezoneAutocomplete.tsx
+++ b/src/components/Timezone/TimezoneAutocomplete.tsx
@@ -22,6 +22,7 @@ interface TimezoneAutocompleteProps {
   inputPadding?: string;
   onClose?: () => void;
   disableClearable?: boolean;
+  hideBorder?: boolean;
 }
 
 export function TimezoneAutocomplete({
@@ -38,6 +39,7 @@ export function TimezoneAutocomplete({
   inputPadding,
   onClose,
   disableClearable = false,
+  hideBorder = false,
 }: TimezoneAutocompleteProps) {
   const options = useMemo<TimezoneOption[]>(() => {
     return zones.map((tz) => ({
@@ -70,6 +72,21 @@ export function TimezoneAutocomplete({
           placeholder={placeholder}
           variant="outlined"
           autoComplete="off"
+          sx={
+            hideBorder
+              ? {
+                  "& .MuiOutlinedInput-notchedOutline": {
+                    border: "none",
+                  },
+                  "&:hover .MuiOutlinedInput-notchedOutline": {
+                    border: "none",
+                  },
+                  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+                    border: "none",
+                  },
+                }
+              : undefined
+          }
           slotProps={{
             input: {
               ...params.InputProps,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Timezone input components now offer an option to remove the input border for a cleaner look.
  * Event form timezone input spacing has been adjusted for improved alignment and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->