### PR TITLE
[#548] peoplesearch validate input on blur

### DIFF
--- a/src/components/Attendees/PeopleSearch.tsx
+++ b/src/components/Attendees/PeopleSearch.tsx
@@ -95,7 +95,7 @@ export function PeopleSearch({
   const handleBlurCommit = useCallback(
     (event: React.SyntheticEvent) => {
       const trimmed = query.trim();
-      if (!trimmed || isOpen) return;
+      if (!trimmed) return;
       if (!isValidEmail(trimmed)) {
         setInputError(
           t("peopleSearch.invalidEmail").replace("%{email}", trimmed)
@@ -111,7 +111,7 @@ export function PeopleSearch({
       onChange(event, [...selectedUsers, newUser]);
       setQuery("");
     },
-    [query, isOpen, selectedUsers, onChange, t]
+    [query, selectedUsers, onChange, t]
   );
 
   useEffect(() => {
@@ -252,7 +252,6 @@ export function PeopleSearch({
         options={options}
         autoComplete={false}
         clearOnBlur={false}
-        blurOnSelect={true}
         onBlur={freeSolo ? handleBlurCommit : undefined}
         open={
           customRenderInput


### PR DESCRIPTION
related to #548 

docker image on eriikaah/twake-calendar-front:issue-548-unkown-attendee-fail-to-validate-input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the attendees search field: when typing an email and clicking away, the input now trims, validates, and auto-adds valid emails while preventing duplicates. Invalid email formats show an error. After successfully adding an address the input clears. This behavior applies only to free-form email entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->