### PR TITLE
[#557] fixed missing translation

### DIFF
--- a/src/features/Events/EventDisplayPreview.tsx
+++ b/src/features/Events/EventDisplayPreview.tsx
@@ -818,10 +818,20 @@ function makeRecurrenceString(
   ];
 
   const recurType: Record<string, string> = {
-    daily: t("eventPreview.days"),
-    monthly: t("eventPreview.months"),
-    yearly: t("eventPreview.years"),
+    daily: t("event.repeat.frequency.days"),
+    weekly: t("event.repeat.frequency.weeks"),
+    monthly: t("event.repeat.frequency.months"),
+    yearly: t("event.repeat.frequency.years"),
   };
+
+  if (event.repetition.interval && event.repetition.interval > 1) {
+    recur.push(
+      t("eventPreview.everyInterval", {
+        interval: event.repetition.interval,
+        unit: recurType[event.repetition.freq] ?? event.repetition.freq,
+      })
+    );
+  }
 
   if (event.repetition.byday) {
     recur.push(
@@ -832,14 +842,7 @@ function makeRecurrenceString(
       })
     );
   }
-  if (event.repetition.interval && event.repetition.interval > 1) {
-    recur.push(
-      t("eventPreview.everyInterval", {
-        interval: event.repetition.interval,
-        unit: recurType[event.repetition.freq],
-      })
-    );
-  }
+
   if (event.repetition.occurrences) {
     recur.push(
       t("eventPreview.forOccurrences", {


### PR DESCRIPTION
related to #557 

docker image on eriikaah/twake-calendar-front:issue-557-evenement-recurrent-hebdomadaire-le-jeudi-tous-les-2-unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recurring event descriptions now correctly include explicit interval phrasing (e.g., "every 2 weeks") and use updated translation keys for frequency labels, improving accuracy and multilingual display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->