### PR TITLE
[#539] support link is now configurable

### DIFF
--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -9,6 +9,7 @@ var CALENDAR_BASE_URL = "https://calendar.example.com";
 var DAV_BASE_URL = "https://dav.example.com";
 var MAIL_SPA_URL = "https://mail.example.com";
 var VIDEO_CONFERENCE_BASE_URL = "https://meet.linagora.com";
+var SUPPORT_URL = "https://twake.app/support/";
 var DEBUG = false;
 var LANG = "en";
 var WEBSOCKET_URL = "wss://calendar.example.com";

--- a/src/components/Menubar/Menubar.tsx
+++ b/src/components/Menubar/Menubar.tsx
@@ -61,6 +61,7 @@ export function Menubar({
   const { t } = useI18n(); // deliberately NOT using f()
   const user = useAppSelector((state) => state.user.userData);
   const applist: AppIconProps[] = window.appList ?? [];
+  const supportLink = window.SUPPORT_URL;
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [userMenuAnchorEl, setUserMenuAnchorEl] = useState<null | HTMLElement>(
     null
@@ -251,19 +252,21 @@ export function Menubar({
           </div>
           {!isIframe && (
             <>
-              <div className="menu-items">
-                <IconButton
-                  component="a"
-                  href="https://twake.app/support/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ marginRight: 8 }}
-                  aria-label={t("menubar.help")}
-                  title={t("menubar.help")}
-                >
-                  <HelpOutlineIcon />
-                </IconButton>
-              </div>
+              {supportLink && (
+                <div className="menu-items">
+                  <IconButton
+                    component="a"
+                    href={supportLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ marginRight: 8 }}
+                    aria-label={t("menubar.help")}
+                    title={t("menubar.help")}
+                  >
+                    <HelpOutlineIcon />
+                  </IconButton>
+                </div>
+              )}
 
               <div className="menu-items">
                 {applist.length > 0 && (

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -18,6 +18,7 @@ declare global {
     DAV_BASE_URL: string;
     MAIL_SPA_URL: string;
     VIDEO_CONFERENCE_BASE_URL: string;
+    SUPPORT_URL: string;
 
     DEBUG: boolean;
     LANG: string;


### PR DESCRIPTION
related to #539 

docker image on eriikaah/twake-calendar-front:issue-539-support-link-should-be-configurable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Made the support link configurable through environment settings instead of hardcoded.
  * Support button in the menu bar now appears only when a support URL is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->