### PR TITLE
[#573] hide declined events based on calendar's owner attendance

### DIFF
--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -179,7 +179,9 @@ export const extractEvents = (
         !(
           hideDeclinedEvents &&
           event.attendee?.some(
-            (a) => a.cal_address === userAddress && a.partstat === "DECLINED"
+            (a) =>
+              calendars[event.calId].owner.emails.includes(a.cal_address) &&
+              a.partstat === "DECLINED"
           )
         )
     );


### PR DESCRIPTION
related to #573 

docker image on eriikaah/twake-calendar-front:issue-573-show-delined-calendar-edge-case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the filtering logic for declined calendar events to more accurately determine which declined attendees should affect event visibility, considering calendar ownership relationships alongside attendance status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->