### PR TITLE
[#574] can now remove the description of the calendar

### DIFF
--- a/src/features/Calendars/CalendarApi.ts
+++ b/src/features/Calendars/CalendarApi.ts
@@ -88,22 +88,16 @@ export async function proppatchCalendar(
   calLink: string,
   patch: { name: string; desc: string; color: Record<string, string> }
 ) {
-  const body: Record<string, string> = {};
-  if (patch.name) {
-    body["dav:name"] = patch.name;
-  }
-  if (patch.desc) {
-    body["caldav:description"] = patch.desc;
-  }
-  if (patch.color.light) {
-    body["apple:color"] = patch.color.light;
-  }
   const response = await api(`dav${calLink}`, {
     method: "PROPPATCH",
     headers: {
       Accept: "application/json, text/plain, */*",
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify({
+      "dav:name": patch.name,
+      "caldav:description": patch.desc,
+      "apple:color": patch.color.light,
+    }),
   });
   return response;
 }


### PR DESCRIPTION
Related to #574

docker image on eriikaah/twake-calendar-front:issue-574-cannot-clear-calendar-description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved calendar update request handling for enhanced reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->