### PR TITLE
[#584] open timezone selector dropdown on button click

### DIFF
--- a/src/components/Calendar/TimezoneSelector.tsx
+++ b/src/components/Calendar/TimezoneSelector.tsx
@@ -76,7 +76,6 @@ export function TimezoneSelector({
           transition: {
             onEntered: () => {
               inputRef.current?.focus();
-              inputRef.current?.click();
             },
           },
         }}
@@ -90,6 +89,7 @@ export function TimezoneSelector({
             getTimezoneOffset(tzName, referenceDate)
           }
           inputRef={inputRef}
+          openOnFocus
           showIcon={false}
           inputFontSize="14px"
           inputPadding="2px 4px"

--- a/src/components/Timezone/TimezoneAutocomplete.tsx
+++ b/src/components/Timezone/TimezoneAutocomplete.tsx
@@ -23,6 +23,7 @@ interface TimezoneAutocompleteProps {
   onClose?: () => void;
   disableClearable?: boolean;
   hideBorder?: boolean;
+  openOnFocus?: boolean;
 }
 
 export function TimezoneAutocomplete({
@@ -40,6 +41,7 @@ export function TimezoneAutocomplete({
   onClose,
   disableClearable = false,
   hideBorder = false,
+  openOnFocus = false,
 }: TimezoneAutocompleteProps) {
   const options = useMemo<TimezoneOption[]>(() => {
     return zones.map((tz) => ({
@@ -53,7 +55,7 @@ export function TimezoneAutocomplete({
 
   return (
     <Autocomplete
-      openOnFocus
+      openOnFocus={openOnFocus}
       value={selectedOption}
       onChange={(event, newValue) => {
         if (newValue) {


### PR DESCRIPTION
related to #584 

docker image on eriikaah/twake-calendar-front:issue-584-click-once-to-have-timezone-dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone selector input now automatically receives focus and is activated when the picker opens.
  * Autocomplete field can open on focus for smoother keyboard/typing interactions.

* **Breaking Changes**
  * Timezone-related component API updated to refine focus behavior; integration may require minor adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->