### PR TITLE
[#555] untoggling calendars doesnt collapse anything anymore

### DIFF
--- a/__test__/components/CalendarSelection.test.tsx
+++ b/__test__/components/CalendarSelection.test.tsx
@@ -276,10 +276,10 @@ describe("CalendarSelection", () => {
       .closest(".MuiAccordionSummary-root");
 
     fireEvent.click(delegatedAccordionSummary!);
-    expect(delegatedAccordionSummary).toHaveAttribute("aria-expanded", "true");
+    expect(delegatedAccordionSummary).toHaveAttribute("aria-expanded", "false");
 
     fireEvent.click(delegatedAccordionSummary!);
-    expect(delegatedAccordionSummary).toHaveAttribute("aria-expanded", "false");
+    expect(delegatedAccordionSummary).toHaveAttribute("aria-expanded", "true");
   });
 
   it("renders owner name caption for non-personal, non-default calendars", () => {

--- a/src/components/Calendar/CalendarSelection.tsx
+++ b/src/components/Calendar/CalendarSelection.tsx
@@ -176,9 +176,7 @@ export default function CalendarSelection({
             setAnchorElCal(document.body);
             setSelectedCalId(id);
           }}
-          defaultExpanded={selectedCalendars.some((id) =>
-            delegatedCalendars.includes(id)
-          )}
+          defaultExpanded
         />
 
         <CalendarAccordion
@@ -194,9 +192,7 @@ export default function CalendarSelection({
             setAnchorElCal(document.body);
             setSelectedCalId(id);
           }}
-          defaultExpanded={selectedCalendars.some((id) =>
-            sharedCalendars.includes(id)
-          )}
+          defaultExpanded
         />
       </div>
       <CalendarPopover


### PR DESCRIPTION
related to #555
docker image on eriikaah/twake-calendar-front:issue-555-calendar-list-prevent-list-from-colapsing-on-untoggling-all