### PR TITLE
[#560] delegated calendars are now called shared

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,7 @@
     "personal": "My calendars",
     "defaultPersonalCalendarName": "My calendar",
     "defaultCalendarName": "%{name}'s calendar",
-    "delegated": "Delegated calendars",
+    "delegated": "Shared calendars",
     "other": "Other calendars",
     "caldav_access": "CalDAV access",
     "secretUrl": "Secret URL",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,7 +4,7 @@
     "personal": "Mes calendriers",
     "defaultPersonalCalendarName": "Mon calendrier",
     "defaultCalendarName": "Calendrier de %{name}",
-    "delegated": "Calendriers délégués",
+    "delegated": "Calendriers partagés",
     "other": "Autres calendriers",
     "caldav_access": "Accès CalDAV",
     "secretUrl": "URL secrète",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -4,7 +4,7 @@
     "personal": "Личные",
     "defaultPersonalCalendarName": "Мой календарь",
     "defaultCalendarName": "Календарь %{name}",
-    "delegated": "Делегированные",
+    "delegated": "Общий",
     "other": "Другие",
     "caldav_access": "Доступ CalDAV",
     "secretUrl": "Секретный URL",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -4,7 +4,7 @@
     "personal": "Lịch cá nhân",
     "defaultPersonalCalendarName": "Lịch của tôi",
     "defaultCalendarName": "Lịch của %{name}",
-    "delegated": "Lịch được ủy quyền",
+    "delegated": "Lịch dùng chung",
     "other": "Lịch khác",
     "caldav_access": "Truy cập CalDAV",
     "secretUrl": "URL bí mật",


### PR DESCRIPTION
related to #560
docker image on eriikaah/twake-calendar-front:issue-549-filler-warning-disclaimer-on-smal-screen