### PR TITLE
[#610] changed fontsize for calendar name

### DIFF
--- a/src/components/Calendar/CalendarName.tsx
+++ b/src/components/Calendar/CalendarName.tsx
@@ -34,7 +34,7 @@ export function CalendarName({ calendar }: { calendar: Calendar }) {
         }}
       />
       <Box style={{ display: "flex", flexDirection: "column" }}>
-        <Typography sx={{ wordBreak: "break-word" }}>
+        <Typography variant="body2" sx={{ wordBreak: "break-word" }}>
           {renameDefault(calendar.name, ownerDisplayName, t, isOwnCalendar)}
         </Typography>
         <OwnerCaption

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -808,7 +808,7 @@ export default function EventFormFields({
           >
             {selectedCalendar?.name ? (
               <Box style={{ display: "flex", flexDirection: "column" }}>
-                <Typography sx={{ wordBreak: "break-word" }}>
+                <Typography variant="body2" sx={{ wordBreak: "break-word" }}>
                   {renameDefault(
                     selectedCalendar.name,
                     selectedOwnerDisplayName,


### PR DESCRIPTION
related to #610 
docker image on  eriikaah/twake-calendar-front:issue-610-reduce-size-of-calender-field-in-event-modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated calendar name text styling to use standardized typography formatting across calendar and event components for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->