### PR TITLE
[#616] fixed wrong file extension in index.html for manifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <link rel="apple-touch-icon" href="<%= assetPrefix %>/calendar.svg" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="<%= assetPrefix %>/manifest.appdata" />
     <!--
       Notice the use of <%= assetPrefix %> in the tags above.


### PR DESCRIPTION
related to #616 

docker image on eriikaah/twake-calendar-front:issue-616-manifest-line-1-column-1-syntax-error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Progressive Web App manifest reference to load manifest.appdata instead of the previous manifest.json, adjusting the manifest resource the app uses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->