### PR TITLE
[#619] translate -15min event 2px towards bottom to align to other sizes

### DIFF
--- a/src/components/Event/EventChip/EventChip.tsx
+++ b/src/components/Event/EventChip/EventChip.tsx
@@ -117,11 +117,13 @@ export function EventChip({
     return (
       <Card
         variant="outlined"
-        style={
-          !isMoreThan15 || isMonthView
-            ? { ...cardStyle, height: "auto", transform: "translateY(2px)" }
-            : { ...cardStyle }
-        }
+        style={{
+          ...cardStyle,
+          ...(!isMoreThan15 || isMonthView ? { height: "auto" } : {}),
+          ...(!isMoreThan15 && !isMonthView
+            ? { transform: "translateY(2px)" }
+            : {}),
+        }}
         ref={cardRef}
         data-testid={`event-card-${event._def.extendedProps.uid}`}
       >


### PR DESCRIPTION
related to #619 

docker image on eriikaah/twake-calendar-front:issue-619-1px-offset-for-2-event-starting-at-the-same-time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined event card styling to better preserve base visuals while applying conditional layout tweaks (automatic height and slight vertical offset) for compact and month calendar views, improving alignment and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->