### PR TITLE
#661 hide empty resource section in event detail

### DIFF
--- a/src/components/Event/InfoRow.tsx
+++ b/src/components/Event/InfoRow.tsx
@@ -9,6 +9,7 @@ type InfoRowProps = {
   content?: React.ReactNode; // if provided, overrides text rendering
   style?: React.CSSProperties;
   alignItems?: React.CSSProperties["alignItems"];
+  flexWrap?: React.CSSProperties["flexWrap"];
 };
 
 function detectUrls(text: string) {
@@ -64,6 +65,7 @@ export function InfoRow({
   content,
   style,
   alignItems = "center",
+  flexWrap = "nowrap",
 }: InfoRowProps) {
   return (
     <Box
@@ -72,7 +74,7 @@ export function InfoRow({
         alignItems,
         gap: 1,
         marginBottom: 1,
-        flexWrap: "wrap",
+        flexWrap,
       }}
     >
       {icon}

--- a/src/features/Events/EventPreview/EventPreviewDetails.tsx
+++ b/src/features/Events/EventPreview/EventPreviewDetails.tsx
@@ -133,9 +133,10 @@ export function EventPreviewDetails({
       )}
 
       {/* Resource */}
-      {resources && (
+      {resources?.length > 0 && (
         <InfoRow
           alignItems="flex-start"
+          flexWrap="wrap"
           icon={
             <Box sx={infoIconSx}>
               <LayersOutlinedIcon />


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource sections now display only when resources are present, eliminating unnecessary empty placeholders
  * Enhanced layout flexibility for resource information displays with improved text wrapping capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->