### PR TITLE
#660 remove owner in calendar of resource

### DIFF
--- a/src/components/Calendar/CalendarName.tsx
+++ b/src/components/Calendar/CalendarName.tsx
@@ -15,7 +15,8 @@ export function CalendarName({ calendar }: { calendar: Calendar }) {
   const ownerId = calendar.id.split("/")[0];
   const ownerDisplayName = makeDisplayName(calendar) ?? "";
   const isOwnCalendar = userData.openpaasId === ownerId;
-  const showCaption = calendar.name !== "#default" && !isOwnCalendar;
+  const showCaption =
+    calendar.name !== "#default" && !isOwnCalendar && !calendar.owner?.resource;
 
   return (
     <Box


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar caption display behavior to prevent it from appearing when a calendar has an owner resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->