### PR TITLE
[#670] removed rogue call to update calendar ACL when it's a subscribed calendar

### DIFF
--- a/src/components/Calendar/CalendarModal.tsx
+++ b/src/components/Calendar/CalendarModal.tsx
@@ -123,8 +123,7 @@ function CalendarPopover({
         })
       ).unwrap();
     }
-
-    if (visibility !== calendar?.visibility) {
+    if (canManageInvites && visibility !== calendar?.visibility) {
       await dispatch(
         patchACLCalendarAsync({
           calId,


### PR DESCRIPTION
resolves #670 

What has been done : added condition that the user can manage the calendar before attempting to update ACL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where users without invite or calendar management permissions could unintentionally update calendar visibility settings during calendar saves. Users can continue to update other calendar details such as name, description, and color without affecting visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->