### PR TITLE
[#671] button for opening visio is now right clickable to copy the link

### DIFF
--- a/src/features/Events/EventPreview/EventPreviewDetails.tsx
+++ b/src/features/Events/EventPreview/EventPreviewDetails.tsx
@@ -1,18 +1,18 @@
 import { InfoRow } from "@/components/Event/InfoRow";
-import { Box, Button, Typography } from "@linagora/twake-mui";
-import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
+import { Box, Button, Link, Typography } from "@linagora/twake-mui";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import LayersOutlinedIcon from "@mui/icons-material/LayersOutlined";
 import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
 import NotificationsNoneIcon from "@mui/icons-material/NotificationsNone";
 import RepeatIcon from "@mui/icons-material/Repeat";
 import SubjectIcon from "@mui/icons-material/Subject";
 import VideocamOutlinedIcon from "@mui/icons-material/VideocamOutlined";
 import { alpha, useTheme } from "@mui/material/styles";
+import { useMemo } from "react";
 import { useI18n } from "twake-i18n";
 import { CalendarEvent } from "../EventsTypes";
 import { EventPreviewAttendees } from "./EventPreviewAttendees";
 import { makeRecurrenceString } from "./utils/makeRecurrenceString";
-import { useMemo } from "react";
 
 interface EventPreviewDetailsProps {
   event: CalendarEvent;
@@ -88,28 +88,20 @@ export function EventPreviewDetails({
             </Box>
           }
           content={
-            <a
+            <Link
               href={event.x_openpass_videoconference}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ textDecoration: "none" }}
-              onClick={(e) => e.preventDefault()}
+              sx={{ textDecoration: "none" }}
             >
               <Button
                 variant="contained"
                 size="medium"
-                onClick={() =>
-                  window.open(
-                    event.x_openpass_videoconference,
-                    "_blank",
-                    "noopener,noreferrer"
-                  )
-                }
                 sx={{ borderRadius: "4px" }}
               >
                 {t("eventPreview.joinVideo")}
               </Button>
-            </a>
+            </Link>
           }
         />
       )}


### PR DESCRIPTION
resolves #671 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video conference link behavior in event preview details: the join control now opens links via standard anchor navigation with proper new-tab and security attributes, and displays without underline for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->