### PR TITLE
feat: parse multiple attendees from pasted text (#723)

### DIFF
--- a/__test__/components/PeopleSearch.test.tsx
+++ b/__test__/components/PeopleSearch.test.tsx
@@ -214,6 +214,171 @@ describe("PeopleSearch", () => {
     });
   });
 
+  describe("paste multiple attendees", () => {
+    function setupFreeSolo(selectedUsers: User[] = []) {
+      const onChange = jest.fn();
+      renderWithProviders(
+        <PeopleSearch
+          objectTypes={["user"]}
+          selectedUsers={selectedUsers}
+          onChange={onChange}
+          freeSolo
+        />
+      );
+      return { onChange };
+    }
+
+    it("splits pasted comma-separated emails into individual attendees", async () => {
+      const { onChange } = setupFreeSolo();
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com, bob@example.com",
+        },
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: "alice@example.com" }),
+            expect.objectContaining({ email: "bob@example.com" }),
+          ])
+        );
+      });
+    });
+
+    it("splits pasted semicolon-separated emails", async () => {
+      const { onChange } = setupFreeSolo();
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com;bob@example.com",
+        },
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: "alice@example.com" }),
+            expect.objectContaining({ email: "bob@example.com" }),
+          ])
+        );
+      });
+    });
+
+    it("splits pasted newline-separated emails", async () => {
+      const { onChange } = setupFreeSolo();
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com\nbob@example.com",
+        },
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: "alice@example.com" }),
+            expect.objectContaining({ email: "bob@example.com" }),
+          ])
+        );
+      });
+    });
+
+    it("splits pasted space-separated emails", async () => {
+      const { onChange } = setupFreeSolo();
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com bob@example.com",
+        },
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: "alice@example.com" }),
+            expect.objectContaining({ email: "bob@example.com" }),
+          ])
+        );
+      });
+    });
+
+    it("skips duplicate emails already in selectedUsers", async () => {
+      const existing: User = {
+        email: "alice@example.com",
+        displayName: "Alice",
+      };
+      const { onChange } = setupFreeSolo([existing]);
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com, bob@example.com",
+        },
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            existing,
+            expect.objectContaining({ email: "bob@example.com" }),
+          ])
+        );
+        // Should NOT have alice duplicated
+        const call = onChange.mock.calls[0][1];
+        const aliceCount = call.filter(
+          (u: User) => u.email === "alice@example.com"
+        ).length;
+        expect(aliceCount).toBe(1);
+      });
+    });
+
+    it("leaves invalid text in input when some emails are invalid", async () => {
+      const { onChange } = setupFreeSolo();
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com, not-an-email, bob@example.com",
+        },
+      });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: "alice@example.com" }),
+            expect.objectContaining({ email: "bob@example.com" }),
+          ])
+        );
+      });
+    });
+
+    it("does not intercept paste of a single email", async () => {
+      const { onChange } = setupFreeSolo();
+      const input = screen.getByRole("combobox");
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => "alice@example.com",
+        },
+      });
+
+      // Single email should NOT trigger multi-paste handler
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   it("retains input value when field loses focus (blur)", async () => {
     let resolveSearch: (value: User[]) => void;
     const searchPromise = new Promise<User[]>((resolve) => {

--- a/src/components/Attendees/PeopleSearch.tsx
+++ b/src/components/Attendees/PeopleSearch.tsx
@@ -124,6 +124,56 @@ export function PeopleSearch({
     [query, selectedUsers, onChange, t, setInputError, setQuery]
   );
 
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLInputElement>) => {
+      if (!freeSolo) return;
+
+      const pasted = event.clipboardData.getData("text/plain");
+      if (!pasted) return;
+
+      // Split by comma, semicolon, newline, or whitespace
+      const chunks = pasted
+        .split(/[,;\n\r\s]+/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      // If there is only one chunk, let the default Autocomplete behaviour handle it
+      if (chunks.length <= 1) return;
+
+      event.preventDefault();
+
+      const existingEmails = new Set(selectedUsers.map((u) => u.email));
+      const validUsers: User[] = [];
+      const invalid: string[] = [];
+
+      for (const chunk of chunks) {
+        if (!isValidEmail(chunk)) {
+          invalid.push(chunk);
+        } else if (!existingEmails.has(chunk)) {
+          existingEmails.add(chunk);
+          validUsers.push({ email: chunk, displayName: chunk });
+        }
+        // silently skip duplicates
+      }
+
+      if (validUsers.length > 0) {
+        onChange(event, [...selectedUsers, ...validUsers]);
+      }
+
+      if (invalid.length > 0) {
+        // Leave the invalid text in the input for manual correction
+        setQuery(invalid.join(", "));
+        setInputError(
+          t("peopleSearch.invalidEmail").replace("%{email}", invalid.join(", "))
+        );
+      } else {
+        setQuery("");
+        setInputError(null);
+      }
+    },
+    [freeSolo, selectedUsers, onChange, setQuery, setInputError, t]
+  );
+
   const defaultRenderInput = useCallback(
     (params: AutocompleteRenderInputParams) => {
       const inputProps = {
@@ -150,6 +200,7 @@ export function PeopleSearch({
         inputProps: {
           ...params.inputProps,
           autoComplete: "off",
+          onPaste: handlePaste,
         },
       };
 
@@ -206,7 +257,7 @@ export function PeopleSearch({
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [inputError, t, onToggleEventPreview, loading, searchPlaceholder]
+    [inputError, t, onToggleEventPreview, loading, searchPlaceholder, handlePaste]
   );
 
   return (


### PR DESCRIPTION
## Summary

Closes #723

- Adds a `handlePaste` callback to `PeopleSearch` that intercepts paste events when `freeSolo` is enabled (attendee input mode)
- Splits pasted text by **comma**, **semicolon**, **newline**, or **space** (`/[,;\n\r\s]+/`) and validates each chunk with the existing `isValidEmail` helper
- Valid emails are added as individual attendee chips; duplicates (already present) are silently skipped
- Invalid chunks are left in the input field with the existing error message so the user can correct them manually
- Single-email pastes are left to the default Autocomplete behaviour (no interception)

### Supported formats

```
alice@example.com, bob@example.com
alice@example.com;bob@example.com
alice@example.com bob@example.com
alice@example.com
bob@example.com
```

## Test plan

- [ ] Paste comma-separated emails into the attendee field -- each email becomes its own chip
- [ ] Paste semicolon-separated emails -- same result
- [ ] Paste newline-separated emails -- same result
- [ ] Paste space-separated emails -- same result
- [ ] Paste a mix of valid and invalid entries -- valid ones become chips, invalid text stays in the input with an error
- [ ] Paste a single email -- default autocomplete behaviour (no multi-parse)
- [ ] Paste emails that include duplicates of already-added attendees -- no duplicate chips created
- [ ] Unit tests added in `__test__/components/PeopleSearch.test.tsx` covering all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)