### PR TITLE
#777 limit date picker height on mobile

### DIFF
--- a/src/components/Menubar/components/DatePickerMobile.tsx
+++ b/src/components/Menubar/components/DatePickerMobile.tsx
@@ -128,7 +128,8 @@ export const DatePickerMobile: React.FC<DatePickerMobileProps> = ({
         sx={{
           width: '100%',
           marginTop: '10px',
-          minHeight: `${rootMinHeight}px`
+          minHeight: `${rootMinHeight}px`,
+          maxHeight: '300px'
         }}
         slotProps={{
           toolbar: { hidden: true },
@@ -138,7 +139,7 @@ export const DatePickerMobile: React.FC<DatePickerMobileProps> = ({
                 width: '100%',
                 margin: 0,
                 maxWidth: 'none',
-                maxHeight: 'none',
+                maxHeight: '400px',
                 height: `${calendarHeight}px`
               },
               '.MuiDayCalendar-header': {
@@ -150,7 +151,8 @@ export const DatePickerMobile: React.FC<DatePickerMobileProps> = ({
                 justifyContent: 'space-around'
               },
               '.MuiDateCalendar-root .MuiDayCalendar-slideTransition': {
-                minHeight: `${slideTransitionMinHeight}px`
+                minHeight: `${slideTransitionMinHeight}px`,
+                maxHeight: '300px'
               }
             }
           },


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/777

### Note:

Currently, I don't have RedMi Note 11 to verify it, but I've verified on iPhone and it works. @Bobpodvalnyi could you verify it on RedMi Note 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted height constraints on the mobile date picker to improve layout consistency and prevent excessive vertical space usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->