### PR TITLE
#779 increase space between switch day buttons on mobile

### DIFF
--- a/src/components/Menubar/MobileMenuBar.tsx
+++ b/src/components/Menubar/MobileMenuBar.tsx
@@ -53,6 +53,7 @@ export const MobileMenubar: React.FC<MobileMenubarProps> = ({
           <IconButton
             onClick={onOpenSidebar}
             aria-label={t('menubar.toggleSidebar')}
+            sx={{ mr: 2 }}
           >
             <MenuIcon />
           </IconButton>

--- a/src/components/Menubar/components/SmallNavigationControls.tsx
+++ b/src/components/Menubar/components/SmallNavigationControls.tsx
@@ -11,13 +11,13 @@ export const SmallNavigationControls: React.FC<{
 
   return (
     <div className="navigation-controls">
-      <Stack direction="row">
+      <Stack direction="row" spacing={1.25}>
         <IconButton
           onClick={() => onNavigate('prev')}
           aria-label={t('menubar.prev')}
           title={t('menubar.prev')}
         >
-          <ChevronLeftIcon sx={{ height: 20 }} />
+          <ChevronLeftIcon sx={{ height: 30 }} />
         </IconButton>
         <IconButton
           color="primary"
@@ -36,7 +36,7 @@ export const SmallNavigationControls: React.FC<{
           aria-label={t('menubar.next')}
           title={t('menubar.next')}
         >
-          <ChevronRightIcon sx={{ height: 20 }} />
+          <ChevronRightIcon sx={{ height: 30 }} />
         </IconButton>
       </Stack>
     </div>


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added right margin to the mobile sidebar toggle for better spacing and alignment.
  * Refined small navigation controls with increased horizontal spacing and larger chevron icons for improved touchability and a more polished mobile experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->