### PR TITLE
#803 adjust desktop layout

### DIFF
--- a/src/components/Calendar/Sidebar/DesktopSidebar.tsx
+++ b/src/components/Calendar/Sidebar/DesktopSidebar.tsx
@@ -30,7 +30,7 @@ export const DesktopSidebar: React.FC<CalendarSidebarProps> = ({
           paddingLeft: 3,
           paddingRight: 2,
           width: '270px',
-          marginTop: isIframe ? 0 : '70px'
+          marginTop: isIframe ? 1 : '70px'
         },
         zIndex: 5
       }}

--- a/src/components/Menubar/DesktopMenubar.tsx
+++ b/src/components/Menubar/DesktopMenubar.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from '@linagora/twake-mui'
+import { IconButton, useTheme } from '@linagora/twake-mui'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import { useI18n } from 'twake-i18n'
@@ -31,9 +31,13 @@ export const DesktopMenubar: React.FC<SharedMenubarProps> = ({
   onUserMenuClose
 }) => {
   const { t } = useI18n()
+  const theme = useTheme()
 
   return (
-    <header className="menubar">
+    <header
+      className="menubar"
+      style={{ borderBottom: `1px solid ${theme.palette.divider}` }}
+    >
       <div className="left-menu">
         {!isIframe && (
           <div className="menu-items">


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The menu bar is no longer visible in the calendar interface.
  * Sidebar top spacing has been adjusted for improved layout alignment.
  * The menu bar border color now dynamically adapts based on your selected application theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->