### PR TITLE
ISSUE-825 Improve refresh without WS

### DIFF
--- a/__test__/features/websocket/utils/notificationStorm.test.tsx
+++ b/__test__/features/websocket/utils/notificationStorm.test.tsx
@@ -60,6 +60,7 @@ describe('websocket messages storm', () => {
     ;(getDisplayedCalendarRange as jest.Mock).mockReturnValue(mockRange)
     ;(store.getState as jest.Mock).mockReturnValue(mockState)
     window.WS_DEBOUNCE_PERIOD_MS = 500
+    window.WS_SKIP_DELAY_MS = 0
     mockAccumulators.calendarsToRefresh = new Map<string, any>()
     mockAccumulators.calendarsToHide = new Set()
     mockAccumulators.shouldRefreshCalendarListRef.current = false
@@ -67,7 +68,7 @@ describe('websocket messages storm', () => {
 
     mockAccumulators.debouncedUpdateFn = undefined
   })
-  it('debounces calendar updates during message storm', () => {
+  it('debounces calendar updates during message storm', async () => {
     const mockMessage = {
       '/calendars/cal1/entry1': {
         syncToken: 'ldsk'
@@ -78,17 +79,21 @@ describe('websocket messages storm', () => {
       updateCalendars(mockMessage, mockDispatch, mockAccumulators)
     }
 
+    // Flush leading edge's inner skip-delay timer (0ms)
+    await jest.advanceTimersByTimeAsync(0)
+
     // Dispatch called once because of leading edge
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
 
-    // Trailing edge
-    jest.advanceTimersByTime(500)
+    // Trailing debounce fires + flush its inner skip-delay timer
+    await jest.advanceTimersByTimeAsync(500)
+    await jest.runAllTimersAsync()
 
     // only one call for the last message + leading edge message
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(2)
   })
 
-  it('debounces calendar updates during message storm with multiple updates', () => {
+  it('debounces calendar updates during message storm with multiple updates', async () => {
     // Send a storm with mixed messages
     for (let i = 0; i < 50; i++) {
       if (i % 3 === 0)
@@ -111,17 +116,21 @@ describe('websocket messages storm', () => {
         )
     }
 
+    // Flush leading edge's inner skip-delay timer (0ms)
+    await jest.advanceTimersByTimeAsync(0)
+
     // Dispatch called once because of leading edge
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
 
-    // Trailing edge
-    jest.advanceTimersByTime(500)
+    // Trailing debounce fires + flush its inner skip-delay timer
+    await jest.advanceTimersByTimeAsync(500)
+    await jest.runAllTimersAsync()
 
     // Trailing edge updates once per calendar + the original leading edge
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(4)
   })
 
-  it('executes immediately when debounce is disabled', () => {
+  it('executes immediately when debounce is disabled', async () => {
     window.WS_DEBOUNCE_PERIOD_MS = 0
 
     updateCalendars(
@@ -129,6 +138,9 @@ describe('websocket messages storm', () => {
       mockDispatch,
       mockAccumulators
     )
+
+    // Flush the inner skip-delay timer (0ms)
+    await jest.advanceTimersByTimeAsync(0)
 
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
   })

--- a/__test__/features/websocket/utils/notificationStorm.test.tsx
+++ b/__test__/features/websocket/utils/notificationStorm.test.tsx
@@ -68,7 +68,7 @@ describe('websocket messages storm', () => {
 
     mockAccumulators.debouncedUpdateFn = undefined
   })
-  it('debounces calendar updates during message storm', async () => {
+  it('debounces calendar updates during message storm', () => {
     const mockMessage = {
       '/calendars/cal1/entry1': {
         syncToken: 'ldsk'
@@ -79,21 +79,17 @@ describe('websocket messages storm', () => {
       updateCalendars(mockMessage, mockDispatch, mockAccumulators)
     }
 
-    // Flush leading edge's inner skip-delay timer (0ms)
-    await jest.advanceTimersByTimeAsync(0)
-
     // Dispatch called once because of leading edge
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
 
-    // Trailing debounce fires + flush its inner skip-delay timer
-    await jest.advanceTimersByTimeAsync(500)
-    await jest.runAllTimersAsync()
+    // Trailing edge
+    jest.advanceTimersByTime(500)
 
     // only one call for the last message + leading edge message
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(2)
   })
 
-  it('debounces calendar updates during message storm with multiple updates', async () => {
+  it('debounces calendar updates during message storm with multiple updates', () => {
     // Send a storm with mixed messages
     for (let i = 0; i < 50; i++) {
       if (i % 3 === 0)
@@ -116,21 +112,17 @@ describe('websocket messages storm', () => {
         )
     }
 
-    // Flush leading edge's inner skip-delay timer (0ms)
-    await jest.advanceTimersByTimeAsync(0)
-
     // Dispatch called once because of leading edge
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
 
-    // Trailing debounce fires + flush its inner skip-delay timer
-    await jest.advanceTimersByTimeAsync(500)
-    await jest.runAllTimersAsync()
+    // Trailing edge
+    jest.advanceTimersByTime(500)
 
     // Trailing edge updates once per calendar + the original leading edge
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(4)
   })
 
-  it('executes immediately when debounce is disabled', async () => {
+  it('executes immediately when debounce is disabled', () => {
     window.WS_DEBOUNCE_PERIOD_MS = 0
 
     updateCalendars(
@@ -138,9 +130,6 @@ describe('websocket messages storm', () => {
       mockDispatch,
       mockAccumulators
     )
-
-    // Flush the inner skip-delay timer (0ms)
-    await jest.advanceTimersByTimeAsync(0)
 
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
   })

--- a/__test__/features/websocket/utils/updateCalendars.test.tsx
+++ b/__test__/features/websocket/utils/updateCalendars.test.tsx
@@ -53,6 +53,7 @@ describe('updateCalendars', () => {
     mockAccumulators.currentDebouncePeriod = 0
     mockAccumulators.shouldRefreshCalendarListRef.current = false
     mockAccumulators.debouncedUpdateFn = jest.fn()
+    window.WS_SKIP_DELAY_MS = 0
   })
 
   it('should not dispatch for non-object messages', () => {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,4 +1,5 @@
 import eventsCalendar from '@/features/Calendars/CalendarSlice'
+import { postMutationRefreshMiddleware } from '@/features/Calendars/listeners/postMutationRefresh'
 import searchResultReducer from '@/features/Search/SearchSlice'
 import settingsReducer from '@/features/Settings/SettingsSlice'
 import userReducer from '@/features/User/userSlice'
@@ -24,7 +25,9 @@ export const setupStore = (preloadedState?: Partial<RootState>) => {
     reducer: rootReducer,
     preloadedState,
     middleware: getDefaultMiddleware =>
-      getDefaultMiddleware().concat(routerMiddleware)
+      getDefaultMiddleware()
+        .concat(routerMiddleware)
+        .prepend(postMutationRefreshMiddleware.middleware)
   })
 }
 

--- a/src/features/Calendars/listeners/postMutationRefresh.ts
+++ b/src/features/Calendars/listeners/postMutationRefresh.ts
@@ -1,0 +1,79 @@
+import type { AppDispatch, RootState } from '@/app/store'
+import { findCalendarById, getDisplayedCalendarRange } from '@/utils'
+import { createListenerMiddleware } from '@reduxjs/toolkit'
+import {
+  deleteEventAsync,
+  deleteEventInstanceAsync,
+  moveEventAsync,
+  putEventAsync,
+  refreshCalendarWithSyncToken,
+  updateEventInstanceAsync,
+  updateSeriesAsync
+} from '../services'
+
+export const postMutationRefreshMiddleware = createListenerMiddleware()
+
+const startListening =
+  postMutationRefreshMiddleware.startListening.withTypes<RootState, AppDispatch>()
+
+function triggerRefresh(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  calId: string
+) {
+  const found = findCalendarById(getState(), calId)
+  if (!found) return
+  dispatch(
+    refreshCalendarWithSyncToken({
+      calendar: found.calendar,
+      calType: found.type,
+      calendarRange: getDisplayedCalendarRange()
+    })
+  )
+}
+
+startListening({
+  actionCreator: putEventAsync.fulfilled,
+  effect: (action, { dispatch, getState }) => {
+    triggerRefresh(dispatch, getState, action.payload.calId)
+  }
+})
+
+startListening({
+  actionCreator: deleteEventAsync.fulfilled,
+  effect: (action, { dispatch, getState }) => {
+    triggerRefresh(dispatch, getState, action.payload.calId)
+  }
+})
+
+startListening({
+  actionCreator: deleteEventInstanceAsync.fulfilled,
+  effect: (action, { dispatch, getState }) => {
+    triggerRefresh(dispatch, getState, action.payload.calId)
+  }
+})
+
+startListening({
+  actionCreator: updateEventInstanceAsync.fulfilled,
+  effect: (action, { dispatch, getState }) => {
+    triggerRefresh(dispatch, getState, action.payload.calId)
+  }
+})
+
+startListening({
+  actionCreator: moveEventAsync.fulfilled,
+  effect: (action, { dispatch, getState }) => {
+    triggerRefresh(dispatch, getState, action.payload.calId)
+    const sourceCalId = action.meta.arg.newEvent.calId
+    if (sourceCalId && sourceCalId !== action.payload.calId) {
+      triggerRefresh(dispatch, getState, sourceCalId)
+    }
+  }
+})
+
+startListening({
+  actionCreator: updateSeriesAsync.fulfilled,
+  effect: (action, { dispatch, getState }) => {
+    triggerRefresh(dispatch, getState, action.meta.arg.cal.id)
+  }
+})

--- a/src/features/Calendars/listeners/postMutationRefresh.ts
+++ b/src/features/Calendars/listeners/postMutationRefresh.ts
@@ -13,17 +13,19 @@ import {
 
 export const postMutationRefreshMiddleware = createListenerMiddleware()
 
-const startListening =
-  postMutationRefreshMiddleware.startListening.withTypes<RootState, AppDispatch>()
+const startListening = postMutationRefreshMiddleware.startListening.withTypes<
+  RootState,
+  AppDispatch
+>()
 
 function triggerRefresh(
   dispatch: AppDispatch,
   getState: () => RootState,
   calId: string
-) {
+): void {
   const found = findCalendarById(getState(), calId)
   if (!found) return
-  dispatch(
+  void dispatch(
     refreshCalendarWithSyncToken({
       calendar: found.calendar,
       calType: found.type,
@@ -34,46 +36,74 @@ function triggerRefresh(
 
 startListening({
   actionCreator: putEventAsync.fulfilled,
-  effect: (action, { dispatch, getState }) => {
-    triggerRefresh(dispatch, getState, action.payload.calId)
+  effect: (action, listenerApi) => {
+    triggerRefresh(
+      listenerApi.dispatch,
+      () => listenerApi.getState(),
+      action.payload.calId
+    )
   }
 })
 
 startListening({
   actionCreator: deleteEventAsync.fulfilled,
-  effect: (action, { dispatch, getState }) => {
-    triggerRefresh(dispatch, getState, action.payload.calId)
+  effect: (action, listenerApi) => {
+    triggerRefresh(
+      listenerApi.dispatch,
+      () => listenerApi.getState(),
+      action.payload.calId
+    )
   }
 })
 
 startListening({
   actionCreator: deleteEventInstanceAsync.fulfilled,
-  effect: (action, { dispatch, getState }) => {
-    triggerRefresh(dispatch, getState, action.payload.calId)
+  effect: (action, listenerApi) => {
+    triggerRefresh(
+      listenerApi.dispatch,
+      () => listenerApi.getState(),
+      action.payload.calId
+    )
   }
 })
 
 startListening({
   actionCreator: updateEventInstanceAsync.fulfilled,
-  effect: (action, { dispatch, getState }) => {
-    triggerRefresh(dispatch, getState, action.payload.calId)
+  effect: (action, listenerApi) => {
+    triggerRefresh(
+      listenerApi.dispatch,
+      () => listenerApi.getState(),
+      action.payload.calId
+    )
   }
 })
 
 startListening({
   actionCreator: moveEventAsync.fulfilled,
-  effect: (action, { dispatch, getState }) => {
-    triggerRefresh(dispatch, getState, action.payload.calId)
+  effect: (action, listenerApi) => {
+    triggerRefresh(
+      listenerApi.dispatch,
+      () => listenerApi.getState(),
+      action.payload.calId
+    )
     const sourceCalId = action.meta.arg.newEvent.calId
     if (sourceCalId && sourceCalId !== action.payload.calId) {
-      triggerRefresh(dispatch, getState, sourceCalId)
+      triggerRefresh(
+        listenerApi.dispatch,
+        () => listenerApi.getState(),
+        sourceCalId
+      )
     }
   }
 })
 
 startListening({
   actionCreator: updateSeriesAsync.fulfilled,
-  effect: (action, { dispatch, getState }) => {
-    triggerRefresh(dispatch, getState, action.meta.arg.cal.id)
+  effect: (action, listenerApi) => {
+    triggerRefresh(
+      listenerApi.dispatch,
+      () => listenerApi.getState(),
+      action.meta.arg.cal.id
+    )
   }
 })

--- a/src/websocket/messaging/updateCalendars.ts
+++ b/src/websocket/messaging/updateCalendars.ts
@@ -26,7 +26,9 @@ function createDebouncedUpdate(
   resetShouldRefreshCalendarList: () => void
 ) {
   return debounce(
-    async (dispatch: AppDispatch) => {
+    (dispatch: AppDispatch) => {
+      const currentRange = getDisplayedCalendarRange()
+
       // Snapshot state
       const calendarsToProcess = new Map(getCalendarsToRefresh())
       const calendarsToHideSnapshot = new Set(getCalendarsToHide())
@@ -38,7 +40,7 @@ function createDebouncedUpdate(
       resetShouldRefreshCalendarList()
 
       try {
-        await processCalendarsToRefreshWithDelay(dispatch, calendarsToProcess)
+        scheduleCalendarsRefresh(dispatch, currentRange, calendarsToProcess)
         processCalendarsToHide(calendarsToHideSnapshot)
 
         if (shouldRefresh) {
@@ -96,6 +98,7 @@ export function updateCalendars(
   }
 
   // Immediate processing if debounce disabled
+  const currentRange = getDisplayedCalendarRange()
   const calendarsToProcess = new Map(accumulators.calendarsToRefresh)
   const calendarsToHideSnapshot = new Set(accumulators.calendarsToHide)
 
@@ -103,37 +106,57 @@ export function updateCalendars(
   accumulators.calendarsToHide.clear()
   accumulators.shouldRefreshCalendarListRef.current = false
 
-  void (async () => {
-    try {
-      await processCalendarsToRefreshWithDelay(dispatch, calendarsToProcess)
-      processCalendarsToHide(calendarsToHideSnapshot)
-      if (shouldRefreshCalendarList) {
-        dispatch(getCalendarsListAsync())
-      }
-    } catch (error) {
-      console.warn('Error processing calendar updates:', error)
+  try {
+    scheduleCalendarsRefresh(dispatch, currentRange, calendarsToProcess)
+    processCalendarsToHide(calendarsToHideSnapshot)
+    if (shouldRefreshCalendarList) {
+      dispatch(getCalendarsListAsync())
     }
-  })()
+  } catch (error) {
+    console.warn('Error processing calendar updates:', error)
+  }
 }
 
 // --- Helpers ---
-async function processCalendarsToRefreshWithDelay(
+
+function scheduleCalendarsRefresh(
   dispatch: AppDispatch,
+  currentRange: { start: Date; end: Date },
   calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>
 ) {
   const skipDelayMs = window.WS_SKIP_DELAY_MS ?? DEFAULT_WS_SKIP_DELAY_MS
-  await new Promise<void>(resolve => setTimeout(resolve, skipDelayMs))
 
-  const currentState = store.getState()
-  const currentRange = getDisplayedCalendarRange()
+  if (skipDelayMs === 0) {
+    dispatchCalendarsRefresh(dispatch, currentRange, calendarsMap)
+    return
+  }
 
-  calendarsMap.forEach(({ calendar, type }, calId) => {
-    const current = findCalendarById(currentState, calId)
-    if (current && current.calendar.syncToken !== calendar.syncToken) return
+  setTimeout(() => {
+    const stateAfterDelay = store.getState()
+    const rangeAfterDelay = getDisplayedCalendarRange()
+    calendarsMap.forEach(({ calendar, type }, calId) => {
+      const current = findCalendarById(stateAfterDelay, calId)
+      if (current && current.calendar.syncToken !== calendar.syncToken) return
+      dispatch(
+        refreshCalendarWithSyncToken({
+          calendar: current?.calendar ?? calendar,
+          calType: type,
+          calendarRange: rangeAfterDelay
+        })
+      )
+    })
+  }, skipDelayMs)
+}
 
+function dispatchCalendarsRefresh(
+  dispatch: AppDispatch,
+  currentRange: { start: Date; end: Date },
+  calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>
+) {
+  calendarsMap.forEach(({ calendar, type }) => {
     dispatch(
       refreshCalendarWithSyncToken({
-        calendar: current?.calendar ?? calendar,
+        calendar,
         calType: type,
         calendarRange: currentRange
       })

--- a/src/websocket/messaging/updateCalendars.ts
+++ b/src/websocket/messaging/updateCalendars.ts
@@ -13,6 +13,7 @@ import { parseMessage } from './parseMessage'
 import { UpdateCalendarsAccumulators } from './type/UpdateCalendarsAccumulators'
 
 const DEFAULT_DEBOUNCE_MS = 0
+const DEFAULT_WS_SKIP_DELAY_MS = 2000
 
 function createDebouncedUpdate(
   debouncePeriodMs: number,
@@ -25,9 +26,7 @@ function createDebouncedUpdate(
   resetShouldRefreshCalendarList: () => void
 ) {
   return debounce(
-    (dispatch: AppDispatch) => {
-      const currentRange = getDisplayedCalendarRange()
-
+    async (dispatch: AppDispatch) => {
       // Snapshot state
       const calendarsToProcess = new Map(getCalendarsToRefresh())
       const calendarsToHideSnapshot = new Set(getCalendarsToHide())
@@ -39,7 +38,7 @@ function createDebouncedUpdate(
       resetShouldRefreshCalendarList()
 
       try {
-        processCalendarsToRefresh(dispatch, currentRange, calendarsToProcess)
+        await processCalendarsToRefreshWithDelay(dispatch, calendarsToProcess)
         processCalendarsToHide(calendarsToHideSnapshot)
 
         if (shouldRefresh) {
@@ -97,7 +96,6 @@ export function updateCalendars(
   }
 
   // Immediate processing if debounce disabled
-  const currentRange = getDisplayedCalendarRange()
   const calendarsToProcess = new Map(accumulators.calendarsToRefresh)
   const calendarsToHideSnapshot = new Set(accumulators.calendarsToHide)
 
@@ -105,18 +103,44 @@ export function updateCalendars(
   accumulators.calendarsToHide.clear()
   accumulators.shouldRefreshCalendarListRef.current = false
 
-  try {
-    processCalendarsToRefresh(dispatch, currentRange, calendarsToProcess)
-    processCalendarsToHide(calendarsToHideSnapshot)
-    if (shouldRefreshCalendarList) {
-      dispatch(getCalendarsListAsync())
+  void (async () => {
+    try {
+      await processCalendarsToRefreshWithDelay(dispatch, calendarsToProcess)
+      processCalendarsToHide(calendarsToHideSnapshot)
+      if (shouldRefreshCalendarList) {
+        dispatch(getCalendarsListAsync())
+      }
+    } catch (error) {
+      console.warn('Error processing calendar updates:', error)
     }
-  } catch (error) {
-    console.warn('Error processing calendar updates:', error)
-  }
+  })()
 }
 
 // --- Helpers ---
+async function processCalendarsToRefreshWithDelay(
+  dispatch: AppDispatch,
+  calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>
+) {
+  const skipDelayMs = window.WS_SKIP_DELAY_MS ?? DEFAULT_WS_SKIP_DELAY_MS
+  await new Promise<void>(resolve => setTimeout(resolve, skipDelayMs))
+
+  const currentState = store.getState()
+  const currentRange = getDisplayedCalendarRange()
+
+  calendarsMap.forEach(({ calendar, type }, calId) => {
+    const current = findCalendarById(currentState, calId)
+    if (current && current.calendar.syncToken !== calendar.syncToken) return
+
+    dispatch(
+      refreshCalendarWithSyncToken({
+        calendar: current?.calendar ?? calendar,
+        calType: type,
+        calendarRange: currentRange
+      })
+    )
+  })
+}
+
 function accumulateCalendarsToRefresh(
   state: ReturnType<typeof store.getState>,
   calendarPaths: Set<string>,
@@ -146,22 +170,6 @@ function accumulateCalendarsToHide(
     if (calendarId) {
       calendarsToHideSet.add(calendarId)
     }
-  })
-}
-
-function processCalendarsToRefresh(
-  dispatch: AppDispatch,
-  currentRange: { start: Date; end: Date },
-  calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>
-) {
-  calendarsMap.forEach(calendar => {
-    dispatch(
-      refreshCalendarWithSyncToken({
-        calendar: calendar.calendar,
-        calType: calendar.type,
-        calendarRange: currentRange
-      })
-    )
   })
 }
 

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -27,6 +27,7 @@ declare global {
 
     WEBSOCKET_URL: string
     WS_DEBOUNCE_PERIOD_MS: number
+    WS_SKIP_DELAY_MS: number
     WS_PING_PERIOD_MS: number
     WS_PING_TIMEOUT_PERIOD_MS: number
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendars now automatically synchronize after creating, deleting, or moving events.

* **Improvements**
  * Calendar refresh scheduling now batches websocket updates with configurable delay for optimized synchronization.
  * Refresh operations validate sync tokens to ensure consistency.
  * Source and destination calendars are refreshed when events are moved between calendars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->