### PR TITLE
#827 fix location field layout

### DIFF
--- a/src/components/Event/AddDescButton.tsx
+++ b/src/components/Event/AddDescButton.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from './components/FieldWithLabel'
 import { SectionPreviewRow } from './components/SectionPreviewRow'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
 export function AddDescButton({
   showDescription,

--- a/src/components/Event/fields/LocationField.tsx
+++ b/src/components/Event/fields/LocationField.tsx
@@ -44,7 +44,7 @@ export default function LocationField({
   return (
     <FieldWithLabel
       label={showInputLabel(isLocationExpanded, t('event.form.location'))}
-      isExpanded={isLocationExpanded && !isMobile}
+      isExpanded={showMore && !isMobile}
     >
       {!isLocationExpanded ? (
         <SectionPreviewRow


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated location field expansion behavior to use the designated expand control instead of preview section interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->