### PR TITLE
[ENHANCEMENT] Split PRs from main docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,13 +93,13 @@ pipeline {
               }
             }
 
-            def dockerTag = "pr-${env.CHANGE_ID}"
+            def dockerTag = "${env.CHANGE_ID}"
             env.DOCKER_TAG = dockerTag
             echo "Docker tag: ${dockerTag}"
             sh 'npm run build'
-            sh 'docker build -t linagora/twake-calendar-web:$DOCKER_TAG .'
+            sh 'docker build -t linagora/twake-calendar-web-pr:$DOCKER_TAG .'
             sh 'echo $DOCKER_HUB_CREDENTIAL_PSW | docker login -u $DOCKER_HUB_CREDENTIAL_USR --password-stdin'
-            sh 'docker push linagora/twake-calendar-web:$DOCKER_TAG'
+            sh 'docker push linagora/twake-calendar-web-pr:$DOCKER_TAG'
             sh """
               HTTP_STATUS=\$(curl -s -o /tmp/gh_comment_response.json -w "%{http_code}" -X POST \\
                 -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
               HTTP_STATUS=\$(curl -s -o /tmp/gh_comment_response.json -w "%{http_code}" -X POST \\
                 -H "Authorization: token \${GITHUB_CREDENTIAL_PSW}" \\
                 -H "Content-Type: application/json" \\
-                -d "{\\"body\\": \\"Docker image published for this PR: linagora/twake-calendar-web:${dockerTag}\\"}" \\
+                -d "{\\"body\\": \\"Docker image published for this PR: linagora/twake-calendar-web-pr:${dockerTag}\\"}" \\
                 "https://api.github.com/repos/linagora/twake-calendar-frontend/issues/\${CHANGE_ID}/comments")
               if [ "\$HTTP_STATUS" -lt 200 ] || [ "\$HTTP_STATUS" -ge 300 ]; then
                 echo "WARNING: GitHub API comment failed with HTTP \$HTTP_STATUS"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment for Docker image handling in PR builds.
  * PR builds now use a PR-specific image repository and tag images using the change ID directly (no prefixed tag).
  * Updated deployment metadata/comments to reference the new repository and tag format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->