### PR TITLE
[#753] reduced size of all day slot and added allday event creation on header click

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -24,7 +24,6 @@ import FullCalendar from '@fullcalendar/react'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import { Fab } from '@linagora/twake-mui'
 import AddIcon from '@mui/icons-material/Add'
-import moment from 'moment-timezone'
 import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { useCalendarDataLoader } from '../../features/Calendars/useCalendarLoader'
@@ -78,6 +77,8 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
   setCurrentView,
   currentView
 }: CalendarAppProps) => {
+  const { t, lang } = useI18n()
+
   const [selectedDate, setSelectedDate] = useState(new Date())
   const [debouncedDate, setDebouncedDate] = useState(new Date())
   useEffect(() => {
@@ -374,7 +375,11 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     tempcalendars,
     // Note: To preserve current logic, this will temporarily disable eslint for react-hooks/refs
     // eslint-disable-next-line react-hooks/refs
-    errorHandler: errorHandler.current
+    errorHandler: errorHandler.current,
+    timezone,
+    isTablet,
+    isMobile,
+    t
   })
 
   useEffect(() => {
@@ -382,8 +387,6 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
       window.__calendarRef = calendarRef
     }
   }, [calendarRef])
-
-  const { t, lang } = useI18n()
 
   useTouchListener(
     eventHandlers.handleDateSelect,
@@ -419,7 +422,6 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
 
         {view === 'calendar' && (
           <>
-            {' '}
             {(isTablet || isMobile) && (
               <Fab
                 color="primary"
@@ -580,33 +582,7 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
                     updateSlotLabelVisibility(new Date())
                   }, 100)
                 }}
-                dayHeaderContent={arg => {
-                  const m = moment.tz(arg.date, timezone)
-
-                  const date = m.date()
-                  const weekDay = m
-                    .toDate()
-                    .toLocaleDateString(t('locale'), {
-                      weekday: 'short',
-                      timeZone: timezone
-                    })
-                    .toUpperCase()
-
-                  return (
-                    <div
-                      className={`fc-daygrid-day-top ${isTablet || isMobile ? 'fc-daygrid-day-top--mobile' : ''}`}
-                    >
-                      <small>{weekDay}</small>
-                      {arg.view.type !== CALENDAR_VIEWS.dayGridMonth && (
-                        <span
-                          className={`fc-daygrid-day-number ${arg.isToday ? 'current-date' : ''}`}
-                        >
-                          {date}
-                        </span>
-                      )}
-                    </div>
-                  )
-                }}
+                dayHeaderContent={viewHandlers.handleDayHeaderContent}
                 dayHeaderDidMount={viewHandlers.handleDayHeaderDidMount}
                 dayHeaderWillUnmount={viewHandlers.handleDayHeaderWillUnmount}
                 viewDidMount={viewHandlers.handleViewDidMount}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -40,7 +40,7 @@ import { useCalendarViewHandlers } from './hooks/useCalendarViewHandlers'
 import { useSwipeNavigation } from './hooks/useSwipeNavigation'
 import Sidebar from './Sidebar/SideBar'
 import TempSearchDialog from './TempSearchDialog'
-import { useTouchListener } from './useTouchListener'
+import { useTouchListener } from './hooks/useTouchListener'
 import {
   eventToFullCalendarFormat,
   extractEvents,

--- a/src/components/Calendar/CustomCalendar.styl
+++ b/src/components/Calendar/CustomCalendar.styl
@@ -338,7 +338,6 @@ tbody > tr.fc-scrollgrid-section:first-of-type .fc-scroller
   border none
   width 95%
   height 100%
-  align-content left
   .fc-event-main
     display flex
     flex-direction row

--- a/src/components/Calendar/CustomCalendar.styl
+++ b/src/components/Calendar/CustomCalendar.styl
@@ -118,7 +118,6 @@ th.fc-timegrid-axis.fc-scrollgrid-shrink
 
 th.fc-col-header-cell.fc-day
   border-right 0
-  border-bottom 0
 
 .fc .fc-scrollgrid
   border 0
@@ -146,9 +145,6 @@ th.fc-col-header-cell.fc-day
 .fc .fc-timegrid-col.fc-day-today,
 .fc .fc-daygrid-day.fc-day-today
   background-color #fff
-
-.fc .fc-daygrid-body-unbalanced .fc-daygrid-day-events
-  min-height 36px
 
 .fc .fc-daygrid-body-natural .fc-daygrid-day-events
   margin-bottom 0
@@ -254,7 +250,7 @@ tbody > tr.fc-scrollgrid-section:first-of-type .fc-scroller
 .navigation-controls
   margin-right 16px
 
-.fc .fc-timegrid-slot-minor 
+.fc .fc-timegrid-slot-minor
   border-top-style: none
 
 /* FullCalendar "more" popover restyle */
@@ -337,12 +333,12 @@ tbody > tr.fc-scrollgrid-section:first-of-type .fc-scroller
       padding 0 !important
 
 // Custom event chips
-.fc-event 
+.fc-event
   background-color transparent
   border none
   width 95%
   height 100%
-  align-content left 
+  align-content left
   .fc-event-main
     display flex
     flex-direction row
@@ -369,7 +365,7 @@ tbody > tr.fc-scrollgrid-section:first-of-type .fc-scroller
   whiteSpace nowrap
 .date-time-group .MuiFormControl-root
   margin: 0
-.date-time-group.show-full-field > .MuiBox-root:first-of-type 
+.date-time-group.show-full-field > .MuiBox-root:first-of-type
   margin-bottom: 8px
 
 li.MuiButtonBase-root.MuiMenuItem-root
@@ -393,3 +389,8 @@ hr.MuiDivider-root.MuiDivider-fullWidth
   grid-area main
   width 100%
   height 100%
+
+// Match all-day row height to a 30-minute slot
+.fc-timeGridWeek-view .fc-daygrid-body .fc-daygrid-day-top,
+.fc-timeGridDay-view .fc-daygrid-body .fc-daygrid-day-top
+  display none

--- a/src/components/Calendar/handlers/viewHandlers.ts
+++ b/src/components/Calendar/handlers/viewHandlers.ts
@@ -4,12 +4,14 @@ import { Calendar } from '@/features/Calendars/CalendarTypes'
 import { userAttendee } from '@/features/User/models/attendee'
 import {
   CalendarApi,
+  DayHeaderContentArg,
   DayHeaderMountArg,
   EventContentArg,
   EventMountArg,
   NowIndicatorContentArg,
   ViewMountArg
 } from '@fullcalendar/core'
+import moment from 'moment-timezone'
 import React from 'react'
 import { CALENDAR_VIEWS } from '../utils/constants'
 import { createMouseHandlers } from './mouseHandlers'
@@ -22,6 +24,10 @@ export interface ViewHandlersProps {
   calendars: Record<string, Calendar>
   tempcalendars: Record<string, Calendar>
   errorHandler: EventErrorHandler
+  timezone: string
+  isTablet: boolean
+  isMobile: boolean
+  t: (key: string) => string
 }
 
 export const createViewHandlers = (props: ViewHandlersProps) => {
@@ -32,10 +38,16 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
     onViewChange,
     calendars,
     tempcalendars,
-    errorHandler
+    errorHandler,
+    timezone,
+    isTablet,
+    isMobile,
+    t
   } = props
 
-  const handleNowIndicatorContent = (arg: NowIndicatorContentArg) => {
+  const handleNowIndicatorContent = (
+    arg: NowIndicatorContentArg
+  ): React.ReactElement | undefined => {
     if (arg.isAxis) {
       return React.createElement(
         'div',
@@ -47,41 +59,95 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
             hour: '2-digit',
             minute: '2-digit',
             hour12: false,
-            timeZone: arg.view.dateEnv.timeZone
+            timeZone: (arg.view.dateEnv as unknown as { timeZone: string })
+              .timeZone
           })
         )
       )
     }
+    return undefined
   }
 
-  const handleDayHeaderDidMount = (arg: DayHeaderMountArg) => {
-    if (arg.view.type === CALENDAR_VIEWS.timeGridWeek) {
-      const headerEl = arg.el
+  const handleDayHeaderClick = (arg: DayHeaderContentArg): void => {
+    const startOfDay = new Date(arg.date)
+    startOfDay.setHours(0, 0, 0, 0)
+    const endOfDay = new Date(arg.date)
+    endOfDay.setHours(23, 59, 59, 999)
+    calendarRef.current?.select({
+      start: startOfDay,
+      end: endOfDay,
+      allDay: true
+    })
+  }
 
-      const handleDayHeaderClick = () => {
-        calendarRef.current?.changeView(CALENDAR_VIEWS.timeGridDay, arg.date)
-        setSelectedDate(new Date(arg.date))
-        setSelectedMiniDate(new Date(arg.date))
-
-        if (onViewChange) {
-          onViewChange(CALENDAR_VIEWS.timeGridDay)
-        }
-      }
-
-      headerEl.addEventListener('click', handleDayHeaderClick)
-      headerEl.__dayHeaderClickHandler = handleDayHeaderClick
+  const handleDayNumberClick = (
+    e: React.MouseEvent,
+    arg: DayHeaderContentArg
+  ): void => {
+    e.stopPropagation()
+    calendarRef.current?.changeView(CALENDAR_VIEWS.timeGridDay, arg.date)
+    setSelectedDate(new Date(arg.date))
+    setSelectedMiniDate(new Date(arg.date))
+    if (onViewChange) {
+      onViewChange(CALENDAR_VIEWS.timeGridDay)
     }
   }
 
-  const handleDayHeaderWillUnmount = (arg: DayHeaderMountArg) => {
+  const handleDayHeaderContent = (arg: DayHeaderContentArg): JSX.Element => {
+    const m = moment.tz(arg.date, timezone)
+    const date = m.date()
+    const weekDay = m
+      .toDate()
+      .toLocaleDateString(t('locale'), {
+        weekday: 'short',
+        timeZone: timezone
+      })
+      .toUpperCase()
+
+    return React.createElement(
+      'div',
+      {
+        className: `fc-daygrid-day-top ${isTablet || isMobile ? 'fc-daygrid-day-top--mobile' : ''}`
+      },
+      React.createElement('small', null, weekDay),
+      arg.view.type !== CALENDAR_VIEWS.dayGridMonth
+        ? React.createElement(
+            'span',
+            {
+              className: `fc-daygrid-day-number ${arg.isToday ? 'current-date' : ''}`,
+              onClick: (e: React.MouseEvent) => handleDayNumberClick(e, arg)
+            },
+            date
+          )
+        : null
+    )
+  }
+
+  const handleDayHeaderDidMount = (arg: DayHeaderMountArg): void => {
+    if (arg.view.type === CALENDAR_VIEWS.timeGridWeek) {
+      const headerEl = arg.el
+
+      const handleDayClick = (): void => {
+        handleDayHeaderClick(arg)
+      }
+
+      headerEl.addEventListener('click', handleDayClick)
+      headerEl.__dayHeaderClickHandler = handleDayClick
+    }
+  }
+
+  const handleDayHeaderWillUnmount = (arg: DayHeaderMountArg): void => {
     const headerEl = arg.el
     if (headerEl.__dayHeaderClickHandler) {
-      headerEl.removeEventListener('click', headerEl.__dayHeaderClickHandler)
+      headerEl.removeEventListener(
+        'click',
+        headerEl.__dayHeaderClickHandler as EventListener
+      )
       delete headerEl.__dayHeaderClickHandler
     }
   }
 
-  const handleViewDidMount = (arg: ViewMountArg) => {
+  const handleViewDidMount = (arg: ViewMountArg): void => {
     if (
       arg.view.type === CALENDAR_VIEWS.timeGridWeek ||
       arg.view.type === CALENDAR_VIEWS.timeGridDay
@@ -94,15 +160,20 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
     }
   }
 
-  const handleViewWillUnmount = (arg: ViewMountArg) => {
-    if (arg.el.__timeInterval) {
-      clearInterval(arg.el.__timeInterval)
-      delete arg.el.__timeInterval
+  const handleViewWillUnmount = (arg: ViewMountArg): void => {
+    const el = arg.el as HTMLElement & {
+      __timeInterval?: ReturnType<typeof setInterval>
+      __timeObserver?: { disconnect: () => void }
     }
 
-    if (arg.el.__timeObserver) {
-      arg.el.__timeObserver.disconnect()
-      delete arg.el.__timeObserver
+    if (el.__timeInterval !== undefined) {
+      clearInterval(el.__timeInterval)
+      delete el.__timeInterval
+    }
+
+    if (el.__timeObserver !== undefined) {
+      el.__timeObserver.disconnect()
+      delete el.__timeObserver
     }
 
     const calendarEl = document.querySelector('.fc') as HTMLElement
@@ -112,7 +183,7 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
     }
   }
 
-  const handleEventContent = (arg: EventContentArg) => {
+  const handleEventContent = (arg: EventContentArg): React.ReactElement => {
     return React.createElement(EventChip, {
       arg,
       calendars,
@@ -121,11 +192,16 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
     })
   }
 
-  const handleEventDidMount = (arg: EventMountArg) => {
-    const attendees = arg.event._def.extendedProps.attendee || []
-    if (!calendars[arg.event._def.extendedProps.calId]) return
+  const handleEventDidMount = (arg: EventMountArg): void => {
+    const extendedProps = arg.event._def.extendedProps as {
+      attendee?: userAttendee[]
+      calId: string
+    }
+    const attendees = extendedProps.attendee ?? []
+    if (!calendars[extendedProps.calId]) return
+
     const ownerEmails = new Set(
-      calendars[arg.event._def.extendedProps.calId].owner?.emails?.map(email =>
+      calendars[extendedProps.calId].owner?.emails?.map(email =>
         email.toLowerCase()
       )
     )
@@ -158,6 +234,7 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
 
   return {
     handleNowIndicatorContent,
+    handleDayHeaderContent,
     handleDayHeaderDidMount,
     handleDayHeaderWillUnmount,
     handleViewDidMount,

--- a/src/components/Calendar/handlers/viewHandlers.ts
+++ b/src/components/Calendar/handlers/viewHandlers.ts
@@ -11,6 +11,7 @@ import {
   NowIndicatorContentArg,
   ViewMountArg
 } from '@fullcalendar/core'
+import { endOfDay } from 'date-fns'
 import moment from 'moment-timezone'
 import React from 'react'
 import { CALENDAR_VIEWS } from '../utils/constants'
@@ -71,11 +72,11 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
   const handleDayHeaderClick = (arg: DayHeaderContentArg): void => {
     const startOfDay = new Date(arg.date)
     startOfDay.setHours(0, 0, 0, 0)
-    const endOfDay = new Date(arg.date)
-    endOfDay.setHours(23, 59, 59, 999)
+    const endOfClickedDay = endOfDay(new Date(arg.date))
+
     calendarRef.current?.select({
       start: startOfDay,
-      end: endOfDay,
+      end: endOfClickedDay,
       allDay: true
     })
   }

--- a/src/components/Calendar/hooks/useCalendarViewHandlers.ts
+++ b/src/components/Calendar/hooks/useCalendarViewHandlers.ts
@@ -8,6 +8,16 @@ export const useCalendarViewHandlers = (
   const viewHandlers = createViewHandlers(props)
 
   return {
+    handleDayHeaderContent: useCallback(viewHandlers.handleDayHeaderContent, [
+      props.calendarRef,
+      props.timezone,
+      props.isTablet,
+      props.isMobile,
+      props.t,
+      props.setSelectedDate,
+      props.setSelectedMiniDate,
+      props.onViewChange
+    ]),
     handleDayHeaderDidMount: useCallback(viewHandlers.handleDayHeaderDidMount, [
       props.calendarRef,
       props.setSelectedDate,

--- a/src/components/Calendar/hooks/useTouchListener.tsx
+++ b/src/components/Calendar/hooks/useTouchListener.tsx
@@ -1,4 +1,5 @@
 import { DateSelectArg } from '@fullcalendar/core'
+import { endOfDay } from 'date-fns'
 import { RefObject, useEffect } from 'react'
 
 const MOVE_THRESHOLD = 10
@@ -80,10 +81,10 @@ export function useTouchListener(
       const allDayDate = isAllDayTap(touch.clientX, touch.clientY)
       if (allDayDate) {
         const startOfDay = new Date(`${allDayDate}T00:00:00`)
-        const endOfDay = new Date(`${allDayDate}T23:59:59`)
+        const endDate = endOfDay(new Date(allDayDate))
         handleDateSelect({
           start: startOfDay,
-          end: endOfDay,
+          end: endDate,
           allDay: true
         } as DateSelectArg)
       }

--- a/src/components/Calendar/hooks/useTouchListener.tsx
+++ b/src/components/Calendar/hooks/useTouchListener.tsx
@@ -30,6 +30,13 @@ function buildSelectArg(date: string, time: string): DateSelectArg {
   return { start, end, allDay: false } as DateSelectArg
 }
 
+function isAllDayTap(x: number, y: number): string | null {
+  const el = document.elementFromPoint(x, y)
+  if (el?.closest('.fc-event')) return null
+  const dayCell = el?.closest('.fc-daygrid-body td.fc-daygrid-day[data-date]')
+  return dayCell?.getAttribute('data-date') ?? null
+}
+
 export function useTouchListener(
   handleDateSelect: (selectInfo: DateSelectArg | null) => void,
   isTouch: boolean,
@@ -61,6 +68,18 @@ export function useTouchListener(
 
       if (time && date) {
         handleDateSelect(buildSelectArg(date, time))
+        return
+      }
+
+      const allDayDate = isAllDayTap(touch.clientX, touch.clientY)
+      if (allDayDate) {
+        const startOfDay = new Date(`${allDayDate}T00:00:00`)
+        const endOfDay = new Date(`${allDayDate}T23:59:59`)
+        handleDateSelect({
+          start: startOfDay,
+          end: endOfDay,
+          allDay: true
+        } as DateSelectArg)
       }
     }
 

--- a/src/components/Calendar/hooks/useTouchListener.tsx
+++ b/src/components/Calendar/hooks/useTouchListener.tsx
@@ -32,7 +32,13 @@ function buildSelectArg(date: string, time: string): DateSelectArg {
 
 function isAllDayTap(x: number, y: number): string | null {
   const el = document.elementFromPoint(x, y)
-  if (el?.closest('.fc-event')) return null
+  if (
+    el?.closest(
+      '.fc-event, .fc-daygrid-more-link, a, button, [role="button"], [data-navlink]'
+    )
+  ) {
+    return null
+  }
   const dayCell = el?.closest('.fc-daygrid-body td.fc-daygrid-day[data-date]')
   return dayCell?.getAttribute('data-date') ?? null
 }


### PR DESCRIPTION
resolves #753 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Day headers (day numbers) are clickable to open the day view.

* **Improvements**
  * Touch support: tapping a day cell can select an all-day date; timed taps preserve timed selection.
  * Week/day views: adjusted all-day row sizing and day-header styling for consistent heights.
  * Locale-aware weekday labels and improved mobile/tablet header display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->