### PR TITLE
[#821] adjusted size of go to today navigation button

### DIFF
--- a/src/components/Menubar/components/SmallNavigationControls.tsx
+++ b/src/components/Menubar/components/SmallNavigationControls.tsx
@@ -25,11 +25,14 @@ export const SmallNavigationControls: React.FC<{
           title={t('menubar.today')}
           sx={{
             border: '1px solid',
-            borderRadius: '12px'
+            borderRadius: '12px',
+            width: '38px',
+            height: '38px'
           }}
+          size="small"
           onClick={() => onNavigate('today')}
         >
-          <TodayIcon />
+          <TodayIcon fontSize="inherit" />
         </IconButton>
         <IconButton
           onClick={() => onNavigate('next')}


### PR DESCRIPTION
resolves #821 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the "today" navigation button appearance with a standardized 38x38 size. Icon sizing now inherits from the surrounding navigation elements, improving visual consistency throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->