### PR TITLE
ISSUE-860 Normalise WKST

### DIFF
--- a/__test__/features/Events/eventUtils.test.ts
+++ b/__test__/features/Events/eventUtils.test.ts
@@ -1434,9 +1434,19 @@ describe('parseCalendarEvent – RRULE WKST normalization (issue #860)', () => {
   it('stores wkst when given as a weekday string', () => {
     const data: VObjectProperty[] = [
       ...baseProps,
-      ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 1, byday: 'TH', wkst: 'MO' }]
+      [
+        'rrule',
+        {},
+        'recur',
+        { freq: 'WEEKLY', interval: 1, byday: 'TH', wkst: 'MO' }
+      ]
     ]
-    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    const result = parseCalendarEvent(
+      data,
+      baseColor,
+      calendar,
+      '/cal/event.ics'
+    )
     expect(result.repetition?.wkst).toBe('MO')
   })
 
@@ -1444,9 +1454,19 @@ describe('parseCalendarEvent – RRULE WKST normalization (issue #860)', () => {
     // ical.js stores WKST=MO as 2 internally when parsing to jCal
     const data: VObjectProperty[] = [
       ...baseProps,
-      ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 1, byday: 'TH', wkst: 2 }]
+      [
+        'rrule',
+        {},
+        'recur',
+        { freq: 'WEEKLY', interval: 1, byday: 'TH', wkst: 2 }
+      ]
     ]
-    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    const result = parseCalendarEvent(
+      data,
+      baseColor,
+      calendar,
+      '/cal/event.ics'
+    )
     expect(result.repetition?.wkst).toBe('MO')
   })
 
@@ -1463,7 +1483,12 @@ describe('parseCalendarEvent – RRULE WKST normalization (issue #860)', () => {
       ...baseProps,
       ['rrule', {}, 'recur', { freq: 'WEEKLY', wkst: num }]
     ]
-    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    const result = parseCalendarEvent(
+      data,
+      baseColor,
+      calendar,
+      '/cal/event.ics'
+    )
     expect(result.repetition?.wkst).toBe(expected)
   })
 
@@ -1472,7 +1497,12 @@ describe('parseCalendarEvent – RRULE WKST normalization (issue #860)', () => {
       ...baseProps,
       ['rrule', {}, 'recur', { freq: 'WEEKLY', byday: 'MO' }]
     ]
-    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    const result = parseCalendarEvent(
+      data,
+      baseColor,
+      calendar,
+      '/cal/event.ics'
+    )
     expect(result.repetition?.wkst).toBeUndefined()
   })
 })

--- a/__test__/features/Events/eventUtils.test.ts
+++ b/__test__/features/Events/eventUtils.test.ts
@@ -1421,6 +1421,62 @@ describe('detectRecurringEventChanges', () => {
   })
 })
 
+describe('parseCalendarEvent – RRULE WKST normalization (issue #860)', () => {
+  const baseColor = { light: '#00FF00' }
+  const calendar = { id: 'calendar-123' } as Calendar
+  const baseProps: VObjectProperty[] = [
+    ['uid', {}, 'text', 'event-wkst-test'],
+    ['dtstart', {}, 'date-time', '20240101T100000Z'],
+    ['dtend', {}, 'date-time', '20240101T110000Z'],
+    ['summary', {}, 'text', 'Recurring Event']
+  ]
+
+  it('stores wkst when given as a weekday string', () => {
+    const data: VObjectProperty[] = [
+      ...baseProps,
+      ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 1, byday: 'TH', wkst: 'MO' }]
+    ]
+    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    expect(result.repetition?.wkst).toBe('MO')
+  })
+
+  it('converts numeric wkst (ical.js internal format) to weekday string', () => {
+    // ical.js stores WKST=MO as 2 internally when parsing to jCal
+    const data: VObjectProperty[] = [
+      ...baseProps,
+      ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 1, byday: 'TH', wkst: 2 }]
+    ]
+    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    expect(result.repetition?.wkst).toBe('MO')
+  })
+
+  it.each([
+    [1, 'SU'],
+    [2, 'MO'],
+    [3, 'TU'],
+    [4, 'WE'],
+    [5, 'TH'],
+    [6, 'FR'],
+    [7, 'SA']
+  ])('maps numeric wkst %i to weekday string "%s"', (num, expected) => {
+    const data: VObjectProperty[] = [
+      ...baseProps,
+      ['rrule', {}, 'recur', { freq: 'WEEKLY', wkst: num }]
+    ]
+    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    expect(result.repetition?.wkst).toBe(expected)
+  })
+
+  it('omits wkst from repetition when not present in rrule', () => {
+    const data: VObjectProperty[] = [
+      ...baseProps,
+      ['rrule', {}, 'recur', { freq: 'WEEKLY', byday: 'MO' }]
+    ]
+    const result = parseCalendarEvent(data, baseColor, calendar, '/cal/event.ics')
+    expect(result.repetition?.wkst).toBeUndefined()
+  })
+})
+
 describe('parseCalendarEvent - delegated calendar URL handling', () => {
   const baseColor = { light: '#00FF00' }
   const rawData: VObjectProperty[] = [

--- a/__test__/features/Events/updateEventHelpers/makeVevent.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeVevent.test.ts
@@ -388,6 +388,22 @@ describe('RFC 5545 – RRULE (§3.8.5.3)', () => {
     expect(rule.byday).toBeUndefined()
   })
 
+  it('preserves wkst as a weekday string (issue #860)', () => {
+    const event = baseEvent({
+      repetition: { freq: 'WEEKLY', interval: 1, byday: ['TH'], wkst: 'MO' }
+    })
+    const vevent = makeVevent(event, TZID, OWNER)
+    const rule = getProp(vevent, 'rrule')![3] as Record<string, unknown>
+    expect(rule.wkst).toBe('MO')
+  })
+
+  it('omits wkst when absent', () => {
+    const event = baseEvent({ repetition: { freq: 'WEEKLY', byday: ['MO'] } })
+    const vevent = makeVevent(event, TZID, OWNER)
+    const rule = getProp(vevent, 'rrule')![3] as Record<string, unknown>
+    expect(rule.wkst).toBeUndefined()
+  })
+
   it('value type is "recur"', () => {
     const event = baseEvent({ repetition: { freq: 'MONTHLY' } })
     const vevent = makeVevent(event, TZID, OWNER)

--- a/src/features/Calendars/types/CalendarData.ts
+++ b/src/features/Calendars/types/CalendarData.ts
@@ -77,4 +77,5 @@ export interface RepetitionRule {
   count?: number
   until?: string
   byday?: string | string[]
+  wkst?: string | number
 }

--- a/src/features/Events/EventDao.ts
+++ b/src/features/Events/EventDao.ts
@@ -97,7 +97,12 @@ function normalizeVeventRrule(vevents: VCalComponent[]): VCalComponent[] {
         if (typeof rule.wkst === 'number') {
           const dayStr = WKST_NUM_TO_DAY[rule.wkst]
           if (dayStr) {
-            return [prop[0], prop[1], prop[2], { ...rule, wkst: dayStr }] as VObjectProperty
+            return [
+              prop[0],
+              prop[1],
+              prop[2],
+              { ...rule, wkst: dayStr }
+            ] as VObjectProperty
           }
         }
       }

--- a/src/features/Events/EventDao.ts
+++ b/src/features/Events/EventDao.ts
@@ -4,6 +4,7 @@ import { CalDavItem } from '../Calendars/api/types'
 import { VCalComponent, VObjectProperty } from '../Calendars/types/CalendarData'
 import { SearchEventsResponse } from '../Search/types/SearchEventsResponse'
 import { CalendarEvent } from './EventsTypes'
+import { WKST_NUM_TO_DAY } from './utils/wkstUtils'
 
 export async function reportEventRaw(
   event: CalendarEvent,
@@ -75,18 +76,6 @@ export async function searchEventRaw(reqParam: {
       body: JSON.stringify(reqParam)
     })
     .json()
-}
-
-// ical.js encodes WKST as a number (1=SU … 7=SA) when parsing ICS to jCal.
-// jCal consumers (including our CalDAV backend) expect the weekday string (SU, MO, …).
-const WKST_NUM_TO_DAY: Record<number, string> = {
-  1: 'SU',
-  2: 'MO',
-  3: 'TU',
-  4: 'WE',
-  5: 'TH',
-  6: 'FR',
-  7: 'SA'
 }
 
 function normalizeVeventRrule(vevents: VCalComponent[]): VCalComponent[] {

--- a/src/features/Events/EventDao.ts
+++ b/src/features/Events/EventDao.ts
@@ -1,7 +1,7 @@
 import { api } from '@/utils/apiUtils'
 import ICAL from 'ical.js'
 import { CalDavItem } from '../Calendars/api/types'
-import { VCalComponent } from '../Calendars/types/CalendarData'
+import { VCalComponent, VObjectProperty } from '../Calendars/types/CalendarData'
 import { SearchEventsResponse } from '../Search/types/SearchEventsResponse'
 import { CalendarEvent } from './EventsTypes'
 
@@ -77,9 +77,39 @@ export async function searchEventRaw(reqParam: {
     .json()
 }
 
+// ical.js encodes WKST as a number (1=SU … 7=SA) when parsing ICS to jCal.
+// jCal consumers (including our CalDAV backend) expect the weekday string (SU, MO, …).
+const WKST_NUM_TO_DAY: Record<number, string> = {
+  1: 'SU',
+  2: 'MO',
+  3: 'TU',
+  4: 'WE',
+  5: 'TH',
+  6: 'FR',
+  7: 'SA'
+}
+
+function normalizeVeventRrule(vevents: VCalComponent[]): VCalComponent[] {
+  return vevents.map(vevent => {
+    const props = (vevent[1] as VObjectProperty[]).map(prop => {
+      if (prop[0] === 'rrule' && prop[2] === 'recur') {
+        const rule = prop[3] as Record<string, unknown>
+        if (typeof rule.wkst === 'number') {
+          const dayStr = WKST_NUM_TO_DAY[rule.wkst]
+          if (dayStr) {
+            return [prop[0], prop[1], prop[2], { ...rule, wkst: dayStr }] as VObjectProperty
+          }
+        }
+      }
+      return prop
+    })
+    return [vevent[0], props, vevent[2]] as VCalComponent
+  })
+}
+
 /**
  * Fetches all VEVENTs (master + overrides) for a recurring series.
- * Returns the raw jCal VEVENT components — no transformation applied.
+ * Returns the raw jCal VEVENT components with RRULE.wkst normalized to a weekday string.
  */
 export async function fetchAllRecurrentVevents(
   event: CalendarEvent
@@ -87,7 +117,8 @@ export async function fetchAllRecurrentVevents(
   const response = await api.get(`dav${event.URL}`)
   const eventData = await response.text()
   const jcal = ICAL.parse(eventData) as VCalComponent
-  return (jcal[2] ?? []).filter(([name]) => name === 'vevent')
+  const vevents = (jcal[2] ?? []).filter(([name]) => name === 'vevent')
+  return normalizeVeventRrule(vevents)
 }
 
 /**

--- a/src/features/Events/EventsTypes.ts
+++ b/src/features/Events/EventsTypes.ts
@@ -39,6 +39,7 @@ export interface RepetitionObject {
   byday?: string[] | null
   occurrences?: number | null
   endDate?: string | null
+  wkst?: string | null
 }
 
 export interface AlarmObject {

--- a/src/features/Events/utils/makeVevent.ts
+++ b/src/features/Events/utils/makeVevent.ts
@@ -98,6 +98,9 @@ export function makeVevent(
     ) {
       repetitionRule.byday = event.repetition.byday
     }
+    if (event.repetition.wkst) {
+      repetitionRule.wkst = event.repetition.wkst
+    }
     vevent[1].push(['rrule', {}, 'recur', repetitionRule])
   }
 

--- a/src/features/Events/utils/parseCalendarEvent.ts
+++ b/src/features/Events/utils/parseCalendarEvent.ts
@@ -188,7 +188,7 @@ export function parseCalendarEvent(
         if (ruleValue.wkst != null) {
           event.repetition.wkst =
             typeof ruleValue.wkst === 'number'
-              ? WKST_NUM_TO_DAY[ruleValue.wkst] ?? String(ruleValue.wkst)
+              ? (WKST_NUM_TO_DAY[ruleValue.wkst] ?? String(ruleValue.wkst))
               : ruleValue.wkst
         }
         break

--- a/src/features/Events/utils/parseCalendarEvent.ts
+++ b/src/features/Events/utils/parseCalendarEvent.ts
@@ -1,4 +1,15 @@
 import { convertEventDateTimeToISO } from '@/utils/timezone'
+
+// ical.js parses WKST as a number (1=SU, 2=MO, ..., 7=SA). Map it back to the RFC 5545 weekday string.
+const WKST_NUM_TO_DAY: Record<number, string> = {
+  1: 'SU',
+  2: 'MO',
+  3: 'TU',
+  4: 'WE',
+  5: 'TH',
+  6: 'FR',
+  7: 'SA'
+}
 import moment from 'moment-timezone'
 import { Calendar } from '../../Calendars/CalendarTypes'
 import {
@@ -173,6 +184,12 @@ export function parseCalendarEvent(
         }
         if (ruleValue.interval) {
           event.repetition.interval = ruleValue.interval
+        }
+        if (ruleValue.wkst != null) {
+          event.repetition.wkst =
+            typeof ruleValue.wkst === 'number'
+              ? WKST_NUM_TO_DAY[ruleValue.wkst] ?? String(ruleValue.wkst)
+              : ruleValue.wkst
         }
         break
       }

--- a/src/features/Events/utils/parseCalendarEvent.ts
+++ b/src/features/Events/utils/parseCalendarEvent.ts
@@ -1,15 +1,4 @@
 import { convertEventDateTimeToISO } from '@/utils/timezone'
-
-// ical.js parses WKST as a number (1=SU, 2=MO, ..., 7=SA). Map it back to the RFC 5545 weekday string.
-const WKST_NUM_TO_DAY: Record<number, string> = {
-  1: 'SU',
-  2: 'MO',
-  3: 'TU',
-  4: 'WE',
-  5: 'TH',
-  6: 'FR',
-  7: 'SA'
-}
 import moment from 'moment-timezone'
 import { Calendar } from '../../Calendars/CalendarTypes'
 import {
@@ -23,6 +12,7 @@ import { AlarmObject, CalendarEvent } from '../EventsTypes'
 import { buildDelegatedEventURL } from './buildDelegatedEventURL'
 import { formatDateToICal } from './formatDateToICal'
 import { inferTimezoneFromValue } from './inferTimezoneFromValue'
+import { WKST_NUM_TO_DAY } from './wkstUtils'
 
 const KNOWN_PROPS = new Set([
   'uid',

--- a/src/features/Events/utils/wkstUtils.ts
+++ b/src/features/Events/utils/wkstUtils.ts
@@ -1,0 +1,10 @@
+// ical.js parses WKST as a number (1=SU, 2=MO, ..., 7=SA). Map it back to the RFC 5545 weekday string.
+export const WKST_NUM_TO_DAY: Record<number, string> = {
+  1: 'SU',
+  2: 'MO',
+  3: 'TU',
+  4: 'WE',
+  5: 'TH',
+  6: 'FR',
+  7: 'SA'
+}


### PR DESCRIPTION
Disclaimer: full AI

Goal is timely solve this customer reported bug that cripple Oulook compatibility.

Feel free to adapt !

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed week start (WKST) handling in recurring calendar events. Calendar events now properly preserve and normalize week start values during parsing and generation of recurrence rules, ensuring full RFC 5545 compliance (issue #860).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->