### PR TITLE
[#830] completed userDAO and added calendar DAO

### DIFF
--- a/__test__/features/Calendars/CalendarAPI.test.tsx
+++ b/__test__/features/Calendars/CalendarAPI.test.tsx
@@ -200,7 +200,9 @@ describe('Calendar API', () => {
       })
     )
 
-    const callBody = JSON.parse(String(api.mock.calls[0][1]?.body))
+    const callBody = JSON.parse(
+      String((api as unknown as jest.Mock).mock.calls[0][1]?.body)
+    )
     expect(callBody['dav:name']).toBe('#default')
   })
 })

--- a/__test__/features/Calendars/CalendarAPI.test.tsx
+++ b/__test__/features/Calendars/CalendarAPI.test.tsx
@@ -1,15 +1,18 @@
 import {
   addSharedCalendar,
-  exportCalendar,
   getCalendar,
   getCalendars,
-  getSecretLink,
   postCalendar,
-  proppatchCalendar,
-  removeCalendar
+  proppatchCalendar
 } from '@/features/Calendars/CalendarApi'
+import {
+  calendarAction,
+  fetchCalendarExport,
+  fetchSecretLink
+} from '@/features/Calendars/CalendarDAO'
 import { clientConfig } from '@/features/User/oidcAuth'
 import { api } from '@/utils/apiUtils'
+import { waitFor } from '@testing-library/dom'
 clientConfig.url = 'https://example.com'
 
 jest.mock('@/utils/apiUtils')
@@ -68,10 +71,11 @@ describe('Calendar API', () => {
 
     const result = await postCalendar(userId, calId, color, name, desc)
 
-    expect(api.post).toHaveBeenCalledWith(`dav/calendars/${userId}.json`, {
+    expect(api).toHaveBeenCalledWith(`dav/calendars/${userId}.json`, {
       headers: {
         Accept: 'application/json, text/plain, */*'
       },
+      method: 'POST',
       body: JSON.stringify({
         id: 'calId',
         'dav:name': 'new cal',
@@ -104,7 +108,7 @@ describe('Calendar API', () => {
 
   it('remove Calendar', async () => {
     const calLink = '/calendars/calId.json'
-    const result = await removeCalendar(calLink)
+    const result = await calendarAction('DELETE', calLink)
 
     expect(api).toHaveBeenCalledWith(`dav${calLink}`, {
       method: 'DELETE',
@@ -117,10 +121,12 @@ describe('Calendar API', () => {
   it('get secret link without reset', async () => {
     const calLink = '/calendars/calId.json'
     ;(api.get as jest.Mock).mockReturnValue({
-      json: jest.fn().mockResolvedValue('link')
+      json: jest.fn().mockResolvedValue({ secretLink: 'link' })
     })
 
-    const noreset = await getSecretLink(calLink, false)
+    await expect(fetchSecretLink(calLink, false)).resolves.toEqual({
+      secretLink: 'link'
+    })
 
     expect(api.get).toHaveBeenCalledWith(
       `calendar/api${calLink}/secret-link?shouldResetLink=false`,
@@ -136,7 +142,7 @@ describe('Calendar API', () => {
     ;(api.get as jest.Mock).mockReturnValue({
       json: jest.fn().mockResolvedValue('link')
     })
-    const reset = await getSecretLink(calLink, true)
+    const reset = await fetchSecretLink(calLink, true)
 
     expect(api.get).toHaveBeenCalledWith(
       `calendar/api${calLink}/secret-link?shouldResetLink=true`,
@@ -153,7 +159,7 @@ describe('Calendar API', () => {
     ;(api.get as jest.Mock).mockReturnValue({
       text: jest.fn().mockResolvedValue('data')
     })
-    const data = await exportCalendar(calLink)
+    const data = await fetchCalendarExport(calLink)
 
     expect(api.get).toHaveBeenCalledWith(`dav${calLink}?export`, {
       headers: {
@@ -163,8 +169,6 @@ describe('Calendar API', () => {
   })
 
   it('When adding a sharedCal with #default #default is preserved', async () => {
-    const mockApiPost = jest.spyOn(api, 'post')
-
     const calData = {
       cal: {
         id: 'cal123',
@@ -189,14 +193,14 @@ describe('Calendar API', () => {
 
     await addSharedCalendar('currentUserId', 'newCalId123', calData)
 
-    expect(mockApiPost).toHaveBeenCalledWith(
+    expect(api).toHaveBeenCalledWith(
       'dav/calendars/currentUserId.json',
       expect.objectContaining({
         body: expect.stringContaining('"dav:name":"#default"')
       })
     )
 
-    const callBody = JSON.parse(String(mockApiPost.mock.calls[0][1]?.body))
+    const callBody = JSON.parse(String(api.mock.calls[0][1]?.body))
     expect(callBody['dav:name']).toBe('#default')
   })
 })

--- a/__test__/features/Calendars/CalendarAccessRights.test.tsx
+++ b/__test__/features/Calendars/CalendarAccessRights.test.tsx
@@ -8,7 +8,7 @@ import { updateDelegationCalendar } from '@/features/Calendars/api/updateDelegat
 import { AccessRight, Calendar } from '@/features/Calendars/CalendarTypes'
 import * as eventThunks from '@/features/Calendars/services'
 import * as delegationThunks from '@/features/Calendars/services/updateDelegationCalendarAsync'
-import { getUserDetails } from '@/features/User/userAPI'
+import { fetchUserById } from '@/features/User/UserDao'
 import { accessRightToDavProp } from '@/utils/accessRightToDavProp'
 import { api } from '@/utils/apiUtils'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
@@ -18,13 +18,13 @@ jest.mock('@/utils/apiUtils', () => ({
   api: { post: jest.fn() }
 }))
 
-jest.mock('@/features/User/userAPI', () => ({
-  getUserDetails: jest.fn()
+jest.mock('@/features/User/UserDao', () => ({
+  fetchUserById: jest.fn()
 }))
 
-jest.mock('@/features/Calendars/CalendarApi', () => ({
-  getSecretLink: jest.fn().mockReturnValue(''),
-  exportCalendar: jest.fn()
+jest.mock('@/features/Calendars/CalendarDAO', () => ({
+  fetchSecretLink: jest.fn().mockResolvedValue({ secretLink: '' }),
+  fetchCalendarExport: jest.fn()
 }))
 
 const mockThunkWithUnwrap = (resolvedValue: unknown = {}) =>
@@ -173,7 +173,7 @@ describe('CalendarAccessRights', () => {
       ]
     }
 
-    ;(getUserDetails as jest.Mock).mockResolvedValue({
+    ;(fetchUserById as jest.Mock).mockResolvedValue({
       preferredEmail: 'bob@example.com',
       firstname: 'Bob',
       lastname: 'Smith',
@@ -190,7 +190,7 @@ describe('CalendarAccessRights', () => {
       { ...userState }
     )
 
-    await waitFor(() => expect(getUserDetails).toHaveBeenCalledWith('bob123'))
+    await waitFor(() => expect(fetchUserById).toHaveBeenCalledWith('bob123'))
     await waitFor(() =>
       expect(mockOnInvitesLoaded).toHaveBeenCalledWith(
         expect.arrayContaining([
@@ -203,7 +203,7 @@ describe('CalendarAccessRights', () => {
     )
   })
 
-  it('skips invite entries where getUserDetails throws', async () => {
+  it('skips invite entries where fetchUserById throws', async () => {
     const calendarWithInvite: Calendar = {
       ...baseCalendar,
       invite: [
@@ -216,7 +216,7 @@ describe('CalendarAccessRights', () => {
       ]
     }
 
-    ;(getUserDetails as jest.Mock).mockRejectedValue(new Error('Not found'))
+    ;(fetchUserById as jest.Mock).mockRejectedValue(new Error('Not found'))
 
     renderWithProviders(
       <CalendarAccessRights
@@ -245,7 +245,7 @@ describe('CalendarAccessRights', () => {
     }
 
     // Never resolves during the assertion window
-    ;(getUserDetails as jest.Mock).mockImplementation(
+    ;(fetchUserById as jest.Mock).mockImplementation(
       () => new Promise(() => {})
     )
 
@@ -292,7 +292,7 @@ describe('CalendarAccessRights', () => {
       }
     }
 
-    ;(getUserDetails as jest.Mock).mockImplementation((id: string) => {
+    ;(fetchUserById as jest.Mock).mockImplementation((id: string) => {
       if (id === 'admin1') {
         return Promise.resolve({
           preferredEmail: 'admin1@example.com',
@@ -321,11 +321,11 @@ describe('CalendarAccessRights', () => {
     )
 
     await waitFor(() => {
-      expect(getUserDetails).toHaveBeenCalledWith('admin1')
-      expect(getUserDetails).toHaveBeenCalledWith('admin2')
+      expect(fetchUserById).toHaveBeenCalledWith('admin1')
+      expect(fetchUserById).toHaveBeenCalledWith('admin2')
     })
 
-    expect(getUserDetails).not.toHaveBeenCalledWith('resource1')
+    expect(fetchUserById).not.toHaveBeenCalledWith('resource1')
 
     expect(await screen.findByText('Admin One')).toBeInTheDocument()
     expect(screen.getByText('admin1@example.com')).toBeInTheDocument()

--- a/__test__/features/Calendars/CalendarModal.test.tsx
+++ b/__test__/features/Calendars/CalendarModal.test.tsx
@@ -1,13 +1,13 @@
 import CalendarPopover from '@/components/Calendar/CalendarModal'
-import { getSecretLink } from '@/features/Calendars/CalendarApi'
+import { fetchSecretLink } from '@/features/Calendars/CalendarDAO'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import * as eventThunks from '@/features/Calendars/services'
 import * as delegationThunks from '@/features/Calendars/services/updateDelegationCalendarAsync'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../../utils/Renderwithproviders'
 
-jest.mock('@/features/Calendars/CalendarApi', () => ({
-  getSecretLink: jest.fn()
+jest.mock('@/features/Calendars/CalendarDAO', () => ({
+  fetchSecretLink: jest.fn()
 }))
 
 const mockThunkWithUnwrap = (resolvedValue: unknown = {}) =>
@@ -331,7 +331,7 @@ describe('CalendarPopover - Tabs Scenarios', () => {
     Object.assign(navigator, {
       clipboard: { writeText: jest.fn() }
     })
-    ;(getSecretLink as jest.Mock).mockResolvedValue({
+    ;(fetchSecretLink as jest.Mock).mockResolvedValue({
       secretLink: 'https://example.org/secret/initial'
     })
 
@@ -460,7 +460,7 @@ describe('CalendarPopover - Tabs Scenarios', () => {
 
   it('fetches and resets the secret link', async () => {
     window.DAV_BASE_URL = 'https://cal.example.org'
-    ;(getSecretLink as jest.Mock)
+    ;(fetchSecretLink as jest.Mock)
       .mockResolvedValueOnce({
         secretLink: 'https://example.org/secret/initial'
       })
@@ -493,7 +493,7 @@ describe('CalendarPopover - Tabs Scenarios', () => {
       ).toBeInTheDocument()
     )
 
-    expect(getSecretLink).toHaveBeenCalledWith(
+    expect(fetchSecretLink).toHaveBeenCalledWith(
       existingCalendar.link.replace('.json', ''),
       true
     )

--- a/__test__/features/Calendars/services/getCalendarsListAsync.test.tsx
+++ b/__test__/features/Calendars/services/getCalendarsListAsync.test.tsx
@@ -1,11 +1,11 @@
-import { getCalendarsListAsync } from '@/features/Calendars/services/getCalendarsListAsync'
-import { getOpenPaasUser } from '@/features/User/userAPI'
-import { fetchOwnerData } from '@/features/Calendars/services/helpers'
 import { getCalendars } from '@/features/Calendars/CalendarApi'
-import { formatReduxError } from '@/utils/errorUtils'
+import { getCalendarsListAsync } from '@/features/Calendars/services/getCalendarsListAsync'
+import { fetchOwnerData } from '@/features/Calendars/services/helpers'
 import { normalizeCalendar } from '@/features/Calendars/utils/normalizeCalendar'
+import { fetchCurrentUser } from '@/features/User/UserDao'
+import { formatReduxError } from '@/utils/errorUtils'
 
-jest.mock('@/features/User/userAPI')
+jest.mock('@/features/User/UserDao')
 jest.mock('@/features/Calendars/services/helpers')
 jest.mock('@/features/Calendars/CalendarApi')
 jest.mock('@/utils/errorUtils')
@@ -18,7 +18,7 @@ jest.mock('@mui/material/styles', () => ({
   createTheme: jest.fn().mockReturnValue({})
 }))
 
-const mockedGetOpenPaasUser = getOpenPaasUser as jest.Mock
+const mockedFetchCurrentUser = fetchCurrentUser as jest.Mock
 const mockedFetchOwnerData = fetchOwnerData as jest.Mock
 const mockedGetCalendars = getCalendars as jest.Mock
 const mockedFormatReduxError = formatReduxError as jest.Mock
@@ -122,25 +122,25 @@ describe('getCalendarsListAsync', () => {
       owner: { firstname: 'Jane', lastname: 'Smith' }
     })
 
-    expect(mockedGetOpenPaasUser).not.toHaveBeenCalled() // User ID existed in state
+    expect(mockedFetchCurrentUser).not.toHaveBeenCalled() // User ID existed in state
     expect(mockedGetCalendars).toHaveBeenCalledWith('user-123')
   })
 
   it('should fetch user using getOpenPaasUser if openpaasId is not in state', async () => {
     getState.mockReturnValue({ calendars: {}, user: {} })
-    mockedGetOpenPaasUser.mockResolvedValue({ id: 'fetched-user-123' })
+    mockedFetchCurrentUser.mockResolvedValue({ id: 'fetched-user-123' })
     mockedGetCalendars.mockResolvedValue({ _embedded: { 'dav:calendar': [] } })
 
     const thunk = getCalendarsListAsync()
     await thunk(dispatch, getState, undefined)
 
-    expect(mockedGetOpenPaasUser).toHaveBeenCalled()
+    expect(mockedFetchCurrentUser).toHaveBeenCalled()
     expect(mockedGetCalendars).toHaveBeenCalledWith('fetched-user-123')
   })
 
   it('should handle error when API call fails', async () => {
     getState.mockReturnValue({ calendars: {}, user: {} })
-    mockedGetOpenPaasUser.mockResolvedValue({ id: 'fetched-user-123' })
+    mockedFetchCurrentUser.mockResolvedValue({ id: 'fetched-user-123' })
 
     mockedGetCalendars.mockRejectedValue({
       response: { status: 500 },

--- a/__test__/features/Calendars/services/getCalendarsListAsync.test.tsx
+++ b/__test__/features/Calendars/services/getCalendarsListAsync.test.tsx
@@ -126,7 +126,7 @@ describe('getCalendarsListAsync', () => {
     expect(mockedGetCalendars).toHaveBeenCalledWith('user-123')
   })
 
-  it('should fetch user using getOpenPaasUser if openpaasId is not in state', async () => {
+  it('should fetch user if openpaasId is not in state', async () => {
     getState.mockReturnValue({ calendars: {}, user: {} })
     mockedFetchCurrentUser.mockResolvedValue({ id: 'fetched-user-123' })
     mockedGetCalendars.mockResolvedValue({ _embedded: { 'dav:calendar': [] } })

--- a/__test__/features/Calendars/services/helpers.test.tsx
+++ b/__test__/features/Calendars/services/helpers.test.tsx
@@ -1,10 +1,16 @@
 import { fetchOwnerData } from '@/features/Calendars/services/helpers'
-import { getResourceDetails, getUserDetails } from '@/features/User/userAPI'
+import { fetchUserById } from '@/features/User/UserDao'
+import { fetchResourceById } from '@/features/User/ResourceDAO'
 
-jest.mock('@/features/User/userAPI')
+jest.mock('@/features/User/UserDao')
+jest.mock('@/features/User/ResourceDAO')
 
-const mockedGetUserDetails = getUserDetails as jest.Mock
-const mockedGetResourceDetails = getResourceDetails as jest.Mock
+const mockedFetchUserById = fetchUserById as jest.MockedFunction<
+  typeof fetchUserById
+>
+const mockedFetchResourceById = fetchResourceById as jest.MockedFunction<
+  typeof fetchResourceById
+>
 
 describe('helpers', () => {
   beforeEach(() => {
@@ -17,40 +23,33 @@ describe('helpers', () => {
         firstname: 'John',
         lastname: 'Doe',
         emails: ['john@example.com']
-      }
-      mockedGetUserDetails.mockResolvedValueOnce(mockUser)
+      } as any
+      mockedFetchUserById.mockResolvedValueOnce(mockUser)
 
       const result = await fetchOwnerData('user-123')
 
-      expect(mockedGetUserDetails).toHaveBeenCalledWith('user-123')
-      expect(mockedGetResourceDetails).not.toHaveBeenCalled()
+      expect(fetchUserById).toHaveBeenCalledWith('user-123')
+      expect(fetchResourceById).not.toHaveBeenCalled()
       expect(result).toEqual(mockUser)
     })
 
     it('should fetch resource details and its creator when user is not found', async () => {
-      const mockResource = { creator: 'creator-456' }
+      const mockResource = { creator: 'creator-456' } as any
       const mockCreator = {
         firstname: 'Creator',
         lastname: 'User',
         emails: ['creator@example.com']
-      }
+      } as any
 
-      // Mock getUserDetails to fail with 404 for the initial call
-      mockedGetUserDetails.mockRejectedValueOnce({
-        response: { status: 404 }
-      })
-
-      // Mock getResourceDetails to succeed and return a creator ID
-      mockedGetResourceDetails.mockResolvedValueOnce(mockResource)
-
-      // Mock getUserDetails to succeed when called for the creator
-      mockedGetUserDetails.mockResolvedValueOnce(mockCreator)
+      mockedFetchUserById.mockRejectedValueOnce({ response: { status: 404 } })
+      mockedFetchResourceById.mockResolvedValueOnce(mockResource)
+      mockedFetchUserById.mockResolvedValueOnce(mockCreator)
 
       const result = await fetchOwnerData('resource-123')
 
-      expect(mockedGetUserDetails).toHaveBeenNthCalledWith(1, 'resource-123')
-      expect(mockedGetResourceDetails).toHaveBeenCalledWith('resource-123')
-      expect(mockedGetUserDetails).toHaveBeenNthCalledWith(2, 'creator-456')
+      expect(fetchUserById).toHaveBeenNthCalledWith(1, 'resource-123')
+      expect(fetchResourceById).toHaveBeenCalledWith('resource-123')
+      expect(fetchUserById).toHaveBeenNthCalledWith(2, 'creator-456')
       expect(result).toEqual({
         ...mockCreator,
         resource: true,
@@ -59,32 +58,26 @@ describe('helpers', () => {
       })
     })
 
-    it('should throw error when getUserDetails fails with non-404 error', async () => {
+    it('should throw error when fetchUserById fails with non-404 error', async () => {
       const mockError = { response: { status: 500 } }
-      mockedGetUserDetails.mockRejectedValueOnce(mockError)
+      mockedFetchUserById.mockRejectedValueOnce(mockError)
 
       await expect(fetchOwnerData('user-123')).rejects.toEqual(mockError)
 
-      expect(mockedGetUserDetails).toHaveBeenCalledWith('user-123')
-      expect(mockedGetResourceDetails).not.toHaveBeenCalled()
+      expect(fetchUserById).toHaveBeenCalledWith('user-123')
+      expect(fetchResourceById).not.toHaveBeenCalled()
     })
 
-    it('should throw error when getResourceDetails fails', async () => {
+    it('should throw error when fetchResourceById fails', async () => {
       const mockError = new Error('Resource not found')
-
-      // Mock getUserDetails to fail with 404 for the initial call
-      mockedGetUserDetails.mockRejectedValueOnce({
-        response: { status: 404 }
-      })
-
-      // Mock getResourceDetails to fail
-      mockedGetResourceDetails.mockRejectedValueOnce(mockError)
+      mockedFetchUserById.mockRejectedValueOnce({ response: { status: 404 } })
+      mockedFetchResourceById.mockRejectedValueOnce(mockError)
 
       await expect(fetchOwnerData('resource-123')).rejects.toEqual(mockError)
 
-      expect(mockedGetUserDetails).toHaveBeenCalledWith('resource-123')
-      expect(mockedGetResourceDetails).toHaveBeenCalledWith('resource-123')
-      expect(mockedGetUserDetails).toHaveBeenCalledTimes(1) // Only called once
+      expect(fetchUserById).toHaveBeenCalledWith('resource-123')
+      expect(fetchResourceById).toHaveBeenCalledWith('resource-123')
+      expect(fetchUserById).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/__test__/features/user/userAPI.test.tsx
+++ b/__test__/features/user/userAPI.test.tsx
@@ -1,27 +1,45 @@
 import { clientConfig } from '@/features/User/oidcAuth'
+import { fetchResourceById } from '@/features/User/ResourceDAO'
 import {
   getOpenPaasUser,
-  updateUserConfigurations,
-  getResourceDetails,
-  getUserDetails
+  getUserDetails,
+  updateUserConfigurations
 } from '@/features/User/userAPI'
+import {
+  fetchCurrentUser,
+  fetchUserById,
+  patchConfigurations
+} from '@/features/User/UserDao'
 import { api } from '@/utils/apiUtils'
 
+jest.mock('@/features/User/UserDao')
 jest.mock('@/utils/apiUtils')
 
 clientConfig.url = 'https://example.com'
 
+const mockFetchCurrentUser = fetchCurrentUser as jest.MockedFunction<
+  typeof fetchCurrentUser
+>
+const mockFetchUserById = fetchUserById as jest.MockedFunction<
+  typeof fetchUserById
+>
+const mockFetchResourceById = api.get as jest.MockedFunction<typeof api.get>
+const mockPatchConfigurations = patchConfigurations as jest.MockedFunction<
+  typeof patchConfigurations
+>
+
 describe('getOpenPaasUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('should fetch and return user data', async () => {
     const mockUser = { id: '123', name: 'OpenPaas User' }
-
-    ;(api.get as jest.Mock).mockReturnValue({
-      json: jest.fn().mockResolvedValue(mockUser)
-    })
+    mockFetchCurrentUser.mockResolvedValue(mockUser)
 
     const result = await getOpenPaasUser()
 
-    expect(api.get).toHaveBeenCalledWith('api/user')
+    expect(fetchCurrentUser).toHaveBeenCalledTimes(1)
     expect(result).toEqual(mockUser)
   })
 })
@@ -32,32 +50,31 @@ describe('getUserDetails', () => {
       firstname: 'John',
       lastname: 'Doe',
       emails: ['john@test.com']
-    }
+    } as any
     const userId = '123'
-
-    ;(api.get as jest.Mock).mockReturnValue({
-      json: jest.fn().mockResolvedValue(mockUser)
-    })
+    mockFetchUserById.mockResolvedValue(mockUser)
 
     const result = await getUserDetails(userId)
 
-    expect(api.get).toHaveBeenCalledWith(`api/users/${userId}`)
+    expect(fetchUserById).toHaveBeenCalledWith(userId)
     expect(result).toEqual(mockUser)
   })
 })
 
 describe('getResourceDetails', () => {
   it('should fetch and return resource details', async () => {
-    const mockResource = { _id: 'res-123', name: 'Meeting Room A' }
+    const mockResource = { _id: 'res-123', name: 'Meeting Room A' } as any
     const resourceId = 'res-123'
 
-    ;(api.get as jest.Mock).mockReturnValue({
-      json: jest.fn().mockResolvedValue(mockResource)
+    mockFetchResourceById.mockReturnValue({
+      json: () => Promise.resolve(mockResource)
     })
 
-    const result = await getResourceDetails(resourceId)
+    const result = await fetchResourceById(resourceId)
 
-    expect(api.get).toHaveBeenCalledWith(`api/resources/${resourceId}`)
+    expect(mockFetchResourceById).toHaveBeenCalledWith(
+      `api/resources/${resourceId}`
+    )
     expect(result).toEqual(mockResource)
   })
 })
@@ -67,48 +84,42 @@ describe('updateUserConfigurations', () => {
     jest.clearAllMocks()
   })
 
-  it('should PATCH configurations with language update', async () => {
-    const mockResponse = { status: 204 }
-    ;(api.patch as jest.Mock).mockResolvedValue(mockResponse)
+  it('should call patchConfigurations with language update', async () => {
+    mockPatchConfigurations.mockResolvedValue({ status: 204 } as any)
 
     await updateUserConfigurations({ language: 'vi' })
 
-    expect(api.patch).toHaveBeenCalledWith('api/configurations?scope=user', {
-      json: [
-        {
-          name: 'core',
-          configurations: [{ name: 'language', value: 'vi' }]
-        }
-      ]
-    })
+    expect(patchConfigurations).toHaveBeenCalledWith([
+      {
+        name: 'core',
+        configurations: [{ name: 'language', value: 'vi' }]
+      }
+    ])
   })
 
-  it('should PATCH configurations with multiple updates', async () => {
-    const mockResponse = { status: 204 }
-    ;(api.patch as jest.Mock).mockResolvedValue(mockResponse)
+  it('should call patchConfigurations with multiple updates', async () => {
+    mockPatchConfigurations.mockResolvedValue({ status: 204 } as any)
 
     await updateUserConfigurations({
       language: 'fr',
       timezone: 'Europe/Paris'
     })
 
-    expect(api.patch).toHaveBeenCalledWith('api/configurations?scope=user', {
-      json: [
-        {
-          name: 'core',
-          configurations: [
-            { name: 'language', value: 'fr' },
-            { name: 'datetime', value: { timeZone: 'Europe/Paris' } }
-          ]
-        }
-      ]
-    })
+    expect(patchConfigurations).toHaveBeenCalledWith([
+      {
+        name: 'core',
+        configurations: [
+          { name: 'language', value: 'fr' },
+          { name: 'datetime', value: { timeZone: 'Europe/Paris' } }
+        ]
+      }
+    ])
   })
 
-  it('should handle empty updates without calling API', async () => {
+  it('should handle empty updates without calling patchConfigurations', async () => {
     const result = await updateUserConfigurations({})
 
-    expect(api.patch).not.toHaveBeenCalled()
-    expect(result).toEqual({ status: 204 })
+    expect(patchConfigurations).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 204 }) // comes from an early return
   })
 })

--- a/__test__/features/user/userAPI.test.tsx
+++ b/__test__/features/user/userAPI.test.tsx
@@ -23,7 +23,7 @@ const mockFetchCurrentUser = fetchCurrentUser as jest.MockedFunction<
 const mockFetchUserById = fetchUserById as jest.MockedFunction<
   typeof fetchUserById
 >
-const mockFetchResourceById = api.get as jest.MockedFunction<typeof api.get>
+const mockedApiGet = api.get as jest.MockedFunction<typeof api.get>
 const mockPatchConfigurations = patchConfigurations as jest.MockedFunction<
   typeof patchConfigurations
 >
@@ -66,15 +66,13 @@ describe('getResourceDetails', () => {
     const mockResource = { _id: 'res-123', name: 'Meeting Room A' } as any
     const resourceId = 'res-123'
 
-    mockFetchResourceById.mockReturnValue({
+    mockedApiGet.mockReturnValue({
       json: () => Promise.resolve(mockResource)
     })
 
     const result = await fetchResourceById(resourceId)
 
-    expect(mockFetchResourceById).toHaveBeenCalledWith(
-      `api/resources/${resourceId}`
-    )
+    expect(mockedApiGet).toHaveBeenCalledWith(`api/resources/${resourceId}`)
     expect(result).toEqual(mockResource)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "prettier": "^3.6.2",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.4.0",
         "typescript-eslint": "^8.54.0"
       },
       "engines": {
@@ -14330,9 +14330,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14340,7 +14340,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
-    "typescript": "^4.9.5",
+    "typescript": "^5.4.0",
     "typescript-eslint": "^8.54.0"
   },
   "overrides": {

--- a/src/components/Calendar/AccessTab.tsx
+++ b/src/components/Calendar/AccessTab.tsx
@@ -46,13 +46,21 @@ export function AccessTab({
   const [secretLink, setSecretLink] = useState('')
   const [open, setOpen] = useState(false)
 
+  const [exportLoading, setExportLoading] = useState(false)
+  const [exportError, setExportError] = useState('')
+
   useEffect(() => {
     async function fetchSecret() {
-      const existing = await fetchSecretLink(
-        calendar.link.replace('.json', ''),
-        false
-      )
-      setSecretLink(existing.secretLink)
+      try {
+        const existing = await fetchSecretLink(
+          calendar.link.replace('.json', ''),
+          false
+        )
+        setSecretLink(existing.secretLink)
+      } catch (e) {
+        console.error(e)
+        setExportError((e as Error).message)
+      }
     }
     fetchSecret()
   }, [calendar.link])
@@ -63,15 +71,17 @@ export function AccessTab({
   }
 
   const handleResetSecretLink = async () => {
-    const newSecret = await fetchSecretLink(
-      calendar.link.replace('.json', ''),
-      true
-    )
-    setSecretLink(newSecret.secretLink)
+    try {
+      const newSecret = await fetchSecretLink(
+        calendar.link.replace('.json', ''),
+        true
+      )
+      setSecretLink(newSecret.secretLink)
+    } catch (e) {
+      console.error(e)
+      setExportError((e as Error).message)
+    }
   }
-
-  const [exportLoading, setExportLoading] = useState(false)
-  const [exportError, setExportError] = useState('')
 
   const handleExport = async () => {
     try {

--- a/src/components/Calendar/AccessTab.tsx
+++ b/src/components/Calendar/AccessTab.tsx
@@ -1,4 +1,7 @@
-import { exportCalendar, getSecretLink } from '@/features/Calendars/CalendarApi'
+import {
+  fetchCalendarExport,
+  fetchSecretLink
+} from '@/features/Calendars/CalendarDAO'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import {
   Box,
@@ -45,7 +48,7 @@ export function AccessTab({
 
   useEffect(() => {
     async function fetchSecret() {
-      const existing = await getSecretLink(
+      const existing = await fetchSecretLink(
         calendar.link.replace('.json', ''),
         false
       )
@@ -60,7 +63,7 @@ export function AccessTab({
   }
 
   const handleResetSecretLink = async () => {
-    const newSecret = await getSecretLink(
+    const newSecret = await fetchSecretLink(
       calendar.link.replace('.json', ''),
       true
     )
@@ -73,7 +76,7 @@ export function AccessTab({
   const handleExport = async () => {
     try {
       setExportLoading(true)
-      const exportedData = await exportCalendar(
+      const exportedData = await fetchCalendarExport(
         calendar.link.replace('.json', '')
       )
       const blob = new Blob([exportedData], { type: 'text/calendar' })

--- a/src/components/Calendar/CalendarSelection.tsx
+++ b/src/components/Calendar/CalendarSelection.tsx
@@ -1,9 +1,12 @@
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
+import { addCalendarResourceAsync } from '@/features/Calendars/api/addCalendarResourceAsync'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import {
   addSharedCalendarAsync,
   removeCalendarAsync
 } from '@/features/Calendars/services'
+import { CalendarInput } from '@/features/Calendars/types/CalendarData'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
 import { makeDisplayName } from '@/utils/makeDisplayName'
 import { renameDefault } from '@/utils/renameDefault'
@@ -19,16 +22,13 @@ import {
 import AddIcon from '@mui/icons-material/Add'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz'
-import { SetStateAction, useEffect, useMemo, useState, useRef } from 'react'
+import { SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import { useI18n } from 'twake-i18n'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 import CalendarPopover from './CalendarModal'
-import RegisterCalendars from './RegisterCalendars'
+import { CalendarSelectorMenu } from './CalendarSelectorMenu'
 import { DeleteCalendarDialog } from './DeleteCalendarDialog'
 import { OwnerCaption } from './OwnerCaption'
-import { CalendarSelectorMenu } from './CalendarSelectorMenu'
-import { CalendarInput } from '@/features/Calendars/types/CalendarData'
-import { addCalendarResourceAsync } from '@/features/Calendars/api/addCalendarResourceAsync'
+import RegisterCalendars from './RegisterCalendars'
 import type { ResourceCal } from './RegisterCalendars/index.types'
 
 const CalendarAccordion: React.FC<{

--- a/src/features/Calendars/CalendarApi.ts
+++ b/src/features/Calendars/CalendarApi.ts
@@ -1,39 +1,20 @@
-import { api } from '@/utils/apiUtils'
+import { calendarAction, fetchCalendar, fetchCalendars } from './CalendarDAO'
 import { CalendarInput, CalendarList } from './types/CalendarData'
 
 export async function getCalendars(
   userId: string,
-  scope: string = 'personal=true&sharedDelegationStatus=accepted&sharedPublicSubscription=true&withRights=true',
+  scope?: string,
   signal?: AbortSignal
 ): Promise<CalendarList> {
-  const calendars = await api
-    .get(`dav/calendars/${userId}.json?${scope}`, {
-      headers: {
-        Accept: 'application/calendar+json'
-      },
-      signal
-    })
-    .json()
-  return calendars as CalendarList
+  return fetchCalendars(userId, scope, signal)
 }
 
 export async function getCalendar(
   id: string,
   match: { start: string; end: string },
   signal?: AbortSignal
-) {
-  const response = await api(`dav/calendars/${id}.json`, {
-    method: 'REPORT',
-    headers: {
-      Accept: 'application/json, text/plain, */*'
-    },
-    body: JSON.stringify({
-      match
-    }),
-    signal
-  })
-  const calendar = await response.json()
-  return calendar
+): Promise<unknown> {
+  return fetchCalendar(id, match, signal)
 }
 
 export async function postCalendar(
@@ -42,105 +23,49 @@ export async function postCalendar(
   color: Record<string, string>,
   name: string,
   desc: string
-) {
-  const response = await api.post(`dav/calendars/${userId}.json`, {
-    headers: {
-      Accept: 'application/json, text/plain, */*'
-    },
-    body: JSON.stringify({
-      id: calId,
-      'dav:name': name,
-      'apple:color': color.light,
-      'caldav:description': desc
-    })
+): Promise<Response> {
+  const body = JSON.stringify({
+    id: calId,
+    'dav:name': name,
+    'apple:color': color.light,
+    'caldav:description': desc
   })
-  return response
+
+  return calendarAction('POST', `/calendars/${userId}.json`, body)
 }
 
 export async function addSharedCalendar(
   userId: string,
   calId: string,
   cal: CalendarInput
-) {
-  const response = await api.post(`dav/calendars/${userId}.json`, {
-    headers: {
-      Accept: 'application/json, text/plain, */*'
-    },
-    body: JSON.stringify({
-      id: calId,
-      ...cal.cal,
-      'calendarserver:source': {
-        acl: cal.cal.acl,
-        calendarHomeId: cal.cal.id,
-        color: cal.cal['apple:color'],
-        description: cal.cal['caldav:description'],
-        href: cal.cal._links.self.href,
-        id: cal.cal.id,
-        invite: cal.cal.invite,
-        name: cal.cal['dav:name']
-      }
-    })
+): Promise<Response> {
+  const body = JSON.stringify({
+    id: calId,
+    ...cal.cal,
+    'calendarserver:source': {
+      acl: cal.cal.acl,
+      calendarHomeId: cal.cal.id,
+      color: cal.cal['apple:color'],
+      description: cal.cal['caldav:description'],
+      href: cal.cal._links.self?.href,
+      id: cal.cal.id,
+      invite: cal.cal.invite,
+      name: cal.cal['dav:name']
+    }
   })
-  return response
+
+  return calendarAction('POST', `/calendars/${userId}.json`, body)
 }
 
 export async function proppatchCalendar(
   calLink: string,
   patch: { name: string; desc: string; color: Record<string, string> }
-) {
-  const response = await api(`dav${calLink}`, {
-    method: 'PROPPATCH',
-    headers: {
-      Accept: 'application/json, text/plain, */*'
-    },
-    body: JSON.stringify({
-      'dav:name': patch.name,
-      'caldav:description': patch.desc,
-      'apple:color': patch.color.light
-    })
+): Promise<Response> {
+  const body = JSON.stringify({
+    'dav:name': patch.name,
+    'caldav:description': patch.desc,
+    'apple:color': patch.color.light
   })
-  return response
-}
 
-export async function removeCalendar(calLink: string) {
-  const response = await api(`dav${calLink}`, {
-    method: 'DELETE',
-    headers: {
-      Accept: 'application/json, text/plain, */*'
-    }
-  })
-  return response
-}
-
-export async function updateAclCalendar(calLink: string, request: string) {
-  const response = await api(`dav${calLink}`, {
-    method: 'ACL',
-    headers: {
-      Accept: 'application/json'
-    },
-    body: JSON.stringify({ public_right: request })
-  })
-  return response
-}
-
-export async function getSecretLink(calLink: string, reset: boolean) {
-  const response = await api
-    .get(`calendar/api${calLink}/secret-link?shouldResetLink=${reset}`, {
-      headers: {
-        Accept: 'application/json, text/plain, */*'
-      }
-    })
-    .json()
-  return response as { secretLink: string }
-}
-
-export async function exportCalendar(calLink: string) {
-  const response = await api
-    .get(`dav${calLink}?export`, {
-      headers: {
-        Accept: 'application/calendar'
-      }
-    })
-    .text()
-  return response
+  return calendarAction('PROPPATCH', calLink, body)
 }

--- a/src/features/Calendars/CalendarApi.ts
+++ b/src/features/Calendars/CalendarApi.ts
@@ -47,7 +47,7 @@ export async function addSharedCalendar(
       calendarHomeId: cal.cal.id,
       color: cal.cal['apple:color'],
       description: cal.cal['caldav:description'],
-      href: cal.cal._links.self?.href,
+      href: cal.cal?._links?.self?.href,
       id: cal.cal.id,
       invite: cal.cal.invite,
       name: cal.cal['dav:name']

--- a/src/features/Calendars/CalendarDAO.ts
+++ b/src/features/Calendars/CalendarDAO.ts
@@ -1,0 +1,75 @@
+import { api } from '@/utils/apiUtils'
+import { CalendarList } from './types/CalendarData'
+
+export async function fetchCalendars(
+  userId: string,
+  scope: string = 'personal=true&sharedDelegationStatus=accepted&sharedPublicSubscription=true&withRights=true',
+  signal?: AbortSignal
+): Promise<CalendarList> {
+  const calendars = await api
+    .get(`dav/calendars/${userId}.json?${scope}`, {
+      headers: { Accept: 'application/calendar+json' },
+      signal
+    })
+    .json()
+  return calendars as CalendarList
+}
+
+export async function fetchCalendar(
+  id: string,
+  match: { start: string; end: string },
+  signal?: AbortSignal
+): Promise<unknown> {
+  const response = await api(`dav/calendars/${id}.json`, {
+    method: 'REPORT',
+    headers: { Accept: 'application/json, text/plain, */*' },
+    body: JSON.stringify({ match }),
+    signal
+  })
+  return response.json()
+}
+
+export type CalendarPostBody = string
+
+export async function calendarAction(
+  method: 'POST' | 'PROPPATCH' | 'DELETE',
+  path: string,
+  body?: CalendarPostBody
+): Promise<Response> {
+  return api(`dav${path}`, {
+    method,
+    headers: { Accept: 'application/json, text/plain, */*' },
+    body
+  })
+}
+
+export async function updateCalendarAcl(
+  calLink: string,
+  request: string
+): Promise<Response> {
+  return api(`dav${calLink}`, {
+    method: 'ACL',
+    headers: { Accept: 'application/json' },
+    body: JSON.stringify({ public_right: request })
+  })
+}
+
+export async function fetchSecretLink(
+  calLink: string,
+  reset: boolean
+): Promise<{ secretLink: string }> {
+  const response = await api
+    .get(`calendar/api${calLink}/secret-link?shouldResetLink=${reset}`, {
+      headers: { Accept: 'application/json, text/plain, */*' }
+    })
+    .json()
+  return response as { secretLink: string }
+}
+
+export async function fetchCalendarExport(calLink: string): Promise<string> {
+  return api
+    .get(`dav${calLink}?export`, {
+      headers: { Accept: 'application/calendar' }
+    })
+    .text()
+}

--- a/src/features/Calendars/services/getCalendarsListAsync.ts
+++ b/src/features/Calendars/services/getCalendarsListAsync.ts
@@ -25,9 +25,7 @@ export const getCalendarsListAsync = createAsyncThunk<
   const existingUser = { id: state.user?.userData?.openpaasId || undefined }
   try {
     const fetchedCalendars: Record<string, Calendar> = {}
-    const user = existingUser.id
-      ? existingUser
-      : ((await getOpenPaasUser()) as OpenPaasUserData)
+    const user = existingUser.id ? existingUser : await getOpenPaasUser()
     const calendars = await getCalendars(user.id)
     const rawCalendars = calendars._embedded['dav:calendar']
 
@@ -44,7 +42,7 @@ export const getCalendarsListAsync = createAsyncThunk<
     const ownerDataMap = new Map<string, OpenPaasUserData>()
     const OWNER_BATCH_SIZE = 20
 
-    const mapOwnerData = async (ownerId: string) => {
+    const mapOwnerData = async (ownerId: string): Promise<void> => {
       try {
         const data = await fetchOwnerData(ownerId)
         ownerDataMap.set(ownerId, data)

--- a/src/features/Calendars/services/helpers.ts
+++ b/src/features/Calendars/services/helpers.ts
@@ -1,11 +1,12 @@
+import { fetchResourceById } from '@/features/User/ResourceDAO'
 import { OpenPaasUserData } from '@/features/User/type/OpenPaasUserData'
-import { getResourceDetails, getUserDetails } from '@/features/User/userAPI'
+import { getUserDetails } from '@/features/User/userAPI'
 
 export const fetchOwnerOfResource = async (
   resourceId: string
 ): Promise<OpenPaasUserData> => {
   try {
-    const data = await getResourceDetails(resourceId)
+    const data = await fetchResourceById(resourceId)
     const ownerData = await getUserDetails(data.creator)
     return {
       ...ownerData,

--- a/src/features/Calendars/services/patchACLCalendarAsync.ts
+++ b/src/features/Calendars/services/patchACLCalendarAsync.ts
@@ -1,6 +1,6 @@
 import { toRejectedError } from '@/utils/errorUtils'
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { updateAclCalendar } from '../CalendarApi'
+import { updateCalendarAcl } from '../CalendarDAO'
 import { RejectedError } from '../types/RejectedError'
 
 export const patchACLCalendarAsync = createAsyncThunk<
@@ -19,7 +19,7 @@ export const patchACLCalendarAsync = createAsyncThunk<
   'calendars/requestACLCalendar',
   async ({ calId, calLink, request }, { rejectWithValue }) => {
     try {
-      await updateAclCalendar(calLink, request)
+      await updateCalendarAcl(calLink, request)
       return {
         calId,
         calLink,

--- a/src/features/Calendars/services/removeCalendarAsync.ts
+++ b/src/features/Calendars/services/removeCalendarAsync.ts
@@ -1,6 +1,6 @@
 import { toRejectedError } from '@/utils/errorUtils'
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { removeCalendar } from '../CalendarApi'
+import { calendarAction } from '../CalendarDAO'
 import { RejectedError } from '../types/RejectedError'
 
 export const removeCalendarAsync = createAsyncThunk<
@@ -16,7 +16,7 @@ export const removeCalendarAsync = createAsyncThunk<
   'calendars/removeCalendar',
   async ({ calId, calLink }, { rejectWithValue }) => {
     try {
-      await removeCalendar(calLink)
+      await calendarAction('DELETE', calLink)
       return {
         calId
       }

--- a/src/features/User/ResourceDAO.ts
+++ b/src/features/User/ResourceDAO.ts
@@ -1,0 +1,7 @@
+import { api } from '@/utils/apiUtils'
+import { ResourceData } from './type/ResourceData'
+
+export async function fetchResourceById(id: string): Promise<ResourceData> {
+  const resource = await api.get(`api/resources/${id}`).json()
+  return resource as ResourceData
+}

--- a/src/features/User/UserDao.ts
+++ b/src/features/User/UserDao.ts
@@ -1,8 +1,12 @@
 import { api } from '@/utils/apiUtils'
+import { OpenPaasUserData } from './type/OpenPaasUserData'
+import { ModuleConfiguration, SearchResponseItem } from './userDataTypes'
 
-/**
- * Fetches user data by email. Returns raw JSON array.
- */
+export async function fetchCurrentUser(): Promise<OpenPaasUserData> {
+  const response = await api.get(`api/user`)
+  return response.json()
+}
+
 export async function fetchUserByEmail(
   email: string
 ): Promise<Array<Record<string, string>>> {
@@ -11,4 +15,31 @@ export async function fetchUserByEmail(
     return []
   }
   return r.json()
+}
+
+export async function fetchUserById(id: string): Promise<OpenPaasUserData> {
+  const user = await api.get(`api/users/${id}`).json()
+  return user as OpenPaasUserData
+}
+
+export async function searchPeople(
+  query: string,
+  objectTypes: string[] = ['user', 'contact']
+): Promise<SearchResponseItem[]> {
+  const response: SearchResponseItem[] = await api
+    .post(`api/people/search`, {
+      body: JSON.stringify({
+        limit: 10,
+        objectTypes,
+        q: query
+      })
+    })
+    .json()
+  return response
+}
+
+export async function patchConfigurations(modules: ModuleConfiguration[]) {
+  return await api.patch(`api/configurations?scope=user`, {
+    json: modules
+  })
 }

--- a/src/features/User/UserDao.ts
+++ b/src/features/User/UserDao.ts
@@ -38,7 +38,9 @@ export async function searchPeople(
   return response
 }
 
-export async function patchConfigurations(modules: ModuleConfiguration[]) {
+export async function patchConfigurations(
+  modules: ModuleConfiguration[]
+): Promise<Response> {
   return await api.patch(`api/configurations?scope=user`, {
     json: modules
   })

--- a/src/features/User/userAPI.ts
+++ b/src/features/User/userAPI.ts
@@ -1,34 +1,25 @@
 import { User } from '@/components/Attendees/types'
-import { api } from '@/utils/apiUtils'
 import { isValidEmail } from '@/utils/isValidEmail'
 import { BusinessHour } from '../Settings/SettingsSlice'
 import { OpenPaasUserData } from './type/OpenPaasUserData'
-import { ResourceData } from './type/ResourceData'
-import { fetchUserByEmail } from './UserDao'
 import {
-  ConfigurationItem,
-  ModuleConfiguration,
-  SearchResponseItem
-} from './userDataTypes'
+  fetchCurrentUser,
+  fetchUserByEmail,
+  fetchUserById,
+  patchConfigurations,
+  searchPeople
+} from './UserDao'
+import { ConfigurationItem, ModuleConfiguration } from './userDataTypes'
 
 export async function getOpenPaasUser() {
-  const user = await api.get(`api/user`)
-  return user.json()
+  return fetchCurrentUser()
 }
 
 export async function searchUsers(
   query: string,
   objectTypes: string[] = ['user', 'contact']
 ): Promise<User[]> {
-  const response: SearchResponseItem[] = await api
-    .post(`api/people/search`, {
-      body: JSON.stringify({
-        limit: 10,
-        objectTypes,
-        q: query
-      })
-    })
-    .json()
+  const response = await searchPeople(query, objectTypes)
 
   return response.map(user => ({
     email: user.emailAddresses?.[0]?.value || '',
@@ -41,13 +32,7 @@ export async function searchUsers(
 }
 
 export async function getUserDetails(id: string): Promise<OpenPaasUserData> {
-  const user = await api.get(`api/users/${id}`).json()
-  return user as OpenPaasUserData
-}
-
-export async function getResourceDetails(id: string): Promise<ResourceData> {
-  const resource = await api.get(`api/resources/${id}`).json()
-  return resource as ResourceData
+  return fetchUserById(id)
 }
 
 export interface UserConfigurationUpdates {
@@ -144,9 +129,7 @@ export async function updateUserConfigurations(
     return Promise.resolve({ status: 204 })
   }
 
-  return await api.patch(`api/configurations?scope=user`, {
-    json: modules
-  })
+  return await patchConfigurations(modules)
 }
 
 export async function getUserDataFromEmail(

--- a/src/features/User/userSlice.ts
+++ b/src/features/User/userSlice.ts
@@ -33,7 +33,7 @@ export const getOpenPaasUserDataAsync = createAsyncThunk<
 >('user/getOpenPaasUserData', async (_, { rejectWithValue }) => {
   try {
     const user = await getOpenPaasUser()
-    return user as OpenPaasUserData
+    return user
   } catch (err) {
     const error = err as { response?: { status?: number } }
     return rejectWithValue({

--- a/src/websocket/WebSocketGate.tsx
+++ b/src/websocket/WebSocketGate.tsx
@@ -110,7 +110,7 @@ export function WebSocketGate() {
         clearReconnectTimeout()
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+
     [scheduleReconnect, clearReconnectTimeout]
   )
 
@@ -156,7 +156,6 @@ export function WebSocketGate() {
 
       clearReconnectTimeout()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSocketOpen, clearReconnectTimeout])
 
   // Manage WebSocket connection
@@ -297,7 +296,6 @@ export function WebSocketGate() {
       window.removeEventListener('online', handleOnline)
       window.removeEventListener('offline', handleOffline)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSocketOpen, isAuthenticated, clearReconnectTimeout])
 
   useEffect(() => {
@@ -334,7 +332,6 @@ export function WebSocketGate() {
         pingCleanupRef.current = null
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSocketOpen])
 
   const triggerReconnect = useCallback(() => {


### PR DESCRIPTION
resolves #830 

Still need to update the tests to be mocking the DAO and not the data handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Calendar and user data access moved to a dedicated data-access layer; behavior and public APIs remain unchanged for users.
  * Calendar secret-link, export, ACL, and deletion flows now use the centralized layer with no visible regressions.

* **Tests**
  * Test suites updated to use the new data-access layer and expanded error-path coverage for owner lookup and invite handling.

* **Chores**
  * Removed redundant lint suppressions in WebSocket handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->