### PR TITLE
[#697] added mobile selector for access selector

### DIFF
--- a/src/components/Calendar/CalendarAccessRights/AccessSelector.tsx
+++ b/src/components/Calendar/CalendarAccessRights/AccessSelector.tsx
@@ -1,0 +1,151 @@
+import { AccessRight } from '@/features/Calendars/CalendarTypes'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
+import {
+  Box,
+  List,
+  ListItemButton,
+  ListItemText,
+  MenuItem,
+  Select,
+  styled,
+  SwipeableDrawer,
+  Typography
+} from '@linagora/twake-mui'
+import { MobileSelector } from '../../MobileSelector'
+
+const StyledSwipeableDrawer = styled(SwipeableDrawer)(({ theme }) => ({
+  zIndex: theme.zIndex.modal + 100
+}))
+
+export const AccessSelector: React.FC<{
+  accessRight: AccessRight
+  setAccessRight: (r: AccessRight) => void
+  accessRightOptions: { value: AccessRight; label: string }[]
+  disabled?: boolean
+}> = ({ accessRight, setAccessRight, accessRightOptions, disabled }) => {
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
+
+  if (isMobile) {
+    const displayText = accessRightOptions.find(
+      right => right.value === accessRight
+    )?.label
+
+    return (
+      <MobileAccessSelector
+        displayText={displayText}
+        disabled={disabled}
+        accessRightOptions={accessRightOptions}
+        accessRight={accessRight}
+        setAccessRight={setAccessRight}
+      />
+    )
+  }
+
+  return (
+    <DesktopAccessSelector
+      accessRight={accessRight}
+      setAccessRight={setAccessRight}
+      disabled={disabled}
+      accessRightOptions={accessRightOptions}
+    />
+  )
+}
+
+const DesktopAccessSelector: React.FC<{
+  accessRight: number
+  setAccessRight: (r: AccessRight) => void
+  disabled: boolean | undefined
+  accessRightOptions: { value: AccessRight; label: string }[]
+}> = ({ accessRight, setAccessRight, disabled, accessRightOptions }) => {
+  return (
+    <Select
+      value={accessRight}
+      onChange={e => setAccessRight(e.target.value as AccessRight)}
+      variant="standard"
+      disableUnderline
+      disabled={disabled}
+      sx={{
+        fontSize: '0.875rem',
+        color: 'text.secondary',
+        '& .MuiSelect-select': {
+          paddingRight: '24px !important',
+          paddingY: 0
+        },
+        '& .MuiSelect-icon': { fontSize: '1rem' },
+        '&:before, &:after': { display: 'none' }
+      }}
+    >
+      {accessRightOptions.map(opt => (
+        <MenuItem
+          key={opt.value}
+          value={opt.value}
+          sx={{ color: 'text.secondary' }}
+        >
+          {opt.label}
+        </MenuItem>
+      ))}
+    </Select>
+  )
+}
+const MobileAccessSelector: React.FC<{
+  displayText: string | undefined
+  disabled: boolean | undefined
+  accessRightOptions: { value: AccessRight; label: string }[]
+  accessRight: number
+  setAccessRight: (r: AccessRight) => void
+}> = ({
+  displayText,
+  disabled,
+  accessRightOptions,
+  accessRight,
+  setAccessRight
+}) => {
+  return (
+    <MobileSelector
+      displayText={displayText}
+      disabled={disabled}
+      selectorButtonSx={{
+        '& .MuiTypography-root': {
+          fontSize: '0.875rem',
+          color: 'text.secondary',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap'
+        }
+      }}
+      bottomSheetChildren={
+        disabled
+          ? undefined
+          : ({ open, onClose }) => (
+              <StyledSwipeableDrawer
+                anchor="bottom"
+                open={open}
+                onClose={onClose}
+                onOpen={(): void => {}}
+              >
+                <List sx={{ overflow: 'auto', flex: 1, pt: 0 }}>
+                  {accessRightOptions.map(opt => (
+                    <ListItemButton
+                      key={opt.value}
+                      selected={opt.value === accessRight}
+                      onClick={() => {
+                        setAccessRight(opt.value)
+                        onClose()
+                      }}
+                    >
+                      <ListItemText
+                        primary={
+                          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                            <Typography>{opt.label}</Typography>
+                          </Box>
+                        }
+                      />
+                    </ListItemButton>
+                  ))}
+                </List>
+              </StyledSwipeableDrawer>
+            )
+      }
+    />
+  )
+}

--- a/src/components/Calendar/CalendarAccessRights/index.tsx
+++ b/src/components/Calendar/CalendarAccessRights/index.tsx
@@ -10,8 +10,6 @@ import {
   CircularProgress,
   IconButton,
   InputAdornment,
-  MenuItem,
-  Select,
   TextField,
   Typography
 } from '@linagora/twake-mui'
@@ -19,11 +17,12 @@ import HighlightOffIcon from '@mui/icons-material/HighlightOff'
 import PeopleOutlineOutlinedIcon from '@mui/icons-material/PeopleOutlineOutlined'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from 'twake-i18n'
-import { PeopleSearch } from '../Attendees/PeopleSearch'
-import { User } from '../Attendees/types'
-import { FieldWithLabel } from '../Event/components/FieldWithLabel'
-import { stringAvatar } from '../Event/utils/eventUtils'
-import { ResourceAdmin } from './ResourceAdmins'
+import { PeopleSearch } from '../../Attendees/PeopleSearch'
+import { User } from '../../Attendees/types'
+import { FieldWithLabel } from '../../Event/components/FieldWithLabel'
+import { stringAvatar } from '../../Event/utils/eventUtils'
+import { ResourceAdmin } from '../ResourceAdmins'
+import { AccessSelector } from './AccessSelector'
 
 export interface UserWithAccess extends User {
   accessRight: AccessRight
@@ -41,6 +40,74 @@ interface UserInCalendar {
   access: AccessRight
 }
 
+function UserAccessRow({
+  user,
+  canEdit,
+  accessRightOptions,
+  onRemove,
+  onChangeRight
+}: {
+  user: UserWithAccess
+  canEdit: boolean
+  accessRightOptions: { value: AccessRight; label: string }[]
+  onRemove: (email: string) => void
+  onChangeRight: (email: string, right: AccessRight) => void
+}) {
+  return (
+    <Box
+      key={user.email}
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      px={1}
+      py={0.5}
+      sx={{
+        borderRadius: '8px',
+        '&:hover': { backgroundColor: 'action.hover' }
+      }}
+    >
+      <Box display="flex" alignItems="center" gap={1.5} minWidth={0}>
+        <Avatar
+          {...stringAvatar(user.displayName)}
+          sx={{ width: 28, height: 28, fontSize: '0.875rem' }}
+        />
+        <Box minWidth={0} display="flex" flexDirection="column" gap={0}>
+          <Typography noWrap>{user.displayName}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            {user.email}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box
+        display="flex"
+        alignItems="center"
+        gap={0.5}
+        flexShrink={0}
+        sx={{ maxWidth: '50%' }}
+        justifyContent="flex-end"
+      >
+        <AccessSelector
+          accessRight={user.accessRight}
+          setAccessRight={right => onChangeRight(user.email, right)}
+          accessRightOptions={accessRightOptions}
+          disabled={!canEdit}
+        />
+        {canEdit && (
+          <IconButton
+            size="small"
+            aria-label="remove"
+            onClick={() => onRemove(user.email)}
+            sx={{ color: 'text.secondary' }}
+          >
+            <HighlightOffIcon fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
 export function CalendarAccessRights({
   calendar,
   value: usersWithAccess,
@@ -55,6 +122,8 @@ export function CalendarAccessRights({
     const invitedEmail = normalizeEmail(invite.href.replace(/^mailto:/i, ''))
     return invitedEmail === currentUserEmail && invite.access === 5
   })
+
+  const canEdit = isPersonalCalendar || isDelegatedWithAdministration
 
   const ownerEmail =
     calendar.owner?.preferredEmail ?? calendar.owner?.emails?.[0] ?? ''
@@ -241,13 +310,13 @@ export function CalendarAccessRights({
   return (
     <FieldWithLabel
       label={
-        isPersonalCalendar || isDelegatedWithAdministration
+        canEdit
           ? t('calendarPopover.access.grantAccessRights')
           : t('calendarPopover.access.accessRights')
       }
       isExpanded={false}
     >
-      {(isPersonalCalendar || isDelegatedWithAdministration) && (
+      {canEdit && (
         <Box ref={containerRef}>
           <PeopleSearch
             selectedUsers={usersWithAccess}
@@ -315,34 +384,11 @@ export function CalendarAccessRights({
                   ),
                   endAdornment: (
                     <InputAdornment position="end">
-                      <Select
-                        value={accessRight}
-                        onChange={e =>
-                          setAccessRight(e.target.value as AccessRight)
-                        }
-                        variant="standard"
-                        disableUnderline
-                        sx={{
-                          fontSize: '0.875rem',
-                          color: 'text.secondary',
-                          '& .MuiSelect-select': {
-                            paddingRight: '24px !important',
-                            paddingY: 0
-                          },
-                          '& .MuiSelect-icon': { fontSize: '1rem' },
-                          '&:before, &:after': { display: 'none' }
-                        }}
-                      >
-                        {accessRightOptions.map(opt => (
-                          <MenuItem
-                            key={opt.value}
-                            value={opt.value}
-                            sx={{ color: 'text.secondary' }}
-                          >
-                            {opt.label}
-                          </MenuItem>
-                        ))}
-                      </Select>
+                      <AccessSelector
+                        accessRight={accessRight}
+                        setAccessRight={setAccessRight}
+                        accessRightOptions={accessRightOptions}
+                      />
                     </InputAdornment>
                   )
                 }}
@@ -384,6 +430,7 @@ export function CalendarAccessRights({
             </Typography>
           </Box>
         </Box>
+
         {adminLoading ? (
           <Box mt={2} display="flex" justifyContent="center">
             <CircularProgress size={24} />
@@ -393,6 +440,7 @@ export function CalendarAccessRights({
             <ResourceAdmin key={admin.email} admin={admin} />
           ))
         )}
+
         {inviteLoading ? (
           <Box mt={2} display="flex" justifyContent="center">
             <CircularProgress size={24} />
@@ -400,77 +448,14 @@ export function CalendarAccessRights({
         ) : (
           usersWithAccess.length > 0 &&
           usersWithAccess.map(user => (
-            <Box
+            <UserAccessRow
               key={user.email}
-              display="flex"
-              alignItems="center"
-              justifyContent="space-between"
-              px={1}
-              py={0.5}
-              sx={{
-                borderRadius: '8px',
-                '&:hover': { backgroundColor: 'action.hover' }
-              }}
-            >
-              <Box display="flex" alignItems="center" gap={1.5} minWidth={0}>
-                <Avatar
-                  {...stringAvatar(user.displayName)}
-                  sx={{ width: 28, height: 28, fontSize: '0.875rem' }}
-                />
-                <Box minWidth={0} display="flex" flexDirection="column" gap={0}>
-                  <Typography noWrap>{user.displayName}</Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {user.email}
-                  </Typography>
-                </Box>
-              </Box>
-
-              <Box display="flex" alignItems="center" gap={0.5} flexShrink={0}>
-                <Select
-                  value={user.accessRight}
-                  onChange={e =>
-                    handleChangeUserRight(
-                      user.email,
-                      e.target.value as AccessRight
-                    )
-                  }
-                  variant="standard"
-                  disableUnderline
-                  disabled={
-                    !(isPersonalCalendar || isDelegatedWithAdministration)
-                  }
-                  sx={{
-                    fontSize: '0.875rem',
-                    color: 'text.secondary',
-                    '& .MuiSelect-select': {
-                      paddingRight: '24px !important',
-                      paddingY: 0
-                    },
-                    '& .MuiSelect-icon': { fontSize: '1rem' }
-                  }}
-                >
-                  {accessRightOptions.map(opt => (
-                    <MenuItem
-                      key={opt.value}
-                      value={opt.value}
-                      sx={{ color: 'text.secondary' }}
-                    >
-                      {opt.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-                {(isPersonalCalendar || isDelegatedWithAdministration) && (
-                  <IconButton
-                    size="small"
-                    aria-label={t('actions.remove')}
-                    onClick={() => handleRemoveUser(user.email)}
-                    sx={{ color: 'text.secondary' }}
-                  >
-                    <HighlightOffIcon fontSize="small" />
-                  </IconButton>
-                )}
-              </Box>
-            </Box>
+              user={user}
+              canEdit={canEdit}
+              accessRightOptions={accessRightOptions}
+              onRemove={handleRemoveUser}
+              onChangeRight={handleChangeUserRight}
+            />
           ))
         )}
       </Box>

--- a/src/components/MobileSelector/index.tsx
+++ b/src/components/MobileSelector/index.tsx
@@ -46,54 +46,76 @@ interface MobileSelectorProps {
     onClose: () => void
   }) => React.ReactNode
   fullscreen?: boolean
+  selectorButtonSx?: React.ComponentProps<typeof ButtonBase>['sx']
+  disabled?: boolean
 }
 
 export const MobileSelector = forwardRef<
   MobileSelectorHandle,
   MobileSelectorProps
->(({ displayText, children, bottomSheetChildren, fullscreen }, ref) => {
-  const [open, setOpen] = useState(false)
-  const onClose = (): void => setOpen(false)
+>(
+  (
+    {
+      displayText,
+      children,
+      bottomSheetChildren,
+      fullscreen,
+      selectorButtonSx,
+      disabled
+    },
+    ref
+  ) => {
+    const [open, setOpen] = useState(false)
+    const onClose = (): void => setOpen(false)
 
-  useImperativeHandle(ref, () => ({ open, onClose }))
+    useImperativeHandle(ref, () => ({ open, onClose }))
 
-  return (
-    <>
-      <SelectorButton onClick={() => setOpen(true)}>
-        {typeof displayText === 'string' ? (
-          <Typography variant="body1">{displayText}</Typography>
-        ) : (
-          displayText
-        )}
-        <Box
-          component={ArrowDropDownIcon}
-          sx={{
-            fontSize: 20,
-            transition: 'transform 0.2s',
-            transform: open ? 'rotate(180deg)' : 'rotate(0deg)'
-          }}
-        />
-      </SelectorButton>
-      {children ? (
-        <StyledSwipeableDrawer
-          anchor="bottom"
-          open={open}
-          onClose={onClose}
-          onOpen={(): void => {}}
-          disableAutoFocus
-          slotProps={{
-            paper: {
-              sx: fullscreen ? { height: '100dvh' } : { maxHeight: '90dvh' }
-            }
-          }}
+    const ButtonComponent = selectorButtonSx ? ButtonBase : SelectorButton
+
+    return (
+      <>
+        <ButtonComponent
+          onClick={() => !disabled && setOpen(true)}
+          disabled={disabled}
+          sx={selectorButtonSx}
         >
-          {children}
-        </StyledSwipeableDrawer>
-      ) : (
-        bottomSheetChildren?.({ open, onClose })
-      )}
-    </>
-  )
-})
+          {typeof displayText === 'string' ? (
+            <Typography variant="body1" noWrap>
+              {displayText}
+            </Typography>
+          ) : (
+            displayText
+          )}
+          <Box
+            component={ArrowDropDownIcon}
+            sx={{
+              fontSize: 20,
+              transition: 'transform 0.2s',
+              transform: open ? 'rotate(180deg)' : 'rotate(0deg)'
+            }}
+          />
+        </ButtonComponent>
+        {children ? (
+          <StyledSwipeableDrawer
+            anchor="bottom"
+            open={open}
+            onClose={onClose}
+            onOpen={(): void => {}}
+            disableAutoFocus
+            slotProps={{
+              paper: {
+                sx: fullscreen ? { height: '100dvh' } : { maxHeight: '90dvh' }
+              }
+            }}
+          >
+            {children}
+          </StyledSwipeableDrawer>
+        ) : (
+          bottomSheetChildren?.({ open, onClose })
+        )}
+      </>
+    )
+  }
+)
 
 MobileSelector.displayName = 'MobileSelector'


### PR DESCRIPTION
resolves #697 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive calendar access selector that switches between a mobile bottom-sheet and a desktop dropdown.
* **Refactor**
  * Streamlined per-user access rows and centralized edit controls for consistent behavior.
  * Mobile selector accepts optional custom button styling and improves drawer/selector interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->