### PR TITLE
#694 create calendar modal on mobile

### DIFF
--- a/src/components/Calendar/CalendarColorPicker.tsx
+++ b/src/components/Calendar/CalendarColorPicker.tsx
@@ -3,14 +3,19 @@ import CheckIcon from '@mui/icons-material/Check'
 import {
   Box,
   Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Popover,
   TextField,
   Typography,
   useTheme
 } from '@linagora/twake-mui'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { HexColorPicker } from 'react-colorful'
 import { useI18n } from 'twake-i18n'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 import { getAccessiblePair } from '@/utils/getAccessiblePair'
 import { defaultColors } from '@/utils/defaultColors'
 
@@ -22,7 +27,7 @@ export function ColorPicker({
   selectedColor: Record<string, string>
   colors?: Record<string, string>[]
   onChange: (color: Record<string, string>) => void
-}) {
+}): JSX.Element {
   const customColor = !colors.find(c => c.light === selectedColor?.light)
     ? selectedColor
     : undefined
@@ -63,7 +68,7 @@ function ColorBox({
   color: Record<string, string>
   onChange: (color: Record<string, string>) => void
   selectedColor: Record<string, string>
-}) {
+}): JSX.Element {
   return (
     <Box
       role="button"
@@ -101,13 +106,107 @@ function ColorBox({
   )
 }
 
+function ColorPickerHeader(): JSX.Element {
+  const { t } = useI18n()
+  return (
+    <>
+      <Typography variant="subtitle1" fontWeight="600">
+        {t('colorPicker.title')}
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+        {t('colorPicker.subtitle')}
+      </Typography>
+    </>
+  )
+}
+
+function ColorPickerFields({
+  color,
+  onColorChange,
+  fullWidth = false
+}: {
+  color: Record<string, string>
+  onColorChange: (c: string) => void
+  fullWidth?: boolean
+}): JSX.Element {
+  const { t } = useI18n()
+  const [draftLight, setDraftLight] = useState(color.light)
+
+  useEffect(() => {
+    const updateDraftColor = (): void => {
+      setDraftLight(color.light)
+    }
+    updateDraftColor()
+  }, [color.light])
+
+  const commitChange = (): void => {
+    onColorChange(draftLight)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter') {
+      commitChange()
+    }
+  }
+
+  return (
+    <>
+      <Box sx={{ mb: 2 }}>
+        <HexColorPicker
+          color={color.light}
+          onChange={onColorChange}
+          style={{ width: '100%' }}
+        />
+      </Box>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        <Typography variant="body2" sx={{ mr: 1 }}>
+          {t('colorPicker.hex')}
+        </Typography>
+        <TextField
+          value={draftLight?.toUpperCase()}
+          onChange={e => setDraftLight(e.target.value)}
+          onBlur={commitChange}
+          onKeyDown={handleKeyDown}
+          variant="standard"
+          size="small"
+          fullWidth={fullWidth}
+          slotProps={{ inputLabel: { shrink: true } }}
+        />
+      </Box>
+    </>
+  )
+}
+
+function ColorPickerActions({
+  onCancel,
+  onSave
+}: {
+  onCancel: () => void
+  onSave: () => void
+}): JSX.Element {
+  const { t } = useI18n()
+  return (
+    <>
+      <Button onClick={onCancel}>{t('common.cancel')}</Button>
+      <Button
+        variant="contained"
+        onClick={onSave}
+        sx={{ textTransform: 'none' }}
+      >
+        {t('actions.save')}
+      </Button>
+    </>
+  )
+}
+
 function ColorPickerBox({
   onChange,
   selectedColor
 }: {
   onChange: (color: Record<string, string>) => void
   selectedColor: Record<string, string>
-}) {
+}): JSX.Element {
   const { t } = useI18n()
   const [oldColor] = useState(
     selectedColor ?? { light: '#ffffff', dark: '#808080' }
@@ -116,23 +215,26 @@ function ColorPickerBox({
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const open = Boolean(anchorEl)
   const theme = useTheme()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
 
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>): void => {
     setAnchorEl(event.currentTarget)
   }
 
-  const handleClose = () => {
+  const handleClose = (): void => {
     onChange(oldColor)
     setAnchorEl(null)
   }
 
-  const handleSave = () => {
+  const handleSave = (): void => {
     onChange(color)
     setAnchorEl(null)
   }
 
-  const handleColorChange = (c: string) => {
-    const newLight = c
+  const handleColorChange = (c: string): void => {
+    const newLight = c.trim().toUpperCase()
+    if (!/^#([0-9A-F]{3}|[0-9A-F]{6})$/.test(newLight)) return
+
     const newColor = {
       light: newLight,
       dark: getAccessiblePair(newLight, theme)
@@ -170,74 +272,55 @@ function ColorPickerBox({
             backgroundColor: '#CBD2E0'
           }}
         ></Box>
-        <AddIcon
-          style={{
-            color: '#CBD2E0'
-          }}
-        />
+        <AddIcon style={{ color: '#CBD2E0' }} />
       </Box>
-      <Popover
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleClose}
-        anchorOrigin={{
-          vertical: 'center',
-          horizontal: 'center'
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left'
-        }}
-        slotProps={{
-          paper: {
-            style: {
-              padding: '24px',
-              width: '294px',
-              borderRadius: '8px',
-              boxShadow: '0px 1px 3px #3C404326'
+
+      {isMobile ? (
+        <Dialog open={open} onClose={handleClose} fullWidth maxWidth="xs">
+          <DialogTitle sx={{ pb: 1 }}>
+            <Typography variant="subtitle1" fontWeight="600">
+              {t('colorPicker.title')}
+            </Typography>
+          </DialogTitle>
+          <DialogContent>
+            <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
+              {t('colorPicker.subtitle')}
+            </Typography>
+            <ColorPickerFields
+              color={color}
+              onColorChange={handleColorChange}
+              fullWidth
+            />
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 2 }}>
+            <ColorPickerActions onCancel={handleClose} onSave={handleSave} />
+          </DialogActions>
+        </Dialog>
+      ) : (
+        <Popover
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+          slotProps={{
+            paper: {
+              style: {
+                padding: '24px',
+                width: '294px',
+                borderRadius: '8px',
+                boxShadow: '0px 1px 3px #3C404326'
+              }
             }
-          }
-        }}
-      >
-        <Typography variant="subtitle1" fontWeight="600">
-          {t('colorPicker.title')}
-        </Typography>
-        <Typography variant="body2" sx={{ mb: 2, color: 'text.secondary' }}>
-          {t('colorPicker.subtitle')}
-        </Typography>
-
-        <Box sx={{ mb: 2 }}>
-          <HexColorPicker
-            color={color.light}
-            onChange={handleColorChange}
-            style={{ width: '100%' }}
-          />
-        </Box>
-
-        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-          <Typography variant="body2" sx={{ mr: 1 }}>
-            {t('colorPicker.hex')}
-          </Typography>
-          <TextField
-            value={color.light?.toUpperCase()}
-            onChange={e => handleColorChange(e.target.value)}
-            variant="standard"
-            size="small"
-            slotProps={{ inputLabel: { shrink: true } }}
-          />
-        </Box>
-
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
-          <Button onClick={handleClose}>{t('common.cancel')}</Button>
-          <Button
-            variant="contained"
-            onClick={handleSave}
-            sx={{ textTransform: 'none' }}
-          >
-            {t('actions.save')}
-          </Button>
-        </Box>
-      </Popover>
+          }}
+        >
+          <ColorPickerHeader />
+          <ColorPickerFields color={color} onColorChange={handleColorChange} />
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+            <ColorPickerActions onCancel={handleClose} onSave={handleSave} />
+          </Box>
+        </Popover>
+      )}
     </>
   )
 }

--- a/src/components/Calendar/CalendarItemList.tsx
+++ b/src/components/Calendar/CalendarItemList.tsx
@@ -4,10 +4,15 @@ import React from 'react'
 import { CalendarName } from './CalendarName'
 
 export function CalendarItemList(
-  userPersonalCalendars: Calendar[]
+  userPersonalCalendars: Calendar[],
+  onClick?: (calendarId: string) => void
 ): React.ReactNode {
   return Object.values(userPersonalCalendars).map(calendar => (
-    <MenuItem key={calendar.id} value={calendar.id}>
+    <MenuItem
+      key={calendar.id}
+      value={calendar.id}
+      onClick={() => onClick?.(calendar.id)}
+    >
       <CalendarName calendar={calendar} />
     </MenuItem>
   ))

--- a/src/components/Calendar/CalendarSelector.tsx
+++ b/src/components/Calendar/CalendarSelector.tsx
@@ -1,0 +1,75 @@
+import React, { useRef } from 'react'
+import { useAppSelector } from '@/app/hooks'
+import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
+import { InputLabel, MenuItem, Select, Typography } from '@linagora/twake-mui'
+import { useI18n } from 'twake-i18n'
+import { CalendarItemList } from './CalendarItemList'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
+import { MobileSelector, MobileSelectorHandle } from '../MobileSelector'
+import { CalendarName } from './CalendarName'
+
+export const CalendarSelector: React.FC<{
+  userId: string
+  importTarget: string
+  setImportTarget: (target: string) => void
+}> = ({ userId, importTarget, setImportTarget }) => {
+  const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const calendars = useAppSelector(state => state.calendars.list)
+  const personalCalendars = Object.values(calendars).filter(
+    cal => extractEventBaseUuid(cal.id) === userId
+  )
+
+  const selectorRef = useRef<MobileSelectorHandle>(null)
+  const selectedCalendar = personalCalendars.find(
+    cal => cal.id === importTarget
+  )
+
+  const handleMobileSelectCalendar = (calendarId: string): void => {
+    setImportTarget(calendarId)
+    selectorRef.current?.onClose()
+  }
+
+  if (isMobile) {
+    return (
+      <>
+        <Typography variant="h6" sx={{ margin: 0, marginBottom: 1 }}>
+          {t('calendar.import_to')}
+        </Typography>
+        <MobileSelector
+          ref={selectorRef}
+          displayText={
+            importTarget === 'new' ? (
+              t('calendar.new_calendar')
+            ) : selectedCalendar ? (
+              <CalendarName calendar={selectedCalendar} />
+            ) : null
+          }
+        >
+          <MenuItem
+            value="new"
+            onClick={() => handleMobileSelectCalendar('new')}
+          >
+            {t('calendar.new_calendar')}
+          </MenuItem>
+          {CalendarItemList(personalCalendars, handleMobileSelectCalendar)}
+        </MobileSelector>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <InputLabel id="import-to-label">{t('calendar.import_to')}</InputLabel>
+      <Select
+        labelId="import-to-label"
+        label={t('calendar.import_to')}
+        value={importTarget}
+        onChange={e => setImportTarget(e.target.value)}
+      >
+        <MenuItem value="new">{t('calendar.new_calendar')}</MenuItem>
+        {CalendarItemList(personalCalendars)}
+      </Select>
+    </>
+  )
+}

--- a/src/components/Calendar/ImportTab.tsx
+++ b/src/components/Calendar/ImportTab.tsx
@@ -1,27 +1,17 @@
-import { useAppSelector } from '@/app/hooks'
-import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
 import {
   Box,
   Button,
   FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
   TextField,
   Typography
 } from '@linagora/twake-mui'
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useI18n } from 'twake-i18n'
-import { CalendarItemList } from './CalendarItemList'
 import { SettingsTab } from './SettingsTab'
+import { CalendarSelector } from './CalendarSelector'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
-export function ImportTab({
-  userId,
-  importTarget,
-  setImportTarget,
-  setImportedContent,
-  newCalParams
-}: {
+export const ImportTab: React.FC<{
   userId: string
   importTarget: string
   setImportTarget: (target: string) => void
@@ -36,15 +26,18 @@ export function ImportTab({
     visibility: 'public' | 'private'
     setVisibility: (visibility: 'public' | 'private') => void
   }
-}) {
+}> = ({
+  userId,
+  importTarget,
+  setImportTarget,
+  setImportedContent,
+  newCalParams
+}) => {
   const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
   const [importMode] = useState<'file' | 'url'>('file')
   const [importFile, setImportFile] = useState<File | null>(null)
   const [importUrl, setImportUrl] = useState('')
-  const calendars = useAppSelector(state => state.calendars.list)
-  const personalCalendars = Object.values(calendars).filter(
-    cal => extractEventBaseUuid(cal.id) === userId
-  )
 
   useEffect(() => {
     setImportedContent(importMode === 'file' ? importFile : null)
@@ -97,7 +90,7 @@ export function ImportTab({
             label={t('calendar.ics_feed_url')}
             value={importUrl}
             onChange={e => setImportUrl(e.target.value)}
-            size="small"
+            size={isMobile ? 'medium' : 'small'}
             margin="dense"
             sx={{
               '&.MuiFormControl-root.MuiFormControl-marginDense': {
@@ -122,18 +115,11 @@ export function ImportTab({
             }
           }}
         >
-          <InputLabel id="import-to-label">
-            {t('calendar.import_to')}
-          </InputLabel>
-          <Select
-            labelId="import-to-label"
-            label={t('calendar.import_to')}
-            value={importTarget}
-            onChange={e => setImportTarget(e.target.value)}
-          >
-            <MenuItem value="new">{t('calendar.new_calendar')}</MenuItem>
-            {CalendarItemList(personalCalendars)}
-          </Select>
+          <CalendarSelector
+            userId={userId}
+            importTarget={importTarget}
+            setImportTarget={setImportTarget}
+          />
         </FormControl>
       </Box>
 

--- a/src/components/Calendar/SettingsTab.tsx
+++ b/src/components/Calendar/SettingsTab.tsx
@@ -18,6 +18,7 @@ import { useI18n } from 'twake-i18n'
 import { AddDescButton } from '../Event/AddDescButton'
 import { ColorPicker } from './CalendarColorPicker'
 import { InfoRow } from '../Event/InfoRow'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
 export function SettingsTab({
   name,
@@ -43,6 +44,7 @@ export function SettingsTab({
   autoFocusName?: boolean
 }) {
   const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
   const [toggleDesc, setToggleDesc] = useState(Boolean(description))
   const userId = useAppSelector(state => state.user.userData?.openpaasId) ?? ''
   const isOwn = calendar ? extractEventBaseUuid(calendar.id) === userId : true
@@ -100,7 +102,7 @@ export function SettingsTab({
               placeholder={t('common.name')}
               value={name}
               onChange={e => setName(e.target.value)}
-              size="small"
+              size={isMobile ? 'medium' : 'small'}
               sx={{
                 '&.MuiFormControl-root': {
                   marginTop: 0,


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated calendar selector for clearer import destination choice.
  * Responsive color picker that uses a full-width dialog on mobile and a popover on desktop.

* **Improvements**
  * Calendar item list supports an optional selection callback for interactive lists.
  * Import UI reorganized to delegate calendar selection to the new selector.
  * Settings form fields adjust sizing for mobile screens.

* **Refactor**
  * Import tab converted to a typed functional component and color picker split into smaller UI subcomponents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->