### PR TITLE
[#867] added  missing condition to hide typography for empty labels

### DIFF
--- a/src/components/Event/components/DateTimeFields/DateTimeSubPanels.tsx
+++ b/src/components/Event/components/DateTimeFields/DateTimeSubPanels.tsx
@@ -64,7 +64,7 @@ export const DateTimeRepeatPanel: React.FC<DateTimeRepeatPanelProps> = ({
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
   return (
-    <FieldWithLabel label=" " isExpanded={showMore && !isMobile}>
+    <FieldWithLabel label="" isExpanded={showMore && !isMobile}>
       <RepeatEvent
         repetition={repetition}
         eventStart={new Date(start)}

--- a/src/components/Event/components/FieldWithLabel.tsx
+++ b/src/components/Event/components/FieldWithLabel.tsx
@@ -17,13 +17,13 @@ export const FieldWithLabel = React.memo(
     children: React.ReactNode
     sx?: SxProps<Theme>
   }) => {
+    const isEmptyLabel =
+      label === null ||
+      label === undefined ||
+      (typeof label === 'string' && label.trim() === '')
+
     if (!isExpanded) {
       // Normal mode: label on top
-      const isEmptyLabel =
-        label === null ||
-        label === undefined ||
-        (typeof label === 'string' && label.trim() === '')
-
       return (
         <Box
           sx={[
@@ -73,17 +73,19 @@ export const FieldWithLabel = React.memo(
     // Extended mode: label on left
     return (
       <Box display="flex" alignItems="center" sx={sx}>
-        <Typography
-          component="div"
-          variant="h6"
-          sx={{
-            minWidth: '115px',
-            marginRight: '12px',
-            flexShrink: 0
-          }}
-        >
-          {label}
-        </Typography>
+        {!isEmptyLabel && (
+          <Typography
+            component="div"
+            variant="h6"
+            sx={{
+              minWidth: '115px',
+              marginRight: '12px',
+              flexShrink: 0
+            }}
+          >
+            {label}
+          </Typography>
+        )}
         <Box
           flexGrow={1}
           sx={{


### PR DESCRIPTION
resolves #867 for real this time

#877 wasn't enough and didn't fix the extended view, I forgot to check apparently...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary empty label space in event datetime fields for a cleaner form interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->