### PR TITLE
Include visio link only when explicitly configured

### DIFF
--- a/__test__/features/Events/EventFullDisplay.test.tsx
+++ b/__test__/features/Events/EventFullDisplay.test.tsx
@@ -385,6 +385,8 @@ describe('Event Full Display', () => {
   })
 
   it('renders video conference info when x_openpass_videoconference exists', () => {
+    window.VIDEO_CONFERENCE_BASE_URL = 'https://meet.test'
+
     const videoState = {
       ...preloadedState,
       calendars: {
@@ -418,5 +420,7 @@ describe('Event Full Display', () => {
     expect(
       screen.getByText('event.form.joinVisioConference')
     ).toBeInTheDocument()
+
+    delete window.VIDEO_CONFERENCE_BASE_URL
   })
 })

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -217,16 +217,18 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
           />
         </FieldWithLabel>
 
-        <VideoConferenceField
-          hasVideoConference={v.hasVideoConference}
-          setHasVideoConference={setHasVideoConference}
-          meetingLink={v.meetingLink}
-          setMeetingLink={setMeetingLink}
-          description={v.description}
-          setDescription={setDescription}
-          showMore={showMore}
-          setShowDescription={setShowDescription}
-        />
+        {window.VIDEO_CONFERENCE_BASE_URL && (
+          <VideoConferenceField
+            hasVideoConference={v.hasVideoConference}
+            setHasVideoConference={setHasVideoConference}
+            meetingLink={v.meetingLink}
+            setMeetingLink={setMeetingLink}
+            description={v.description}
+            setDescription={setDescription}
+            showMore={showMore}
+            setShowDescription={setShowDescription}
+          />
+        )}
 
         <AddDescButton
           showDescription={v.showDescription}

--- a/src/utils/videoConferenceUtils.ts
+++ b/src/utils/videoConferenceUtils.ts
@@ -24,8 +24,7 @@ export function generateMeetingId(): string {
  * @returns {string} Complete meeting link
  */
 export function generateMeetingLink(baseUrl?: string): string {
-  const base =
-    baseUrl || window.VIDEO_CONFERENCE_BASE_URL || 'https://meet.linagora.com'
+  const base = baseUrl || window.VIDEO_CONFERENCE_BASE_URL
   const meetingId = generateMeetingId()
   return `${base}/${meetingId}`
 }

--- a/src/utils/videoConferenceUtils.ts
+++ b/src/utils/videoConferenceUtils.ts
@@ -25,6 +25,7 @@ export function generateMeetingId(): string {
  */
 export function generateMeetingLink(baseUrl?: string): string {
   const base = baseUrl || window.VIDEO_CONFERENCE_BASE_URL
+  if (!base) return ''
   const meetingId = generateMeetingId()
   return `${base}/${meetingId}`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Video conference field is now shown only when the app is properly configured, avoiding display of unavailable options.

* **Changes**
  * Meeting link generation now relies on an explicit base URL configuration instead of falling back to a default service.

* **Tests**
  * Video conference rendering test made deterministic and now cleans up global state to prevent cross-test interference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/892)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->