### PR TITLE
#875 option to disable public visibility

### DIFF
--- a/__test__/features/Events/EventModal.test.tsx
+++ b/__test__/features/Events/EventModal.test.tsx
@@ -126,6 +126,7 @@ describe('EventPopover', () => {
   }
 
   it('renders correctly with inputs and calendar options', () => {
+    ;(window as any).DISABLE_PUBLIC_VISIBILITY = false
     renderPopover()
 
     // Check dialog title
@@ -162,6 +163,20 @@ describe('EventPopover', () => {
     expect(screen.getAllByText('event.form.notification')).toHaveLength(1)
     expect(screen.getAllByText('event.form.visibleTo')).toHaveLength(1)
     expect(screen.getAllByText('event.form.showMeAs')).toHaveLength(1)
+  })
+
+  it('hides visibleTo field when DISABLE_PUBLIC_VISIBILITY is true', () => {
+    ;(window as any).DISABLE_PUBLIC_VISIBILITY = true
+    renderPopover()
+    fireEvent.click(screen.getByRole('button', { name: 'common.moreOptions' }))
+    expect(screen.queryByText('event.form.visibleTo')).not.toBeInTheDocument()
+  })
+
+  it('shows visibleTo field when DISABLE_PUBLIC_VISIBILITY is false', () => {
+    ;(window as any).DISABLE_PUBLIC_VISIBILITY = false
+    renderPopover()
+    fireEvent.click(screen.getByRole('button', { name: 'common.moreOptions' }))
+    expect(screen.getByText('event.form.visibleTo')).toBeInTheDocument()
   })
 
   it('fills start from selectedRange', () => {

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -17,3 +17,4 @@ var WS_DEBOUNCE_PERIOD_MS = 100 // milliseconds, remove or set to 0 to disable d
 var WS_PING_PERIOD_MS = 30000
 var WS_PING_TIMEOUT_PERIOD_MS = 35000
 // var SENTRY_DSN = "https://...@sentry.io/..."; // optional, omit to disable Sentry
+var DISABLE_PUBLIC_VISIBILITY = false

--- a/src/components/Event/EventFormFields.types.ts
+++ b/src/components/Event/EventFormFields.types.ts
@@ -42,7 +42,7 @@ export const DEFAULT_FORM_VALUES: EventFormValues = {
   attendees: [],
   alarm: '',
   busy: 'OPAQUE',
-  eventClass: 'PUBLIC',
+  eventClass: window.DISABLE_PUBLIC_VISIBILITY ? 'PRIVATE' : 'PUBLIC',
   timezone: '',
   calendarid: '',
   hasVideoConference: false,

--- a/src/components/Event/components/EventFormFieldsExpanded.tsx
+++ b/src/components/Event/components/EventFormFieldsExpanded.tsx
@@ -65,11 +65,13 @@ export const EventFormFieldsExpanded: React.FC<
 
       <FreeBusyField busy={busy} setBusy={setBusy} showMore={showMore} />
 
-      <VisibilityField
-        eventClass={eventClass}
-        setEventClass={setEventClass}
-        showMore={showMore}
-      />
+      {!window.DISABLE_PUBLIC_VISIBILITY && (
+        <VisibilityField
+          eventClass={eventClass}
+          setEventClass={setEventClass}
+          showMore={showMore}
+        />
+      )}
     </>
   )
 }

--- a/src/components/Event/utils/eventInitialValuesHelpers.ts
+++ b/src/components/Event/utils/eventInitialValuesHelpers.ts
@@ -88,7 +88,8 @@ export function buildFromExistingEvent({
     repetition,
     attendees,
     alarm: event.alarm?.trigger ?? '',
-    eventClass: event.class ?? 'PUBLIC',
+    eventClass:
+      event.class ?? (window.DISABLE_PUBLIC_VISIBILITY ? 'PRIVATE' : 'PUBLIC'),
     busy: event.transp ?? 'OPAQUE',
     timezone: eventTimezone,
     calendarid: formCalendarId,

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -34,5 +34,7 @@ declare global {
     appList: AppIconProps[]
 
     __calendarRef: MutableRefObject<CalendarApi | null>
+
+    DISABLE_PUBLIC_VISIBILITY: boolean
   }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configuration flag to control public visibility features for events. When enabled, events default to public with full visibility controls available. When disabled, events default to private and visibility controls are hidden from the user interface.

* **Chores**
  * Added `ENABLE_PUBLIC_VISIBILITY` configuration flag to environment settings for managing feature deployment across instances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/893)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->