### PR TITLE
#735 timezone change alert

### DIFF
--- a/__test__/components/Timezone/TimezoneChangeAlert.test.tsx
+++ b/__test__/components/Timezone/TimezoneChangeAlert.test.tsx
@@ -1,0 +1,153 @@
+import { screen, fireEvent, act } from '@testing-library/react'
+import { renderWithProviders } from '../../utils/Renderwithproviders'
+import TimezoneChangeAlert from '@/components/Timezone/TimezoneChangeAlert'
+
+jest.mock('@/features/User/userSlice', () => {
+  const actual = jest.requireActual('@/features/User/userSlice')
+  return {
+    ...actual,
+    updateUserConfigurationsAsync: jest.fn().mockImplementation(() => {
+      return () => {
+        const mockPromise = Promise.resolve() as any
+        mockPromise.unwrap = () => Promise.resolve()
+        return mockPromise
+      }
+    })
+  }
+})
+
+describe('TimezoneChangeAlert', () => {
+  let originalDateTimeFormat: typeof Intl.DateTimeFormat
+
+  beforeEach(() => {
+    originalDateTimeFormat = Intl.DateTimeFormat
+    // Mock localStorage
+    jest.spyOn(Storage.prototype, 'getItem').mockReturnValue(null)
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {})
+    window.ASK_FOR_TZ_UPDATE = true
+  })
+
+  afterEach(() => {
+    Intl.DateTimeFormat = originalDateTimeFormat
+    jest.restoreAllMocks()
+  })
+
+  const mockBrowserTZ = (tz: string) => {
+    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(
+      () =>
+        ({
+          resolvedOptions: () => ({ timeZone: tz })
+        }) as any
+    )
+  }
+
+  const baseState = {
+    settings: { timeZone: 'Europe/Paris' },
+    user: { coreConfig: { datetime: { timeZone: 'Europe/Paris' } } }
+  }
+
+  it('shows snackbar when browser TZ differs from configured TZ', () => {
+    mockBrowserTZ('Asia/Ho_Chi_Minh')
+
+    const state = baseState
+
+    renderWithProviders(<TimezoneChangeAlert />, state)
+
+    expect(screen.getByText(/settings\.tzPrompt\.detected/)).toBeInTheDocument()
+  })
+
+  it('does not show snackbar when browser TZ matches configured TZ', () => {
+    mockBrowserTZ('Europe/Paris')
+
+    const state = baseState
+
+    renderWithProviders(<TimezoneChangeAlert />, state)
+
+    expect(screen.queryByText(/We detected you are in/)).not.toBeInTheDocument()
+  })
+
+  it('does not show snackbar when ASK_FOR_TZ_UPDATE is false', () => {
+    window.ASK_FOR_TZ_UPDATE = false
+    mockBrowserTZ('Asia/Ho_Chi_Minh')
+
+    const state = baseState
+
+    renderWithProviders(<TimezoneChangeAlert />, state)
+
+    expect(screen.queryByText(/We detected you are in/)).not.toBeInTheDocument()
+  })
+
+  it('shows snackbar when auto-detect is enabled and browser TZ differs from last checked TZ', () => {
+    mockBrowserTZ('Asia/Ho_Chi_Minh')
+    jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('Europe/Paris')
+
+    const state = {
+      settings: {
+        timeZone: 'Europe/Paris',
+        isBrowserDefaultTimeZone: true
+      },
+      user: { coreConfig: { datetime: { timeZone: null } } }
+    }
+
+    renderWithProviders(<TimezoneChangeAlert />, state)
+
+    expect(screen.getByText(/settings\.tzPrompt\.detected/)).toBeInTheDocument()
+  })
+
+  it('does not show snackbar when same TZ was already checked', () => {
+    mockBrowserTZ('Asia/Ho_Chi_Minh')
+    jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('Asia/Ho_Chi_Minh')
+
+    const state = baseState
+
+    renderWithProviders(<TimezoneChangeAlert />, state)
+
+    expect(screen.queryByText(/We detected you are in/)).not.toBeInTheDocument()
+  })
+
+  it('saves to localStorage and closes when NO is clicked', async () => {
+    mockBrowserTZ('Asia/Ho_Chi_Minh')
+
+    const state = baseState
+
+    renderWithProviders(<TimezoneChangeAlert />, state)
+
+    const noButton = screen.getByRole('button', { name: /cancel|no/i })
+
+    await act(async () => {
+      fireEvent.click(noButton)
+    })
+
+    expect(Storage.prototype.setItem).toHaveBeenCalledWith(
+      'lastCheckedTZ',
+      'Asia/Ho_Chi_Minh'
+    )
+    expect(screen.queryByText(/We detected you are in/)).not.toBeInTheDocument()
+  })
+
+  it('saves to localStorage and dispatches actions when YES is clicked', async () => {
+    mockBrowserTZ('Asia/Ho_Chi_Minh')
+
+    const state = baseState
+
+    const { store } = renderWithProviders(<TimezoneChangeAlert />, state)
+
+    const yesButton = screen.getByRole('button', { name: /ok|yes/i })
+
+    await act(async () => {
+      fireEvent.click(yesButton)
+    })
+
+    expect(Storage.prototype.setItem).toHaveBeenCalledWith(
+      'lastCheckedTZ',
+      'Asia/Ho_Chi_Minh'
+    )
+
+    // Verify that actions were dispatched
+    // In a real test we would check the store state or specific actions
+    // But since we are mocking the store in renderWithProviders, we can check if the state updated if we didn't mock the reducer.
+    // Or we can just verify the store has the new timezone if the reducer handled it.
+    const updatedState = store.getState()
+    expect(updatedState.settings.timeZone).toBe('Asia/Ho_Chi_Minh')
+  })
+})

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -19,3 +19,4 @@ var WS_PING_TIMEOUT_PERIOD_MS = 35000
 // var SENTRY_DSN = "https://...@sentry.io/..."; // optional, omit to disable Sentry
 // var HIDE_RESOURCES = true; // optional
 var DISABLE_PUBLIC_VISIBILITY = false
+var ASK_FOR_TZ_UPDATE = true

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -48,6 +48,7 @@ import {
 } from './utils/calendarUtils'
 import { CALENDAR_VIEWS } from './utils/constants'
 import ViewMoreEvents from './ViewMoreEvents'
+import { TimezoneChangeAlert } from '../Timezone/TimezoneChangeAlert'
 
 const localeMap: Record<string, LocaleInput | undefined> = {
   fr: frLocale,
@@ -400,6 +401,7 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     <main
       className={`main-layout calendar-layout ${menubarProps?.isIframe ? ' isInIframe' : ''}`}
     >
+      <TimezoneChangeAlert />
       <Sidebar
         open={openSidebar}
         onClose={onCloseSidebar}

--- a/src/components/Timezone/TimezoneChangeAlert.tsx
+++ b/src/components/Timezone/TimezoneChangeAlert.tsx
@@ -1,0 +1,116 @@
+import { useAppDispatch, useAppSelector } from '@/app/hooks'
+import { setTimeZone as setSettingsTimeZone } from '@/features/Settings/SettingsSlice'
+import {
+  setTimezone as setUserTimeZone,
+  updateUserConfigurationsAsync
+} from '@/features/User/userSlice'
+import { Alert, Box, Button, Snackbar, Typography } from '@linagora/twake-mui'
+import React, { useEffect, useState } from 'react'
+import { useI18n } from 'twake-i18n'
+
+export const TimezoneChangeAlert: React.FC = () => {
+  const dispatch = useAppDispatch()
+  const { t } = useI18n()
+
+  const configuredTZ = useAppSelector(
+    state =>
+      state.user?.coreConfig?.datetime?.timeZone ?? state.settings?.timeZone
+  )
+  const previousConfig = useAppSelector(state => state.user?.coreConfig)
+
+  const [open, setOpen] = useState(false)
+  const [browserTZ, setBrowserTZ] = useState('')
+
+  useEffect(() => {
+    const openTimezoneChangeAlert = (): void => {
+      if (!window.ASK_FOR_TZ_UPDATE) return
+
+      const currentBrowserTZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+      setBrowserTZ(currentBrowserTZ)
+
+      const lastCheckedTZ = localStorage.getItem('lastCheckedTZ')
+
+      const hasTimezoneChanged = currentBrowserTZ !== lastCheckedTZ
+      const shouldPrompt = currentBrowserTZ !== configuredTZ
+
+      if (hasTimezoneChanged && shouldPrompt) {
+        setOpen(true)
+      }
+    }
+    openTimezoneChangeAlert()
+  }, [configuredTZ])
+
+  const handleAccept = (): void => {
+    const previousTimeZone = configuredTZ
+    dispatch(setUserTimeZone(browserTZ))
+    dispatch(setSettingsTimeZone(browserTZ))
+    dispatch(
+      updateUserConfigurationsAsync({ timezone: browserTZ, previousConfig })
+    )
+      .unwrap()
+      .catch(() => {
+        // Rollback on error
+        if (previousTimeZone) {
+          dispatch(setUserTimeZone(previousTimeZone))
+          dispatch(setSettingsTimeZone(previousTimeZone))
+        }
+      })
+
+    localStorage.setItem('lastCheckedTZ', browserTZ)
+    setOpen(false)
+  }
+
+  const handleDecline = (): void => {
+    localStorage.setItem('lastCheckedTZ', browserTZ)
+    setOpen(false)
+  }
+
+  const handleClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ): void => {
+    if (reason === 'clickaway') {
+      return
+    }
+    setOpen(false)
+  }
+
+  return (
+    <Snackbar
+      open={open}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <Alert severity="info" sx={{ width: '100%' }}>
+        <Box>
+          <Typography>
+            {t('settings.tzPrompt.detected', {
+              browserTZ,
+              configuredTZ: configuredTZ || ''
+            })}
+          </Typography>
+          <Typography>
+            {t('settings.tzPrompt.askSwitch', { browserTZ })}
+          </Typography>
+        </Box>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '8px',
+            marginTop: '8px'
+          }}
+        >
+          <Button color="inherit" size="small" onClick={handleAccept}>
+            {t('common.ok')}
+          </Button>
+          <Button color="inherit" size="small" onClick={handleDecline}>
+            {t('common.cancel')}
+          </Button>
+        </div>
+      </Alert>
+    </Snackbar>
+  )
+}
+
+export default TimezoneChangeAlert

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -274,6 +274,10 @@
     "timeZone": "Timezone",
     "timeZoneBrowserDefault": "Detect time zone automatically",
     "timeZoneUpdateError": "Failed to update time zone",
+    "tzPrompt": {
+      "detected": "We detected you are in %{browserTZ} instead of your %{configuredTZ} configured TZ",
+      "askSwitch": "Do you want to switch the app to %{browserTZ} TZ?"
+    },
     "notifications.empty": "Notifications settings coming soon",
     "notifications.email": "Email",
     "notifications.deliveryMethod": "Delivery method",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -275,6 +275,10 @@
     "timeZone": "Fuseau horaire",
     "timeZoneBrowserDefault": "Détection automatique du fuseau horaire",
     "timeZoneUpdateError": "Échec de la mise à jour du fuseau horaire",
+    "tzPrompt": {
+      "detected": "Nous avons détecté que vous êtes actuellement situé dans le fuseau horaire %{browserTZ} au lieu de votre fuseau horaire configuré %{configuredTZ}",
+      "askSwitch": "Voulez-vous basculer l'application vers le fuseau horaire %{browserTZ} ?"
+    },
     "notifications.empty": "Paramètres de notifications à venir",
     "notifications.email": "Email",
     "notifications.deliveryMethod": "Mode de réception",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -275,6 +275,10 @@
     "timeZone": "Часовой пояс",
     "timeZoneBrowserDefault": "Определять часовой пояс автоматически",
     "timeZoneUpdateError": "Не удалось обновить часовой пояс",
+    "tzPrompt": {
+      "detected": "Мы обнаружили, что вы находитесь в часовом поясе %{browserTZ} вместо вашего настроенного часового пояса %{configuredTZ}",
+      "askSwitch": "Хотите переключить приложение на часовой пояс %{browserTZ}?"
+    },
     "notifications.empty": "Настройки уведомлений скоро появятся",
     "notifications.email": "Email",
     "notifications.deliveryMethod": "Способ доставки",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -273,6 +273,10 @@
     "timeZone": "Múi giờ",
     "timeZoneBrowserDefault": "Tự động phát hiện múi giờ",
     "timeZoneUpdateError": "Không cập nhật được múi giờ",
+    "tzPrompt": {
+      "detected": "Chúng tôi phát hiện bạn đang ở múi giờ %{browserTZ} thay vì múi giờ %{configuredTZ} đã cấu hình",
+      "askSwitch": "Bạn có muốn chuyển ứng dụng sang múi giờ %{browserTZ} không?"
+    },
     "notifications.empty": "Cài đặt thông báo sắp có",
     "notifications.email": "Email",
     "notifications.deliveryMethod": "Phương thức gửi",

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -38,5 +38,7 @@ declare global {
     __calendarRef: MutableRefObject<CalendarApi | null>
 
     DISABLE_PUBLIC_VISIBILITY: boolean
+
+    ASK_FOR_TZ_UPDATE: boolean
   }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added timezone change detection feature that prompts users when their browser's timezone differs from the app's configured setting, with options to accept the change or decline and keep current settings.
  * Added multi-language support for timezone change prompts (English, French, Russian, Vietnamese).

* **Tests**
  * Added comprehensive test suite for timezone change detection and update functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/895)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->