### PR TITLE
[#896] fixed condition to use selected range for date

### DIFF
--- a/__test__/features/Calendars/TimezoneInGrid.test.tsx
+++ b/__test__/features/Calendars/TimezoneInGrid.test.tsx
@@ -4,7 +4,7 @@ import { updateSlotLabelVisibility } from '@/components/Calendar/utils/calendarU
 import EventPreviewModal from '@/features/Events/EventPreview'
 import { CalendarEvent } from '@/features/Events/EventsTypes'
 import * as SettingsSlice from '@/features/Settings/SettingsSlice'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../../utils/Renderwithproviders'
 
 describe('Calendar - Timezone Integration', () => {
@@ -88,6 +88,65 @@ describe('Calendar - Timezone Integration', () => {
     fireEvent.click(option)
 
     expect(setTimeZoneSpy).toHaveBeenCalledWith('Asia/Tokyo')
+  })
+
+  it('bugfix : temp timezone opens event with the time offseted', async () => {
+    const setTimeZoneSpy = jest.spyOn(SettingsSlice, 'setTimeZone')
+
+    renderWithProviders(
+      <CalendarApp
+        setCurrentView={jest.fn()}
+        onViewChange={jest.fn()}
+        openSidebar={false}
+        onCloseSidebar={jest.fn()}
+        currentView="timeGridWeek"
+        calendarRef={mockCalendarRef}
+      />,
+      baseState
+    )
+
+    // Find and click timezone selector
+    await waitFor(() => {
+      const timezoneButton = screen.getByText(/UTC/i)
+      fireEvent.click(timezoneButton)
+
+      // Select a different timezone
+      const autocomplete = screen.getByRole('combobox')
+      fireEvent.change(autocomplete, { target: { value: 'Jakarta' } })
+    })
+    const option = await screen.findByText(/Jakarta/i)
+    fireEvent.click(option)
+
+    expect(setTimeZoneSpy).toHaveBeenCalledWith('Asia/Jakarta')
+
+    const slot = document.querySelector('[data-time="14:00:00"]')
+
+    expect(slot).toBeInTheDocument()
+
+    fireEvent.mouseDown(slot!)
+    fireEvent.mouseMove(slot!)
+    fireEvent.mouseUp(slot!)
+
+    await waitFor(() => {
+      expect(window.__calendarRef?.current).toBeTruthy()
+    })
+
+    const calendarApi = window.__calendarRef.current
+
+    act(() => {
+      calendarApi?.select({
+        start: '2026-05-11T14:00:00',
+        end: '2026-05-11T14:30:00'
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('14:00 - 14:30')).toBeInTheDocument()
+    })
   })
 })
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -603,7 +603,6 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
         )}
         {view === 'search' && <SearchResultsPage />}
         <EventPopover
-          anchorEl={anchorEl}
           open={Boolean(anchorEl)}
           onClose={eventHandlers.handleClosePopover}
           selectedRange={selectedRange}

--- a/src/components/Event/hooks/useBuildInitialValues.ts
+++ b/src/components/Event/hooks/useBuildInitialValues.ts
@@ -85,7 +85,6 @@ export const useBuildInitialValues = ({
       selectedRange,
       event
     )
-    console.log({ isInitFromSelectedRange })
     if (isInitFromSelectedRange) {
       return {
         ...defaultEvent,

--- a/src/components/Event/hooks/useBuildInitialValues.ts
+++ b/src/components/Event/hooks/useBuildInitialValues.ts
@@ -28,7 +28,7 @@ const isValidToInitBySelectedRange = (
 
   const isEventNew = !event?.start && !event?.end
 
-  return isEventNew || selectedRange.allDay
+  return !isEventNew || selectedRange.allDay
 }
 
 export const useBuildInitialValues = ({

--- a/src/components/Event/hooks/useBuildInitialValues.ts
+++ b/src/components/Event/hooks/useBuildInitialValues.ts
@@ -26,7 +26,7 @@ const isValidToInitBySelectedRange = (
   if (!selectedRange) return false
   if (!selectedRange.start || !selectedRange.end) return false
 
-  const isEventNew = !event?.start && !event?.end
+  const isEventNew = !event?.uid
 
   return isEventNew || selectedRange.allDay
 }
@@ -85,6 +85,7 @@ export const useBuildInitialValues = ({
       selectedRange,
       event
     )
+    console.log({ isInitFromSelectedRange })
     if (isInitFromSelectedRange) {
       return {
         ...defaultEvent,

--- a/src/components/Event/hooks/useBuildInitialValues.ts
+++ b/src/components/Event/hooks/useBuildInitialValues.ts
@@ -28,7 +28,7 @@ const isValidToInitBySelectedRange = (
 
   const isEventNew = !event?.start && !event?.end
 
-  return !isEventNew || selectedRange.allDay
+  return isEventNew || selectedRange.allDay
 }
 
 export const useBuildInitialValues = ({

--- a/src/components/Event/utils/eventInitialValuesHelpers.ts
+++ b/src/components/Event/utils/eventInitialValuesHelpers.ts
@@ -62,7 +62,7 @@ export function buildFromExistingEvent({
     ? resolveTimezone(event.timezone)
     : resolvedCalendarTimezone
 
-  const { start, end } = formatEventDates(event, isAllDay, eventTimezone)
+  const { start, end } = formatEventDates(event, isAllDay)
   const description = resolveDescription(event)
   const { repetition, showRepeat } = resolveRepetition(event, calId, calList)
   const organizerEmail = resolveOrganizerEmail(event, organizer)

--- a/src/components/Event/utils/initialValues/dateResolvers.ts
+++ b/src/components/Event/utils/initialValues/dateResolvers.ts
@@ -1,8 +1,5 @@
 import { CalendarEvent } from '@/features/Events/EventsTypes'
-import {
-  formatDateTimeInTimezone,
-  formatLocalDateTime
-} from '@/components/Event/utils/dateTimeFormatters'
+import { formatLocalDateTime } from '@/components/Event/utils/dateTimeFormatters'
 import { DateSelectArg } from '@fullcalendar/core'
 import { EventFormValues } from '@/components/Event/EventFormFields.types'
 
@@ -11,13 +8,12 @@ import { EventFormValues } from '@/components/Event/EventFormFields.types'
  */
 export function formatEventDates(
   event: CalendarEvent,
-  isAllDay: boolean,
-  eventTimezone: string
+  isAllDay: boolean
 ): { start: string; end: string } {
   const start = event.start
     ? isAllDay
       ? new Date(event.start).toISOString().split('T')[0]
-      : formatDateTimeInTimezone(event.start, eventTimezone)
+      : formatLocalDateTime(new Date(event.start), event.timezone)
     : ''
 
   if (!event.end) {
@@ -30,7 +26,10 @@ export function formatEventDates(
     return { start, end: endDate.toISOString().split('T')[0] }
   }
 
-  return { start, end: formatDateTimeInTimezone(event.end, eventTimezone) }
+  return {
+    start,
+    end: formatLocalDateTime(new Date(event.end), event.timezone)
+  }
 }
 
 /**
@@ -111,8 +110,8 @@ export function buildDefaultNewEvent(
 
   return {
     ...base,
-    start: formatLocalDateTime(nextHour) ?? '',
-    end: formatLocalDateTime(endTime) ?? '',
+    start: formatLocalDateTime(nextHour, base.timezone) ?? '',
+    end: formatLocalDateTime(endTime, base.timezone) ?? '',
     allday: false
   }
 }


### PR DESCRIPTION
resolves #896 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed events opening/creating with incorrect time offsets after changing calendar timezone.
  * Improved when the UI treats an event as “new”, making selected-range event creation more consistent.

* **Tests**
  * Added a regression test verifying event selection and preview show the correct time range after timezone changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/897)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->