### PR TITLE
#898 adjust display condition of RSVP on read-only subscribed calendar

### DIFF
--- a/__test__/features/Events/AttendanceValidation.delegated.test.tsx
+++ b/__test__/features/Events/AttendanceValidation.delegated.test.tsx
@@ -69,7 +69,7 @@ describe('AttendanceValidation - delegation', () => {
       expect(container.firstChild).not.toBeNull()
     })
 
-    it('renders when not isOwn but currentUserAttendee exists', () => {
+    it('returns null when not isOwn but currentUserAttendee exists', () => {
       const { container } = render(
         <AttendanceValidation
           contextualizedEvent={makeContext({ isOwn: false })}
@@ -78,7 +78,7 @@ describe('AttendanceValidation - delegation', () => {
           setOpenEditModePopup={noopSetFunc}
         />
       )
-      expect(container.firstChild).not.toBeNull()
+      expect(container.firstChild).toBeNull()
     })
 
     it('returns null when not isOwn, not delegated, and not an attendee', () => {

--- a/src/features/Events/AttendanceValidation/useAttendanceValidationAuthorization.ts
+++ b/src/features/Events/AttendanceValidation/useAttendanceValidationAuthorization.ts
@@ -38,7 +38,7 @@ export function useAttendanceValidationAuthorization(
   const createByTheUser = !!(currentUserAttendee || noAttendeesOrOrganizer)
 
   const isAuthorized =
-    createByTheUser ||
+    (createByTheUser && isOwn) ||
     isOwn ||
     checkIsDelegatedPublicEvent(calendar, event) ||
     checkIsAdminOfResource(calendar.owner, openpaasId)


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/898

In case the calendar is public, but if creator of the event is not owner or does not have edit rights to the calendar, RSVP buttons cannot display