### PR TITLE
#900 update to correct organizer when creating event

### DIFF
--- a/__test__/features/Events/EventModal.test.tsx
+++ b/__test__/features/Events/EventModal.test.tsx
@@ -111,17 +111,22 @@ describe('EventPopover', () => {
     resource: undefined
   } as unknown as DateSelectArg
 
-  const renderPopover = (selectedRange = defaultSelectedRange) => {
+  const renderPopover = (
+    selectedRange = defaultSelectedRange,
+    state = preloadedState
+  ) => {
+    const el = document.createElement('div')
+    document.body.appendChild(el)
     renderWithProviders(
       <EventPopover
-        anchorEl={document.body}
+        anchorEl={el}
         open={true}
         onClose={mockOnClose}
         selectedRange={selectedRange}
         setSelectedRange={mockSetSelectedRange}
         calendarRef={mockCalendarRef}
       />,
-      preloadedState
+      state
     )
   }
 
@@ -240,6 +245,62 @@ describe('EventPopover', () => {
     const calendarSelect = screen.getByRole('combobox', { name: /Calendar/i })
     expect(calendarSelect).toHaveTextContent('Calendar 2')
   })
+
+  it('updates organizer to calendar owner when changing to a delegated calendar', async () => {
+    const customState = {
+      ...preloadedState,
+      calendars: {
+        ...preloadedState.calendars,
+        list: {
+          ...preloadedState.calendars.list,
+          'otherUser/cal3': {
+            id: 'otherUser/cal3',
+            name: 'Calendar 3',
+            color: '#0000FF',
+            delegated: true,
+            access: { write: true },
+            link: 'https://example.com/calendar.json',
+            owner: {
+              emails: ['owner@example.com'],
+              firstname: 'Owner',
+              lastname: 'User'
+            }
+          }
+        }
+      }
+    }
+
+    renderPopover(defaultSelectedRange, customState)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.moreOptions' }))
+    const select = screen.getByLabelText('event.form.calendar')
+    fireEvent.mouseDown(select)
+
+    const option = await screen.findByText('Calendar 3')
+    fireEvent.click(option)
+
+    const spy = jest
+      .spyOn(eventThunks, 'putEventAsync')
+      .mockImplementation(payload => {
+        const promise = Promise.resolve(payload)
+        ;(promise as any).unwrap = () => promise
+        return () => promise as any
+      })
+
+    fireEvent.click(screen.getByRole('button', { name: 'actions.save' }))
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalled()
+    })
+
+    const receivedPayload = spy.mock.calls[0][0]
+
+    expect(receivedPayload.newEvent.organizer).toEqual({
+      cn: 'Owner User',
+      cal_address: 'owner@example.com'
+    })
+  })
+
   it('adds a attendee', async () => {
     jest.useFakeTimers()
     try {

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -150,7 +150,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
           fromError: false
         })
 
-        await onSubmit(values)
+        await onSubmit(values, organizerRef.current)
       },
       cancel: (): void => {
         onCancel()

--- a/src/components/Event/EventFormFields.types.ts
+++ b/src/components/Event/EventFormFields.types.ts
@@ -87,7 +87,10 @@ export interface EventFormFieldsProps {
   userPersonalCalendars: Calendar[]
 
   // Save / cancel delegation
-  onSubmit: (values: EventFormValues) => Promise<void>
+  onSubmit: (
+    values: EventFormValues,
+    organizer?: { cn: string; cal_address: string }
+  ) => Promise<void>
   onCancel: () => void
 
   // Temp-storage context

--- a/src/features/Events/EventModal.tsx
+++ b/src/features/Events/EventModal.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { Calendar } from '../Calendars/CalendarTypes'
 import { CalendarEvent } from './EventsTypes'
-import { useEventOrganizer } from './useEventOrganizer'
 import { useCalendarPreviewSync } from '@/components/Event/hooks/useCalendarPreviewSync'
 import { EventActions } from './EventActions'
 import { useBuildInitialValues } from '@/components/Event/hooks/useBuildInitialValues'
@@ -33,7 +32,6 @@ const EventPopover: React.FC<{
 
   const userId = useAppSelector(state => state.user.userData?.openpaasId) ?? ''
   const calList = useAppSelector(state => state.calendars.list)
-  const userOrganizer = useAppSelector(state => state.user.organiserData)
 
   const [showMore, setShowMore] = useState(false)
   const formRef = useRef<EventFormHandle>(null)
@@ -41,12 +39,6 @@ const EventPopover: React.FC<{
   const initialValues = useBuildInitialValues({
     event,
     selectedRange: open ? selectedRange : null
-  })
-
-  const { organizer } = useEventOrganizer({
-    calendarid: initialValues.calendarid ?? '',
-    calList,
-    userOrganizer
   })
 
   const userPersonalCalendars: Calendar[] = Object.values(calList || {}).filter(
@@ -72,8 +64,7 @@ const EventPopover: React.FC<{
   const { handleSubmit } = useSubmitCreateEvent({
     showMore,
     onClose: () => onClose(true),
-    userPersonalCalendars,
-    organizer
+    userPersonalCalendars
   })
 
   const handleClose = useCallback(() => {

--- a/src/features/Events/hooks/useSubmitCreateEvent.ts
+++ b/src/features/Events/hooks/useSubmitCreateEvent.ts
@@ -8,22 +8,26 @@ export interface UseSubmitCreateEventProps {
   showMore: boolean
   onClose: (refresh?: boolean) => void
   userPersonalCalendars: Calendar[]
-  organizer?: { cn: string; cal_address: string }
 }
 
 export function useSubmitCreateEvent({
   showMore,
   onClose,
-  userPersonalCalendars,
-  organizer
+  userPersonalCalendars
 }: UseSubmitCreateEventProps): {
-  handleSubmit: (values: EventFormValues) => Promise<void>
+  handleSubmit: (
+    values: EventFormValues,
+    organizer?: { cn: string; cal_address: string }
+  ) => Promise<void>
 } {
   const dispatch = useAppDispatch()
   const calList = useAppSelector(state => state.calendars.list)
 
   const handleSubmit = useCallback(
-    async (values: EventFormValues): Promise<void> => {
+    async (
+      values: EventFormValues,
+      organizer?: { cn: string; cal_address: string }
+    ): Promise<void> => {
       const targetCalendar: Calendar | undefined =
         calList[values.calendarid] ||
         userPersonalCalendars[0] ||
@@ -43,7 +47,7 @@ export function useSubmitCreateEvent({
         onClose
       })
     },
-    [showMore, onClose, userPersonalCalendars, organizer, dispatch, calList]
+    [showMore, onClose, userPersonalCalendars, dispatch, calList]
   )
 
   return { handleSubmit }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/900

- When creating an event: Change calendar that you're not the owner => The event will be created with wrong organizer (expect the owner of the selected calandar is organizer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event submissions now include the correct organizer (name and calendar address), including when saving to a delegated calendar.
* **Tests**
  * Added test coverage verifying organizer is set correctly when changing calendar selection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/901)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->