### PR TITLE
#623 implement error boundary to handle white page of death

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react": "^18.2.0",
         "react-colorful": "^5.6.1",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^6.1.1",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.23.1",
         "react-virtuoso": "^4.18.5",
@@ -12516,6 +12517,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.1.tgz",
+      "integrity": "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^18.2.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^6.1.1",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.23.1",
     "react-virtuoso": "^4.18.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react'
 import { TwakeMuiThemeProvider } from '@linagora/twake-mui'
 import { Suspense, useEffect } from 'react'
 import { Route, Routes } from 'react-router-dom'
@@ -9,6 +10,7 @@ import { history } from './app/store'
 import { default as CalendarLayout } from './components/Calendar/CalendarLayout'
 import { Error as ErrorPage } from './components/Error/Error'
 import { ErrorSnackbar } from './components/Error/ErrorSnackbar'
+import { ErrorBoundary } from 'react-error-boundary'
 import { Loading } from './components/Loading/Loading'
 import { AVAILABLE_LANGUAGES } from './features/Settings/constants'
 import { default as HandleLogin } from './features/User/HandleLogin'
@@ -70,19 +72,34 @@ function App(): JSX.Element {
         lang={lang}
         locales={dateLocales}
       >
-        <Suspense fallback={<Loading />}>
-          <WebSocketGate />
-          <Router history={history}>
-            <Routes>
-              <Route path="/" element={<HandleLogin />} />
-              <Route path="/calendar" element={<CalendarLayout />} />
-              <Route path="/callback" element={<CallbackResume />} />
-              <Route path="/error" element={<ErrorPage />} />
-            </Routes>
-          </Router>
-          <ErrorSnackbar error={error} type="user" />
-        </Suspense>
-        {appLoading && <Loading />}
+        <ErrorBoundary
+          FallbackComponent={({ error }) => (
+            <ErrorPage isCrashFallback errorBoundaryMessage={error as Error} />
+          )}
+          onError={(error, errorInfo) => {
+            Sentry.captureException(error, {
+              contexts: {
+                react: {
+                  componentStack: errorInfo.componentStack
+                }
+              }
+            })
+          }}
+        >
+          <Suspense fallback={<Loading />}>
+            <WebSocketGate />
+            <Router history={history}>
+              <Routes>
+                <Route path="/" element={<HandleLogin />} />
+                <Route path="/calendar" element={<CalendarLayout />} />
+                <Route path="/callback" element={<CallbackResume />} />
+                <Route path="/error" element={<ErrorPage />} />
+              </Routes>
+            </Router>
+            <ErrorSnackbar error={error} type="user" />
+          </Suspense>
+          {appLoading && <Loading />}
+        </ErrorBoundary>
       </I18n>
     </TwakeMuiThemeProvider>
   )

--- a/src/components/Error/Error.tsx
+++ b/src/components/Error/Error.tsx
@@ -12,19 +12,30 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import ReplayIcon from '@mui/icons-material/Replay'
 import { useI18n } from 'twake-i18n'
 
-export const Error: React.FC = () => {
+interface ErrorProps {
+  isCrashFallback?: boolean
+  errorBoundaryMessage?: Error
+}
+
+export const Error: React.FC<ErrorProps> = ({
+  isCrashFallback,
+  errorBoundaryMessage
+}) => {
   const { t } = useI18n()
   const userError = useAppSelector(state => state.user.error)
   const calendarError = useAppSelector(state => state.calendars.error)
   const initialError = useRef(userError || calendarError)
 
   useEffect(() => {
-    if (!initialError.current) {
+    if (!initialError.current && !isCrashFallback) {
       window.location.replace('/')
     }
-  }, [])
+  }, [isCrashFallback])
 
-  const errorMessage = userError || calendarError || t('error.unknown')
+  const errorMessage =
+    userError ||
+    calendarError ||
+    (isCrashFallback ? errorBoundaryMessage?.message : t('error.unknown'))
 
   return (
     <Fade in timeout={500}>


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/623

In React, the White Screen of Death happens only when a component crashes during the rendering phase. The ErrorBoundary catches that crash, prevents the white screen, and fallback to our ErrorPage (which contains message and refresh button).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented application-wide error boundary to gracefully handle and recover from unexpected runtime errors during normal operation.
  * Added enhanced error recovery with a dedicated fallback interface that displays when critical application failures occur, providing clear error messaging and recovery guidance to users.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/903)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->