### PR TITLE
#871 auto set accept when creating event from other client

### DIFF
--- a/__test__/features/Events/EventDisplay.test.tsx
+++ b/__test__/features/Events/EventDisplay.test.tsx
@@ -151,8 +151,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -180,8 +180,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -195,8 +195,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'otherCal/cal'}
-        eventId={'event1'}
+        calId="otherCal/cal"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -212,8 +212,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -226,8 +226,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -291,8 +291,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       rsvpStateIsOrga
     )
@@ -345,8 +345,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       rsvpStateIsOrga
     )
@@ -408,8 +408,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       rsvpState
     )
@@ -469,8 +469,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       rsvpState
     )
@@ -530,8 +530,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       rsvpState
     )
@@ -552,8 +552,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event4'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event4"
       />,
       preloadedState
     )
@@ -570,8 +570,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'otherCal/cal'}
-        eventId={'event2'}
+        calId="otherCal/cal"
+        eventId="event2"
       />,
       preloadedState
     )
@@ -585,8 +585,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -603,8 +603,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -617,8 +617,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event2'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event2"
       />,
       preloadedState
     )
@@ -629,8 +629,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -645,8 +645,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event1'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event1"
       />,
       preloadedState
     )
@@ -720,8 +720,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'eventWithSpecialChars'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="eventWithSpecialChars"
       />,
       specialCharState
     )
@@ -939,8 +939,8 @@ describe('Event Preview Display', () => {
       <EventPreviewModal
         open={true}
         onClose={mockOnClose}
-        calId={'667037022b752d0026472254/cal1'}
-        eventId={'event3'}
+        calId="667037022b752d0026472254/cal1"
+        eventId="event3"
       />,
       preloadedState
     )
@@ -1033,8 +1033,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1078,8 +1078,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1123,8 +1123,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1184,8 +1184,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1229,8 +1229,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1251,14 +1251,17 @@ describe('Event Preview Display', () => {
     })
 
     describe('No display when count is 0', () => {
-      it('does not display attendee preview when no attendees', () => {
+      it('does not display attendee preview when no attendees and no organizer', () => {
         const state = createStateWithAttendees([])
+        delete state.calendars.list['667037022b752d0026472254/cal1'].events
+          .event1.organizer
+
         renderWithProviders(
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1320,8 +1323,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1389,8 +1392,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1450,8 +1453,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1495,8 +1498,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1537,8 +1540,8 @@ describe('Event Preview Display', () => {
           <EventPreviewModal
             open={true}
             onClose={mockOnClose}
-            calId={'667037022b752d0026472254/cal1'}
-            eventId={'event1'}
+            calId="667037022b752d0026472254/cal1"
+            eventId="event1"
           />,
           state
         )
@@ -1740,8 +1743,8 @@ describe('Event Preview Display', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'event1'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="event1"
         />,
         allDayState
       )

--- a/src/components/Event/EventChip/EventChip.tsx
+++ b/src/components/Event/EventChip/EventChip.tsx
@@ -22,6 +22,7 @@ import {
   IconDisplayConfig,
   useCompactMode
 } from './EventChipUtils'
+import { userAttendee } from '@/features/User/models/attendee'
 
 const PRIVATE_CLASSIFICATIONS = ['PRIVATE', 'CONFIDENTIAL']
 
@@ -31,12 +32,12 @@ export const EVENT_DURATION = {
   LONG: 60
 } as const
 
-export function EventChip({
+export const EventChip: React.FC<EventChipProps> = ({
   arg,
   calendars,
   tempcalendars,
   errorHandler
-}: EventChipProps) {
+}) => {
   const cardRef = useRef<HTMLDivElement>(null)
   const showCompact = useCompactMode(cardRef)
 
@@ -47,18 +48,25 @@ export function EventChip({
   try {
     // Calendar validation
     const calendarsSource = temp ? tempcalendars : calendars
-    const calendar = calendarsSource[calId]
+    const calendar = calendarsSource[calId as string]
     if (!calendar) return null
 
     // Event properties
-    const isPrivate = PRIVATE_CLASSIFICATIONS.includes(classification)
+    const isPrivate = PRIVATE_CLASSIFICATIONS.includes(classification as string)
     const ownerEmails = new Set(
       calendar.owner?.emails?.map(e => e.toLowerCase())
     )
     // const delegated = calendar.delegated;
 
     // Determine owner attendee
-    const ownerAttendee = getOwnerAttendee(attendees, ownerEmails)
+    const ownerAttendee = getOwnerAttendee(
+      attendees as userAttendee[],
+      ownerEmails
+    )
+
+    // Presentation trick: if owner is not an attendee (e.g. created from external app like Apple Calendar),
+    // treat them as ACCEPTED to show the event filled rather than blank.
+    const displayPartstat = ownerAttendee?.partstat || 'ACCEPTED'
 
     // Color and contrast logic
     const bestColor = getBestColor(
@@ -89,7 +97,7 @@ export function EventChip({
     // Style calculation
     const titleStyle = getTitleStyle(
       bestColor,
-      ownerAttendee?.partstat,
+      displayPartstat,
       calendar,
       isPrivate
     )
@@ -97,17 +105,18 @@ export function EventChip({
     const cardStyle = getCardStyle(
       bestColor,
       eventLength,
-      ownerAttendee?.partstat,
+      displayPartstat,
       calendar,
       isPrivate
     )
 
     // Organizer avatar
-    const OrganizerAvatar = event._def.extendedProps.organizer
-      ? stringAvatar(
-          event._def.extendedProps.organizer?.cn ??
-            event._def.extendedProps.organizer?.cal_address
-        )
+    const organizer = event._def.extendedProps.organizer as
+      | { cn?: string; cal_address?: string }
+      | undefined
+
+    const OrganizerAvatar = organizer
+      ? stringAvatar(organizer.cn ?? organizer.cal_address ?? '')
       : { color: undefined, children: null }
 
     return (

--- a/src/components/Event/EventChip/EventChipUtils.tsx
+++ b/src/components/Event/EventChip/EventChipUtils.tsx
@@ -13,7 +13,7 @@ import { EVENT_DURATION } from './EventChip'
 const COMPACT_WIDTH_THRESHOLD = 100
 
 export interface EventChipProps {
-  arg: EventContentArg['event']
+  arg: EventContentArg
   calendars: Record<string, Calendar>
   tempcalendars: Record<string, Calendar>
   errorHandler: EventErrorHandler

--- a/src/components/Event/utils/eventInitialValuesHelpers.ts
+++ b/src/components/Event/utils/eventInitialValuesHelpers.ts
@@ -88,8 +88,9 @@ export function buildFromExistingEvent({
     repetition,
     attendees,
     alarm: event.alarm?.trigger ?? '',
-    eventClass:
-      event.class ?? (window.DISABLE_PUBLIC_VISIBILITY ? 'PRIVATE' : 'PUBLIC'),
+    eventClass: window.DISABLE_PUBLIC_VISIBILITY
+      ? 'PRIVATE'
+      : (event.class ?? 'PUBLIC'),
     busy: event.transp ?? 'OPAQUE',
     timezone: eventTimezone,
     calendarid: formCalendarId,

--- a/src/features/Events/AttendanceValidation/RSVPButton.tsx
+++ b/src/features/Events/AttendanceValidation/RSVPButton.tsx
@@ -1,5 +1,5 @@
 import { useAppDispatch } from '@/app/hooks'
-import { PartStat } from '@/features/User/models/attendee'
+import { PartStat, userAttendee } from '@/features/User/models/attendee'
 import { userData } from '@/features/User/userDataTypes'
 import { Box, Button, CircularProgress, Theme } from '@linagora/twake-mui'
 import Tooltip from '@/components/Tooltip'
@@ -29,7 +29,33 @@ interface RSVPButtonProps {
   loadingValue: PartStat | null
 }
 
-export function RSVPButton({
+function useClearLoadingOnStatusChange(
+  currentUserAttendee: userAttendee | undefined,
+  isLoading: boolean,
+  onLoadingChange: (loading: boolean, value?: PartStat) => void
+): React.MutableRefObject<PartStat | undefined> {
+  const previousPartstatRef = useRef<PartStat | undefined>(
+    currentUserAttendee?.partstat
+  )
+
+  useEffect(() => {
+    const currentPartstat = currentUserAttendee?.partstat
+
+    const statusChanged =
+      previousPartstatRef.current !== undefined &&
+      currentPartstat !== previousPartstatRef.current
+
+    if (isLoading && statusChanged) {
+      onLoadingChange(false)
+    }
+
+    previousPartstatRef.current = currentPartstat
+  }, [currentUserAttendee?.partstat, isLoading, onLoadingChange])
+
+  return previousPartstatRef
+}
+
+export const RSVPButton: React.FC<RSVPButtonProps> = ({
   rsvpValue,
   contextualizedEvent,
   user,
@@ -38,36 +64,28 @@ export function RSVPButton({
   isLoading,
   onLoadingChange,
   loadingValue
-}: RSVPButtonProps) {
+}) => {
   const { t } = useI18n()
   const dispatch = useAppDispatch()
   const { currentUserAttendee, calendar } = contextualizedEvent
+
+  const effectivePartstat =
+    currentUserAttendee?.partstat ||
+    (contextualizedEvent.isOwn ? 'ACCEPTED' : undefined)
   const showLoading = isLoading && loadingValue === rsvpValue
   const isReadDelegated =
     calendar.delegated && calendar.access?.read && !calendar.access?.write
-  const previousPartstatRef = useRef<PartStat | undefined>(
-    currentUserAttendee?.partstat
+
+  const previousPartstatRef = useClearLoadingOnStatusChange(
+    currentUserAttendee,
+    isLoading,
+    onLoadingChange
   )
 
-  // Detect when attendee status changes (via WebSocket) and clear loading
-  useEffect(() => {
-    const currentPartstat = currentUserAttendee?.partstat
-
-    if (
-      isLoading &&
-      previousPartstatRef.current !== undefined &&
-      currentPartstat !== previousPartstatRef.current
-    ) {
-      onLoadingChange(false)
-    }
-
-    previousPartstatRef.current = currentPartstat
-  }, [currentUserAttendee?.partstat, isLoading, rsvpValue, onLoadingChange])
-
-  const handleClick = async () => {
+  const handleClick = async (): Promise<void> => {
     // Store current partstat before making changes
     previousPartstatRef.current = currentUserAttendee?.partstat
-    if (previousPartstatRef.current === rsvpValue) {
+    if (effectivePartstat === rsvpValue) {
       return
     }
     // For recurring events, don't set loading yet - wait for modal choice
@@ -95,7 +113,7 @@ export function RSVPButton({
     }
   }
 
-  const isCurrentlyActive = currentUserAttendee?.partstat === rsvpValue
+  const isCurrentlyActive = effectivePartstat === rsvpValue
 
   // Show as active (colored) if:
   // 1. This button is currently loading, OR

--- a/src/features/Events/EventPreview/EventPreviewDetails.tsx
+++ b/src/features/Events/EventPreview/EventPreviewDetails.tsx
@@ -14,6 +14,7 @@ import { CalendarEvent } from '../EventsTypes'
 import { EventPreviewAttendees } from './EventPreviewAttendees'
 import { makeRecurrenceString } from './utils/makeRecurrenceString'
 import { renderAttendeeBadge } from '@/components/Event/utils/eventUtils'
+import { userAttendee } from '@/features/User/models/attendee'
 
 interface EventPreviewDetailsProps {
   event: CalendarEvent
@@ -62,11 +63,20 @@ export function EventPreviewDetails({
     eventAttendees?.filter(
       a => a.cal_address !== event.organizer?.cal_address
     ) || []
-  const organizer = eventAttendees?.find(
-    a => a.cal_address === event.organizer?.cal_address
-  )
+  const organizer =
+    eventAttendees?.find(a => a.cal_address === event.organizer?.cal_address) ||
+    ({
+      ...event.organizer,
+      partstat: 'ACCEPTED',
+      role: 'CHAIR',
+      cutype: 'INDIVIDUAL',
+      rsvp: 'FALSE'
+    } as userAttendee)
 
   const showDetails = isNotPrivate || isOwn
+
+  const shouldShowAttendeesSection =
+    attendees.length > 0 || Boolean(organizer?.cal_address || organizer?.cn)
 
   if (!showDetails) {
     return (
@@ -133,7 +143,7 @@ export function EventPreviewDetails({
         renderAttendeeBadge(organizer, 'org', t, true, true)}
 
       {/* Attendees */}
-      {!isResourceEventPreview && attendees.length > 0 && (
+      {!isResourceEventPreview && shouldShowAttendeesSection && (
         <EventPreviewAttendees
           attendees={attendees}
           organizer={organizer}
@@ -237,7 +247,7 @@ export function EventPreviewDetails({
           }
           text={t('eventPreview.alarmText', {
             trigger: t(`event.form.notifications.${event.alarm.trigger}`),
-            action: (() => {
+            action: ((): string => {
               if (!event.alarm.action) return ''
               const translationKey = `event.form.notifications.${event.alarm.action}`
               const translated = t(translationKey)
@@ -262,7 +272,7 @@ export function EventPreviewDetails({
             t,
             startText: `${t('eventPreview.recurrentEvent')} · ${t(
               `eventPreview.freq.${event.repetition.freq}`,
-              event.repetition.freq
+              { defaultValue: event.repetition.freq }
             )}`
           })}
         />

--- a/src/features/Events/EventPreview/utils/makeRecurrenceString.ts
+++ b/src/features/Events/EventPreview/utils/makeRecurrenceString.ts
@@ -4,10 +4,76 @@ const WEEK_DAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
 
 interface MakeRecurrenceStringParams {
   repetition: RepetitionObject
-  t: (k: string, p?: string | object) => string
+  t: (k: string, p?: Record<string, unknown>) => string
   startText: string
   joinChar?: string
   enableStrForOneTimeInterval?: boolean
+}
+
+const getRecurType = (
+  t: (k: string, p?: Record<string, unknown>) => string
+): Record<string, string> => ({
+  daily: t('event.repeat.frequency.days'),
+  weekly: t('event.repeat.frequency.weeks'),
+  monthly: t('event.repeat.frequency.months'),
+  yearly: t('event.repeat.frequency.years')
+})
+
+const getIntervalText = (
+  repetition: RepetitionObject,
+  t: (k: string, p?: Record<string, unknown>) => string,
+  enableStrForOneTimeInterval?: boolean
+): string | undefined => {
+  const interval = repetition.interval ?? 1
+  const recurType = getRecurType(t)
+
+  if (interval === 1 && enableStrForOneTimeInterval) {
+    return recurType[repetition.freq]
+  }
+
+  if (interval > 1) {
+    return t('eventPreview.everyInterval', {
+      interval,
+      unit: recurType[repetition.freq] ?? repetition.freq
+    })
+  }
+
+  return undefined
+}
+
+const getByDayText = (
+  repetition: RepetitionObject,
+  t: (k: string, p?: Record<string, unknown>) => string
+): string | undefined => {
+  if (!repetition.byday) return undefined
+
+  const weekDaysByOrder = WEEK_DAYS.filter(day =>
+    repetition.byday?.includes(day)
+  )
+  return t('eventPreview.recurrenceOnDays', {
+    days: weekDaysByOrder.map(s => t(`eventPreview.onDays.${s}`)).join(', ')
+  })
+}
+
+const getEndConditionText = (
+  repetition: RepetitionObject,
+  t: (k: string, p?: Record<string, unknown>) => string
+): string | undefined => {
+  if (repetition.occurrences) {
+    return t('eventPreview.forOccurrences', {
+      count: repetition.occurrences
+    })
+  }
+  if (repetition.endDate) {
+    return t('eventPreview.until', {
+      date: new Date(repetition.endDate).toLocaleDateString(t('locale'), {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      })
+    })
+  }
+  return undefined
 }
 
 export function makeRecurrenceString({
@@ -21,56 +87,18 @@ export function makeRecurrenceString({
 
   const recur: string[] = [startText]
 
-  const recurType: Record<string, string> = {
-    daily: t('event.repeat.frequency.days'),
-    weekly: t('event.repeat.frequency.weeks'),
-    monthly: t('event.repeat.frequency.months'),
-    yearly: t('event.repeat.frequency.years')
-  }
+  const intervalText = getIntervalText(
+    repetition,
+    t,
+    enableStrForOneTimeInterval
+  )
+  if (intervalText) recur.push(intervalText)
 
-  const interval = repetition.interval ?? 1
+  const byDayText = getByDayText(repetition, t)
+  if (byDayText) recur.push(byDayText)
 
-  if (interval === 1 && enableStrForOneTimeInterval) {
-    recur.push(recurType[repetition.freq])
-  }
+  const endConditionText = getEndConditionText(repetition, t)
+  if (endConditionText) recur.push(endConditionText)
 
-  if (interval > 1) {
-    recur.push(
-      t('eventPreview.everyInterval', {
-        interval,
-        unit: recurType[repetition.freq] ?? repetition.freq
-      })
-    )
-  }
-
-  if (repetition.byday) {
-    const weekDaysByOrder = WEEK_DAYS.filter(day =>
-      repetition.byday?.includes(day)
-    )
-    recur.push(
-      t('eventPreview.recurrenceOnDays', {
-        days: weekDaysByOrder.map(s => t(`eventPreview.onDays.${s}`)).join(', ')
-      })
-    )
-  }
-
-  if (repetition.occurrences) {
-    recur.push(
-      t('eventPreview.forOccurrences', {
-        count: repetition.occurrences
-      })
-    )
-  }
-  if (repetition.endDate) {
-    recur.push(
-      t('eventPreview.until', {
-        date: new Date(repetition.endDate).toLocaleDateString(t('locale'), {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric'
-        })
-      })
-    )
-  }
   return recur.filter(Boolean).join(`${joinChar ?? ','} `)
 }

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -42,5 +42,7 @@ declare global {
     ASK_FOR_TZ_UPDATE: boolean
 
     TOOLTIP_DELAY_MS: number
+
+    displayOrgAvatar: boolean
   }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/871

When creating an event from another calendar app (like thunderbird, calendar in ios,...) the Twake Calendar should automatically display the event as accepted for myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global control for organizer avatar display visibility.

* **Bug Fixes**
  * Improved event privacy setting handling to respect visibility preferences.
  * Enhanced event preview to display organizer information as fallback when needed.
  * Fixed attendees section visibility in event previews.

* **Refactor**
  * Improved RSVP button reliability and loading state management.
  * Streamlined event organizer data handling and display logic.
  * Enhanced recurrence string generation with better end-condition handling.

* **Tests**
  * Expanded test coverage for event display scenarios with organizers and attendees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->