### PR TITLE
#907 remove whitespace in people search component

### DIFF
--- a/src/components/Attendees/AttendeeSearch.tsx
+++ b/src/components/Attendees/AttendeeSearch.tsx
@@ -187,15 +187,6 @@ export const AttendeeSearch: React.FC<{
       }
       onChange={handleOnChange}
       freeSolo
-      inputStyles={{
-        '& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root': {
-          py: 0,
-          display: 'flex',
-          alignItems: 'center',
-          flexWrap: 'wrap',
-          flexDirection: 'row'
-        }
-      }}
     />
   )
 }

--- a/src/components/Attendees/PeopleSearch.tsx
+++ b/src/components/Attendees/PeopleSearch.tsx
@@ -304,8 +304,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
             display: 'flex',
             alignItems: 'center',
             flexWrap: 'wrap',
-            flexDirection: 'row',
-            justifyContent: 'space-between'
+            flexDirection: 'row'
           },
           '& .MuiInputBase-input': {
             maxWidth: '80%'

--- a/src/components/Menubar/EventSearchBar.tsx
+++ b/src/components/Menubar/EventSearchBar.tsx
@@ -324,6 +324,16 @@ const SearchBar: React.FC<{
                 }}
               />
             )}
+            inputStyles={{
+              '& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root': {
+                py: 0,
+                display: 'flex',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+                flexDirection: 'row',
+                justifyContent: 'space-between'
+              }
+            }}
           />
         )}
       </Box>


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/907

There is a weird whitespace in PeopleSearch component

<img width="1050" height="134" alt="image" src="https://github.com/user-attachments/assets/e6b7e865-f076-48b0-bedf-bf81aaaae6bb" />

This bug occurred from this PR https://github.com/linagora/twake-calendar-frontend/pull/853