### PR TITLE
[#746] scroll doesn't reset on weekchange

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -549,7 +549,7 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
                 }}
                 slotDuration="00:30:00"
                 slotLabelInterval="01:00:00"
-                scrollTime="12:00:00"
+                scrollTimeReset={false}
                 unselectAuto={false}
                 allDayText=""
                 slotLabelFormat={{


### PR DESCRIPTION
resolves #746 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar scroll position resetting when switching between different calendar views, improving navigation experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->