### PR TITLE
[#690] added calendar moving in the event preview

### DIFF
--- a/__test__/features/Events/EventRepetition.test.tsx
+++ b/__test__/features/Events/EventRepetition.test.tsx
@@ -102,6 +102,21 @@ const basePreloadedState = {
   }
 } as unknown as RootState
 
+// Master VEVENT fixture (no recurrence-id = master event)
+const masterVeventFixture = [
+  [
+    'vevent',
+    [
+      ['uid', {}, 'text', 'recurring-base'],
+      ['summary', {}, 'text', 'Recurring Event Instance'],
+      ['dtstart', {}, 'date-time', '20250315T100000Z'],
+      ['dtend', {}, 'date-time', '20250315T110000Z']
+      // No recurrence-id — this marks it as the master
+    ],
+    []
+  ]
+] as any
+
 describe('EditModeDialog Component', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -674,7 +689,7 @@ describe('Edit Recurring Event in Full Display', () => {
       )
     const spy = jest
       .spyOn(eventThunks, 'updateEventInstanceAsync')
-      .mockImplementation(payload => {
+      .mockImplementation(() => {
         return () => {
           const promise = Promise.resolve()
           ;(promise as any).unwrap = () => promise
@@ -728,7 +743,7 @@ describe('Edit Recurring Event in Full Display', () => {
 
     const spy = jest
       .spyOn(eventThunks, 'updateSeriesAsync')
-      .mockImplementation(payload => {
+      .mockImplementation(() => {
         return () => {
           const promise = Promise.resolve()
           ;(promise as any).unwrap = () => promise
@@ -1208,6 +1223,15 @@ describe('Event URL handling for recurring events', () => {
         ;(promise as any).unwrap = () => promise
         return () => promise as any
       })
+    jest.spyOn(eventThunks, 'putEventAsync').mockImplementation(payload => {
+      const result = { calId: payload.cal.id, events: [] }
+      const promise = Promise.resolve(result)
+      ;(promise as any).unwrap = () => promise
+      return () => promise as any
+    })
+    jest
+      .spyOn(EventDao, 'fetchAllRecurrentVevents')
+      .mockResolvedValue(masterVeventFixture)
 
     const twoCalState = {
       user: {

--- a/src/components/Event/components/SectionPreviewRow.tsx
+++ b/src/components/Event/components/SectionPreviewRow.tsx
@@ -23,7 +23,7 @@ export const SectionPreviewRow: React.FC<SectionPreviewRowProps> = ({
   const theme = useTheme()
   const color = iconColor ?? alpha(theme.palette.grey[900], 0.9)
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent): void => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       onClick()

--- a/src/components/Event/components/SectionPreviewRow.tsx
+++ b/src/components/Event/components/SectionPreviewRow.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, useTheme } from '@linagora/twake-mui'
+import { Box, radius, Typography, useTheme } from '@linagora/twake-mui'
 import { alpha } from '@mui/material/styles'
 import React from 'react'
 
@@ -41,7 +41,7 @@ export const SectionPreviewRow: React.FC<SectionPreviewRowProps> = ({
         alignItems: 'center',
         cursor: 'pointer',
         padding: '8px 0px',
-        borderRadius: '4px',
+        borderRadius: radius.sm,
         '&:hover': {
           backgroundColor: 'action.hover'
         }

--- a/src/components/Event/components/SectionPreviewRow.tsx
+++ b/src/components/Event/components/SectionPreviewRow.tsx
@@ -40,7 +40,7 @@ export const SectionPreviewRow: React.FC<SectionPreviewRowProps> = ({
         display: 'flex',
         alignItems: 'center',
         cursor: 'pointer',
-        padding: '8px 12px',
+        padding: '8px 0px',
         borderRadius: '4px',
         '&:hover': {
           backgroundColor: 'action.hover'

--- a/src/features/Calendars/CalendarSlice.ts
+++ b/src/features/Calendars/CalendarSlice.ts
@@ -100,6 +100,9 @@ const CalendarSlice = createSlice({
       if (!state.list[action.payload]) return
       state.list[action.payload].lastCacheCleared = Date.now()
     },
+    setCalendarError: (state, action: PayloadAction<string>) => {
+      state.error = action.payload
+    },
     clearError: state => {
       state.error = null
     },
@@ -558,6 +561,7 @@ export const {
   removeTempCal,
   emptyEventsCal,
   clearFetchCache,
+  setCalendarError,
   clearError,
   updateCalColor,
   setIsMobileSearchOpen

--- a/src/features/Events/EventPreview/EventPreviewModal.tsx
+++ b/src/features/Events/EventPreview/EventPreviewModal.tsx
@@ -1,10 +1,10 @@
-import { CalendarName } from '@/components/Calendar/CalendarName'
 import { formatEventChipTitle } from '@/components/Calendar/utils/calendarUtils'
 import ResponsiveDialog from '@/components/Dialog/ResponsiveDialog'
 import { EditModeDialog } from '@/components/Event/EditModeDialog'
+import { CalendarSelectField } from '@/components/Event/fields/CalendarSelectField'
+import Tooltip from '@/components/Tooltip'
 import { DateSelectArg } from '@fullcalendar/core'
 import { Box, Chip, Typography } from '@linagora/twake-mui'
-import Tooltip from '@/components/Tooltip'
 import CircleIcon from '@mui/icons-material/Circle'
 import LockOutlineIcon from '@mui/icons-material/LockOutline'
 import { useEffect } from 'react'
@@ -15,9 +15,9 @@ import { EventPreviewActionMenu } from '../EventPreview/EventPreviewActionMenu'
 import { EventPreviewDetails } from '../EventPreview/EventPreviewDetails'
 import { EventPreviewHeader } from '../EventPreview/EventPreviewHeader'
 import { useEventPreviewState } from '../EventPreview/useEventPreviewState'
+import { CalendarEvent } from '../EventsTypes'
 import EventUpdateModal from '../EventUpdateModal'
 import { EventTimeSubtitle } from './EventTimeSubtitle'
-import { CalendarEvent } from '../EventsTypes'
 
 interface EventPreviewTitleRowProps {
   event: CalendarEvent
@@ -117,7 +117,10 @@ const EventPreviewModal: React.FC<{
     handleEditClick,
     handleEditInOrganizerCalendar,
     handleDeleteClick,
-    handleDuplicateClick
+    handleDuplicateClick,
+    calendarid,
+    handleCalendarMove,
+    userPersonalCalendars
   } = useEventPreviewState(eventId, calId, tempEvent, open, onClose)
 
   useEffect(
@@ -209,9 +212,12 @@ const EventPreviewModal: React.FC<{
         />
 
         {/* Calendar label */}
-        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 2 }}>
-          <CalendarName calendar={calendar} />
-        </Box>
+        <CalendarSelectField
+          calendarid={calendarid}
+          setCalendarid={handleCalendarMove}
+          userPersonalCalendars={userPersonalCalendars}
+          showMore={false}
+        />
       </ResponsiveDialog>
 
       {/* Action menu (more vert) */}

--- a/src/features/Events/EventPreview/useEventPreviewState.ts
+++ b/src/features/Events/EventPreview/useEventPreviewState.ts
@@ -1,6 +1,7 @@
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
 import { AppDispatch } from '@/app/store'
 import { handleDelete } from '@/components/Event/eventHandlers/eventHandlers'
+import { setCalendarError } from '@/features/Calendars/CalendarSlice'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import { userData } from '@/features/User/userDataTypes'
 import { assertThunkSuccess } from '@/utils/assertThunkSuccess'
@@ -262,6 +263,7 @@ export function useEventPreviewState(
       .then(() => setCalendarid(calendarid))
       .catch(error => {
         console.error('Failed to move event:', error)
+        dispatch(setCalendarError(`Failed to move event: ${error}`))
         setCalendarid(calId)
       })
   }

--- a/src/features/Events/EventPreview/useEventPreviewState.ts
+++ b/src/features/Events/EventPreview/useEventPreviewState.ts
@@ -85,13 +85,6 @@ export function useEventPreviewState(
   const event = calendar?.events[eventId]
 
   const [calendarid, setCalendarid] = useState<string>(calendar?.id ?? '')
-  const userPersonalCalendars: Calendar[] = Object.values(
-    calendars.list || {}
-  ).filter(
-    (cal): boolean | undefined =>
-      cal.id?.split('/')[0] === user.openpaasId ||
-      (cal.delegated && cal.access?.write)
-  )
 
   // Modal visibility
   const [openUpdateModal, setOpenUpdateModal] = useState<boolean>(false)
@@ -179,6 +172,16 @@ export function useEventPreviewState(
     }
     return undefined
   })()
+
+  const userPersonalCalendars: Calendar[] = Object.values(
+    calendars.list || {}
+  ).filter(
+    (cal): boolean | undefined =>
+      cal.id?.split('/')[0] === user.openpaasId ||
+      (cal.delegated &&
+        cal.access?.write &&
+        isEventOrganiser(event, effectiveEmail))
+  )
 
   // Action handlers
   const handleEditClick = (): void => {

--- a/src/features/Events/EventPreview/useEventPreviewState.ts
+++ b/src/features/Events/EventPreview/useEventPreviewState.ts
@@ -1,5 +1,8 @@
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
+import { AppDispatch } from '@/app/store'
+import { handleDelete } from '@/components/Event/eventHandlers/eventHandlers'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
+import { userData } from '@/features/User/userDataTypes'
 import { assertThunkSuccess } from '@/utils/assertThunkSuccess'
 import { getEffectiveEmail } from '@/utils/getEffectiveEmail'
 import { isEventOrganiser } from '@/utils/isEventOrganiser'
@@ -8,8 +11,61 @@ import { useState } from 'react'
 import { deleteEventAsync } from '../../Calendars/services'
 import { ToUserData } from '../../User/type/OpenPaasUserData'
 import { createEventContext } from '../createEventContext'
-import { handleDelete } from '@/components/Event/eventHandlers/eventHandlers'
+import { CalendarEvent, ContextualizedEvent } from '../EventsTypes'
+import { moveEventBetweenCalendars } from '../updateEventHelpers/moveEventBetweenCalendars'
 import { useEventUpdateModalReopen } from './useEventUpdateModalReopen'
+
+interface StoredEventReopenData {
+  eventId: string
+  calId: string
+  typeOfAction?: 'solo' | 'all'
+}
+
+interface UseEventPreviewStateReturn {
+  event: CalendarEvent
+  calendar: Calendar | undefined
+  user: userData
+  timezone: string
+  contextualizedEvent: ContextualizedEvent | null
+  attendanceUser: userData | undefined
+  isRecurring: boolean
+  isOwn: boolean
+  isWriteDelegated: boolean
+  isOrganizer: boolean
+  isNotPrivate: boolean
+  canEdit: boolean
+  organizerWritableCalendar: Calendar | undefined
+  openUpdateModal: boolean
+  setOpenUpdateModal: React.Dispatch<React.SetStateAction<boolean>>
+  openDuplicateModal: boolean
+  setOpenDuplicateModal: React.Dispatch<React.SetStateAction<boolean>>
+  hidePreview: boolean
+  setHidePreview: React.Dispatch<React.SetStateAction<boolean>>
+  toggleActionMenu: Element | null
+  setToggleActionMenu: React.Dispatch<React.SetStateAction<Element | null>>
+  updateModalCalId: string
+  openEditModePopup: string | null
+  setOpenEditModePopup: React.Dispatch<React.SetStateAction<string | null>>
+  typeOfAction: 'solo' | 'all' | undefined
+  setTypeOfAction: React.Dispatch<
+    React.SetStateAction<'solo' | 'all' | undefined>
+  >
+  afterChoiceFunc: ((type: 'solo' | 'all' | undefined) => void) | undefined
+  setAfterChoiceFunc: React.Dispatch<
+    React.SetStateAction<
+      ((type: 'solo' | 'all' | undefined) => void) | undefined
+    >
+  >
+  resolvedTypeOfAction: 'solo' | 'all' | undefined
+  handleEditClick: () => void
+  handleEditInOrganizerCalendar: () => void
+  handleDeleteClick: () => Promise<void>
+  handleDuplicateClick: () => void
+  calendarid: string
+  handleCalendarMove: (calendarid: string) => void
+  userPersonalCalendars: Calendar[]
+  dispatch: AppDispatch
+}
 
 export function useEventPreviewState(
   eventId: string,
@@ -17,9 +73,10 @@ export function useEventPreviewState(
   tempEvent: boolean | undefined,
   open: boolean,
   onClose: (event: unknown, reason: 'backdropClick' | 'escapeKeyDown') => void
-) {
+): UseEventPreviewStateReturn {
   const dispatch = useAppDispatch()
   const calendars = useAppSelector(state => state.calendars)
+
   const timezone =
     useAppSelector(state => state.settings.timeZone) ?? browserDefaultTimeZone
   const user = useAppSelector(state => state.user.userData)
@@ -27,12 +84,21 @@ export function useEventPreviewState(
   const calendar = tempEvent ? calendars.templist[calId] : calendars.list[calId]
   const event = calendar?.events[eventId]
 
+  const [calendarid, setCalendarid] = useState<string>(calendar?.id ?? '')
+  const userPersonalCalendars: Calendar[] = Object.values(
+    calendars.list || {}
+  ).filter(
+    (cal): boolean | undefined =>
+      cal.id?.split('/')[0] === user.openpaasId ||
+      (cal.delegated && cal.access?.write)
+  )
+
   // Modal visibility
-  const [openUpdateModal, setOpenUpdateModal] = useState(false)
-  const [openDuplicateModal, setOpenDuplicateModal] = useState(false)
-  const [hidePreview, setHidePreview] = useState(false)
+  const [openUpdateModal, setOpenUpdateModal] = useState<boolean>(false)
+  const [openDuplicateModal, setOpenDuplicateModal] = useState<boolean>(false)
+  const [hidePreview, setHidePreview] = useState<boolean>(false)
   const [toggleActionMenu, setToggleActionMenu] = useState<Element | null>(null)
-  const [updateModalCalId, setUpdateModalCalId] = useState(calId)
+  const [updateModalCalId, setUpdateModalCalId] = useState<string>(calId)
 
   // Recurring event handling
   const [openEditModePopup, setOpenEditModePopup] = useState<string | null>(
@@ -78,7 +144,7 @@ export function useEventPreviewState(
   const organizerWritableCalendar: Calendar | undefined =
     !canEdit && organizerEmail
       ? Object.values(calendars.list).find(
-          cal =>
+          (cal): boolean | undefined =>
             cal.delegated &&
             cal.access?.write &&
             cal.owner?.emails?.some(e => e.toLowerCase() === organizerEmail) &&
@@ -93,18 +159,19 @@ export function useEventPreviewState(
     isWriteDelegated && calendar?.owner ? ToUserData(calendar.owner) : user
 
   // Resolve typeOfAction for EventUpdateModal (state or sessionStorage fallback)
-  const resolvedTypeOfAction = (() => {
+  const resolvedTypeOfAction = ((): 'solo' | 'all' | undefined => {
     if (typeOfAction) return typeOfAction
     try {
       const stored = sessionStorage.getItem('eventUpdateModalReopen')
       if (stored) {
-        const data = JSON.parse(stored)
+        const data = JSON.parse(stored) as StoredEventReopenData
         if (
+          data &&
           data.eventId === eventId &&
           data.calId === calId &&
           data.typeOfAction
         ) {
-          return data.typeOfAction as 'solo' | 'all'
+          return data.typeOfAction
         }
       }
     } catch {
@@ -114,10 +181,10 @@ export function useEventPreviewState(
   })()
 
   // Action handlers
-  const handleEditClick = () => {
+  const handleEditClick = (): void => {
     setUpdateModalCalId(calId)
     if (isRecurring) {
-      setAfterChoiceFunc(() => () => {
+      setAfterChoiceFunc(() => (): void => {
         setHidePreview(true)
         setOpenUpdateModal(true)
       })
@@ -128,11 +195,11 @@ export function useEventPreviewState(
     }
   }
 
-  const handleEditInOrganizerCalendar = () => {
+  const handleEditInOrganizerCalendar = (): void => {
     if (!organizerWritableCalendar) return
     setUpdateModalCalId(organizerWritableCalendar.id)
     if (isRecurring) {
-      setAfterChoiceFunc(() => () => {
+      setAfterChoiceFunc(() => (): void => {
         setHidePreview(true)
         setOpenUpdateModal(true)
       })
@@ -143,20 +210,21 @@ export function useEventPreviewState(
     }
   }
 
-  const handleDeleteClick = async () => {
+  const handleDeleteClick = async (): Promise<void> => {
     if (isRecurring) {
       setAfterChoiceFunc(
-        () => (type?: 'solo' | 'all') =>
-          void handleDelete(
-            isRecurring,
-            type,
-            onClose,
-            dispatch,
-            calendar,
-            event,
-            calId,
-            eventId
-          )
+        () =>
+          (type?: 'solo' | 'all'): void =>
+            void handleDelete(
+              isRecurring,
+              type,
+              onClose,
+              dispatch,
+              calendar,
+              event,
+              calId,
+              eventId
+            )
       )
       setOpenEditModePopup('delete')
     } else {
@@ -172,9 +240,27 @@ export function useEventPreviewState(
     }
   }
 
-  const handleDuplicateClick = () => {
+  const handleDuplicateClick = (): void => {
     setHidePreview(true)
     setOpenDuplicateModal(true)
+  }
+
+  const handleCalendarMove = (calendarid: string): void => {
+    if (!event || calendarid === calId) return
+    void Promise.resolve(
+      moveEventBetweenCalendars({
+        dispatch,
+        calList: calendars.list,
+        newEvent: event,
+        oldCalId: calId,
+        newCalId: calendarid
+      })
+    )
+      .then(() => setCalendarid(calendarid))
+      .catch(error => {
+        console.error('Failed to move event:', error)
+        setCalendarid(calId)
+      })
   }
 
   return {
@@ -220,6 +306,11 @@ export function useEventPreviewState(
     handleEditInOrganizerCalendar,
     handleDeleteClick,
     handleDuplicateClick,
+
+    // moving calendar
+    calendarid,
+    handleCalendarMove,
+    userPersonalCalendars,
 
     dispatch
   }

--- a/src/features/Events/updateEventHelpers/moveEventBetweenCalendars.ts
+++ b/src/features/Events/updateEventHelpers/moveEventBetweenCalendars.ts
@@ -210,7 +210,7 @@ async function moveDelegatedEvent({
     organizer: newOrganizer,
     attendee: newAttendees
   }
-  console.log(eventForTargetCalendar, targetCalendar)
+
   const putResult = await dispatch(
     putEventAsync({ cal: targetCalendar, newEvent: eventForTargetCalendar })
   )

--- a/src/features/Events/updateEventHelpers/moveEventBetweenCalendars.ts
+++ b/src/features/Events/updateEventHelpers/moveEventBetweenCalendars.ts
@@ -5,12 +5,14 @@ import {
   moveEventAsync,
   putEventAsync
 } from '@/features/Calendars/services'
+import { fetchAllRecurrentVevents } from '@/features/Events/EventDao'
 import { userAttendee } from '@/features/User/models/attendee'
 import { userOrganiser } from '@/features/User/userDataTypes'
 import { assertThunkSuccess } from '@/utils/assertThunkSuccess'
 import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
 import { makeDisplayName } from '@/utils/makeDisplayName'
 import { CalendarEvent } from '../EventsTypes'
+import { parseCalendarEvent } from '../utils'
 import { buildDelegatedEventURL } from '../utils/buildDelegatedEventURL'
 
 export interface MoveEventBetweenCalendarsParams {
@@ -19,6 +21,33 @@ export interface MoveEventBetweenCalendarsParams {
   newEvent: CalendarEvent
   oldCalId: string
   newCalId: string
+}
+
+/**
+ * If the event is a recurring instance (has a recurrenceId), fetch all
+ * VEVENTs for the series and return the master — the VEVENT that has no
+ * RECURRENCE-ID.  If the event is already the master (or is not recurring),
+ * it is returned as-is.
+ */
+async function resolveMasterEvent(
+  event: CalendarEvent,
+  calendar: Calendar
+): Promise<CalendarEvent> {
+  if (!event.recurrenceId) {
+    return event
+  }
+
+  const vevents = await fetchAllRecurrentVevents(event)
+  const masterVevent = vevents
+    .filter(([n]) => n === 'vevent')
+    .find(([, props]) => !props.some(([k]) => k === 'recurrence-id'))
+
+  if (!masterVevent) {
+    throw new Error(
+      `Could not find master event for recurring series: ${event.uid}`
+    )
+  }
+  return parseCalendarEvent(masterVevent[1], event.color, calendar, event.URL)
 }
 
 function resolveOrganizerForCalendar(
@@ -89,19 +118,22 @@ export async function moveEventBetweenCalendars({
     throw new Error(`Target calendar not found: ${newCalId}`)
   }
 
+  // Always operate on the master event — never on a recurring instance
+  const masterEvent = await resolveMasterEvent(newEvent, oldCalendar)
+
   const isDelegatedMove = oldCalendar.delegated || targetCalendar.delegated
 
   if (isDelegatedMove) {
     await moveDelegatedEvent({
       dispatch,
-      newEvent,
+      newEvent: masterEvent,
       oldCalendar,
       targetCalendar
     })
   } else {
     await moveStandardEvent({
       dispatch,
-      newEvent,
+      newEvent: masterEvent,
       targetCalendar,
       oldCalendar
     })
@@ -169,7 +201,6 @@ async function moveDelegatedEvent({
   )
 
   const newURL = `/calendars/${newCalId}/${extractEventBaseUuid(newEvent.uid)}.ics`
-
   const eventForTargetCalendar: CalendarEvent = {
     ...newEvent,
     calId: newCalId,
@@ -179,7 +210,7 @@ async function moveDelegatedEvent({
     organizer: newOrganizer,
     attendee: newAttendees
   }
-
+  console.log(eventForTargetCalendar, targetCalendar)
   const putResult = await dispatch(
     putEventAsync({ cal: targetCalendar, newEvent: eventForTargetCalendar })
   )

--- a/src/utils/isEventOrganiser.ts
+++ b/src/utils/isEventOrganiser.ts
@@ -4,7 +4,7 @@ export function isEventOrganiser(
   event: CalendarEvent,
   effectiveEmail: string | undefined
 ): boolean {
-  if (!event.organizer) return true // no organizer = assume owner
+  if (!event?.organizer) return true // no organizer = assume owner
   const organizerEmail = event.organizer.cal_address?.toLowerCase()
   if (!organizerEmail || !effectiveEmail) return false
   return organizerEmail === effectiveEmail.toLowerCase()


### PR DESCRIPTION
resolves #690 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event preview modal now includes a calendar selection dropdown and lets you move events between calendars.
  * Direct action to duplicate events from the preview.

* **Improvements**
  * More reliable recurring-event handling and move semantics for series; improved edit/delete flows and calendar error reporting.

* **Bug Fixes**
  * Safer organizer checks to avoid incorrect organizer resolution when event data is missing.

* **Style**
  * Adjusted row spacing in event sections for improved layout and click targets.

* **Tests**
  * Added master recurring-event fixture and updated mocks to cover series/move logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->