### PR TITLE
Schedule view

### DIFF
--- a/__test__/utils/calendarUtils.test.tsx
+++ b/__test__/utils/calendarUtils.test.tsx
@@ -114,7 +114,8 @@ const callFormat = (
     userId,
     userAddress,
     pending: false,
-    calendars
+    calendars,
+    t: (key: string) => key
   })
 
 describe('eventToFullCalendarFormat - editable flag', () => {
@@ -150,7 +151,8 @@ describe('eventToFullCalendarFormat - editable flag', () => {
         userId: 'user1',
         userAddress: 'alice@example.com',
         pending: true,
-        calendars: { 'user1/cal1': calendar }
+        calendars: { 'user1/cal1': calendar },
+        t: (key: string) => key
       })
       expect(result.editable).toBe(false)
     })
@@ -216,7 +218,8 @@ describe('eventToFullCalendarFormat - editable flag', () => {
         userId: 'user1',
         userAddress: 'alice@example.com',
         pending: true,
-        calendars: { 'user2/cal1': writeDelegatedCalendar }
+        calendars: { 'user2/cal1': writeDelegatedCalendar },
+        t: (key: string) => key
       })
       expect(result.editable).toBe(false)
     })

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -32,6 +32,7 @@ import { Fab, CircularProgress, Box, Typography } from '@linagora/twake-mui'
 import Tooltip from '@/components/Tooltip'
 import AddIcon from '@mui/icons-material/Add'
 import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import moment from 'moment-timezone'
 import { useI18n } from 'twake-i18n'
 import { useCalendarDataLoader } from '../../features/Calendars/useCalendarLoader'
 import { User } from '../Attendees/types'
@@ -51,11 +52,15 @@ import { useTouchListener } from './hooks/useTouchListener'
 import {
   eventToFullCalendarFormat,
   extractEvents,
+  sortEventsByDateTime,
   updateSlotLabelVisibility
 } from './utils/calendarUtils'
 import { CALENDAR_VIEWS } from './utils/constants'
 import ViewMoreEvents from './ViewMoreEvents'
 import { TimezoneChangeAlert } from '../Timezone/TimezoneChangeAlert'
+import { useFindUpcommingEvent } from './hooks/useFindUpcommingEvent'
+import { useAutoScrollToUpcommingEvent } from '../Event/hooks/useAutoScrollToUpcommingEvent'
+import { usePreserveScrollPositionInScheduleView } from './hooks/usePreserveScrollPositionInScheduleView'
 
 const localeMap: Record<string, LocaleInput | undefined> = {
   fr: frLocale,
@@ -99,7 +104,7 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
   const dispatch = useAppDispatch()
   const view = useAppSelector(state => state.settings.view)
   const userData = useAppSelector(state => state.user.userData)
-  const workingDays = useAppSelector(
+  const workingDays: number[] | undefined = useAppSelector(
     state => state.settings.businessHours?.daysOfWeek
   )
   const hideWorkingDays = useAppSelector(state => state.settings.workingDays)
@@ -160,7 +165,8 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
 
   useEffect(() => {
     const updateSelectedCalendars = (): void => {
-      if (initialLoadRef.current && calendarIds.length > 0 && userId) {
+      const isValid = initialLoadRef.current && calendarIds.length > 0 && userId
+      if (isValid) {
         const cached = localStorage.getItem('selectedCalendars')
         if (cached && cached.length > 0) {
           const parsed = JSON.parse(cached) as string[]
@@ -264,6 +270,25 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     t
   ])
 
+  const filteredCalendarEvents = useMemo(() => {
+    if (currentView !== CALENDAR_VIEWS.listWeek) {
+      return fullCalendarEvents
+    }
+
+    const now = moment().tz(timezone)
+    const startOfToday = now.clone().startOf('day')
+
+    return fullCalendarEvents.filter(event => {
+      if (!event.start) return false
+
+      const eventEnd = event.end
+        ? moment(event.end).tz(timezone)
+        : moment(event.start).tz(timezone)
+      // Keep events that end today or in the future (includes multi-day events that are still ongoing)
+      return eventEnd.isSameOrAfter(startOfToday, 'day')
+    })
+  }, [fullCalendarEvents, currentView, timezone])
+
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [openEventDisplay, setOpenEventDisplay] = useState(false)
   const [eventDisplayedId, setEventDisplayedId] = useState('')
@@ -296,11 +321,11 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
           )
 
           // Open EventDisplayPreview if it's not already open with matching event, so it can pick up the sessionStorage
-          if (
-            !openEventDisplay ||
-            eventDisplayedId !== event.detail.eventId ||
-            eventDisplayedCalId !== event.detail.calId
-          ) {
+          const isCurrentlyDisplayedEvent =
+            openEventDisplay &&
+            eventDisplayedId === event.detail.eventId &&
+            eventDisplayedCalId === event.detail.calId
+          if (!isCurrentlyDisplayedEvent) {
             setEventDisplayedId(event.detail.eventId)
             setEventDisplayedCalId(event.detail.calId)
             setEventDisplayedTemp(false)
@@ -374,6 +399,20 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     })
     return (): void => cancelAnimationFrame(id)
   }, [view, isTablet, currentView, calendarRef])
+
+  const upcommingEventId = useFindUpcommingEvent(
+    fullCalendarEvents,
+    currentView
+  )
+
+  useAutoScrollToUpcommingEvent(upcommingEventId)
+
+  // When the preview modal opens in the schedule view, FullCalendar
+  // re-renders event content because getEventAsync updates the calendars store.
+  // This re-render resets the list scroller to the top. We save the current
+  // scroll position immediately and restore it after the re-render settles.
+  usePreserveScrollPositionInScheduleView(openEventDisplay, currentView)
+
   // Event handlers
   const eventHandlers = useCalendarEventHandlers({
     setSelectedRange,
@@ -407,7 +446,8 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     timezone,
     isTablet,
     isMobile,
-    t
+    t,
+    upcommingEventId
   })
 
   useEffect(() => {
@@ -539,23 +579,10 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
                 }}
                 dayMaxEvents={true}
                 moreLinkClick={handleMoreLinkClick}
-                events={fullCalendarEvents}
-                eventOrder={(a: unknown, b: unknown) => {
-                  const ea = a as EventApi
-                  const eb = b as EventApi
-                  const aStart = ea.start ? new Date(ea.start).getTime() : 0
-                  const bStart = eb.start ? new Date(eb.start).getTime() : 0
-                  if (aStart !== bStart) return aStart - bStart
-                  // Tiebreak by end time so longer events sort later
-                  const aEnd = ea.end ? new Date(ea.end).getTime() : aStart
-                  const bEnd = eb.end ? new Date(eb.end).getTime() : bStart
-                  if (aEnd !== bEnd) return aEnd - bEnd
-                  const aPriority =
-                    (ea.extendedProps as { priority?: number })?.priority ?? 0
-                  const bPriority =
-                    (eb.extendedProps as { priority?: number })?.priority ?? 0
-                  return aPriority - bPriority
-                }}
+                events={filteredCalendarEvents}
+                eventOrder={(a: unknown, b: unknown) =>
+                  sortEventsByDateTime(a as EventApi, b as EventApi)
+                }
                 weekNumbers={
                   currentView === CALENDAR_VIEWS.timeGridWeek ||
                   currentView === CALENDAR_VIEWS.timeGridDay

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -12,7 +12,12 @@ import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
 import { setSelectedCalendars as setSelectedCalendarsToStorage } from '@/utils/storage/setSelectedCalendars'
 import { useSelectedCalendars } from '@/utils/storage/useSelectedCalendars'
 import { browserDefaultTimeZone } from '@/utils/timezone'
-import type { EventApi, LocaleInput, MoreLinkArg } from '@fullcalendar/core'
+import type {
+  EventApi,
+  LocaleInput,
+  MoreLinkArg,
+  SlotLabelContentArg
+} from '@fullcalendar/core'
 import { CalendarApi, DateSelectArg } from '@fullcalendar/core'
 import frLocale from '@fullcalendar/core/locales/fr'
 import ruLocale from '@fullcalendar/core/locales/ru'
@@ -22,7 +27,8 @@ import interactionPlugin from '@fullcalendar/interaction'
 import momentTimezonePlugin from '@fullcalendar/moment-timezone'
 import FullCalendar from '@fullcalendar/react'
 import timeGridPlugin from '@fullcalendar/timegrid'
-import { Fab } from '@linagora/twake-mui'
+import listPlugin from '@fullcalendar/list'
+import { Fab, CircularProgress, Box, Typography } from '@linagora/twake-mui'
 import Tooltip from '@/components/Tooltip'
 import AddIcon from '@mui/icons-material/Add'
 import { MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
@@ -237,6 +243,26 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     userData?.email,
     hideDeclinedEvents
   )
+
+  const fullCalendarEvents = useMemo(() => {
+    return eventToFullCalendarFormat({
+      filteredEvents,
+      filteredTempEvents,
+      userId,
+      userAddress: userData?.email,
+      pending: isPending,
+      calendars,
+      t
+    })
+  }, [
+    filteredEvents,
+    filteredTempEvents,
+    userId,
+    userData?.email,
+    isPending,
+    calendars,
+    t
+  ])
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [openEventDisplay, setOpenEventDisplay] = useState(false)
@@ -461,7 +487,8 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
                   dayGridPlugin,
                   timeGridPlugin,
                   interactionPlugin,
-                  momentTimezonePlugin
+                  momentTimezonePlugin,
+                  listPlugin
                 ]}
                 initialView={
                   currentView ||
@@ -483,6 +510,27 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
                   updateSlotLabelVisibility(new Date(), arg, timezone)
                 ]}
                 nowIndicatorContent={viewHandlers.handleNowIndicatorContent}
+                noEventsContent={(): React.ReactNode => {
+                  return (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        padding: '24px'
+                      }}
+                    >
+                      {isPending ? (
+                        <CircularProgress size={24} />
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          {t('event.noEventsToDisplay')}
+                        </Typography>
+                      )}
+                    </Box>
+                  )
+                }}
+                noEventsText=""
                 headerToolbar={false}
                 views={{
                   timeGridWeek: {
@@ -491,17 +539,23 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
                 }}
                 dayMaxEvents={true}
                 moreLinkClick={handleMoreLinkClick}
-                events={eventToFullCalendarFormat({
-                  filteredEvents,
-                  filteredTempEvents,
-                  userId,
-                  userAddress: userData?.email,
-                  pending: isPending,
-                  calendars
-                })}
-                eventOrder={(a: EventApi, b: EventApi) =>
-                  a.extendedProps.priority - b.extendedProps.priority
-                }
+                events={fullCalendarEvents}
+                eventOrder={(a: unknown, b: unknown) => {
+                  const ea = a as EventApi
+                  const eb = b as EventApi
+                  const aStart = ea.start ? new Date(ea.start).getTime() : 0
+                  const bStart = eb.start ? new Date(eb.start).getTime() : 0
+                  if (aStart !== bStart) return aStart - bStart
+                  // Tiebreak by end time so longer events sort later
+                  const aEnd = ea.end ? new Date(ea.end).getTime() : aStart
+                  const bEnd = eb.end ? new Date(eb.end).getTime() : bStart
+                  if (aEnd !== bEnd) return aEnd - bEnd
+                  const aPriority =
+                    (ea.extendedProps as { priority?: number })?.priority ?? 0
+                  const bPriority =
+                    (eb.extendedProps as { priority?: number })?.priority ?? 0
+                  return aPriority - bPriority
+                }}
                 weekNumbers={
                   currentView === CALENDAR_VIEWS.timeGridWeek ||
                   currentView === CALENDAR_VIEWS.timeGridDay
@@ -584,7 +638,11 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
 
                   // Update slot label visibility when view changes
                   setTimeout(() => {
-                    updateSlotLabelVisibility(new Date())
+                    updateSlotLabelVisibility(
+                      new Date(),
+                      {} as SlotLabelContentArg,
+                      timezone
+                    )
                   }, 100)
                 }}
                 dayHeaderContent={viewHandlers.handleDayHeaderContent}

--- a/src/components/Calendar/CalendarLayout.tsx
+++ b/src/components/Calendar/CalendarLayout.tsx
@@ -70,15 +70,16 @@ export default function CalendarLayout(): JSX.Element {
   }
 
   const handleViewChange = (view: string): void => {
-    if (!calendarRef.current) return
     dispatch(setView('calendar'))
 
     // Notify parent about view change
     setCurrentView(view)
 
-    // Notify parent about date change after view change
-    const newDate = calendarRef.current.getDate()
-    handleDateChange(newDate)
+    if (calendarRef.current) {
+      // Notify parent about date change after view change
+      const newDate = calendarRef.current.getDate()
+      handleDateChange(newDate)
+    }
   }
 
   // Hide topbar navigation elements when in settings view (same as fullscreen dialog mode)

--- a/src/components/Calendar/CustomCalendar.styl
+++ b/src/components/Calendar/CustomCalendar.styl
@@ -393,3 +393,42 @@ hr.MuiDivider-root.MuiDivider-fullWidth
 .fc-timeGridWeek-view .fc-daygrid-body .fc-daygrid-day-top,
 .fc-timeGridDay-view .fc-daygrid-body .fc-daygrid-day-top
   display none
+
+/* FullCalendar List View Custom Styling */
+.fc-listWeek-view.fc-list
+  border-width 0
+
+.fc-list-table
+  border-width 0
+  border-collapse collapse
+
+.fc-list-day
+  display none !important
+
+.fc-list-event
+  cursor pointer
+  transition background-color 0.2s ease
+  
+  &:hover
+    background-color #F8FAFC !important
+
+  td
+    border none !important
+    padding 0 !important
+    vertical-align middle
+
+.fc-list-day + .fc-list-event td
+  border-top 1px solid #B5B7C033 !important
+
+.fc-list-day:first-child + .fc-list-event td
+  border-top none !important
+
+.fc-list-event-time
+  display none !important
+
+.fc-list-event-graphic
+  display none !important
+
+.fc-list-event-title
+  width 100% !important
+  padding 0 !important

--- a/src/components/Calendar/handlers/viewHandlers.ts
+++ b/src/components/Calendar/handlers/viewHandlers.ts
@@ -30,11 +30,23 @@ export interface ViewHandlersProps {
   isTablet: boolean
   isMobile: boolean
   t: (key: string) => string
+  upcommingEventId?: string
 }
 
-export const createViewHandlers = (
-  props: ViewHandlersProps
-): Record<string, unknown> => {
+export interface ViewHandlers {
+  handleNowIndicatorContent: (
+    arg: NowIndicatorContentArg
+  ) => React.ReactElement | undefined
+  handleDayHeaderContent: (arg: DayHeaderContentArg) => JSX.Element
+  handleDayHeaderDidMount: (arg: DayHeaderMountArg) => void
+  handleDayHeaderWillUnmount: (arg: DayHeaderMountArg) => void
+  handleViewDidMount: (arg: ViewMountArg) => void
+  handleViewWillUnmount: (arg: ViewMountArg) => void
+  handleEventContent: (arg: EventContentArg) => React.ReactElement
+  handleEventDidMount: (arg: EventMountArg) => void
+}
+
+export const createViewHandlers = (props: ViewHandlersProps): ViewHandlers => {
   const {
     calendarRef,
     setSelectedDate,
@@ -46,7 +58,8 @@ export const createViewHandlers = (
     timezone,
     isTablet,
     isMobile,
-    t
+    t,
+    upcommingEventId
   } = props
 
   const handleNowIndicatorContent = (
@@ -194,7 +207,8 @@ export const createViewHandlers = (
         arg,
         calendars,
         tempcalendars,
-        timezone
+        timezone,
+        upcommingEventId
       })
     }
     return React.createElement(EventChip, {

--- a/src/components/Calendar/handlers/viewHandlers.ts
+++ b/src/components/Calendar/handlers/viewHandlers.ts
@@ -16,6 +16,7 @@ import moment from 'moment-timezone'
 import React from 'react'
 import { CALENDAR_VIEWS } from '../utils/constants'
 import { createMouseHandlers } from './mouseHandlers'
+import { EventChipSchedule } from '@/components/Event/EventChip/EventChipSchedule'
 
 export interface ViewHandlersProps {
   calendarRef: React.RefObject<CalendarApi | null>
@@ -31,7 +32,9 @@ export interface ViewHandlersProps {
   t: (key: string) => string
 }
 
-export const createViewHandlers = (props: ViewHandlersProps) => {
+export const createViewHandlers = (
+  props: ViewHandlersProps
+): Record<string, unknown> => {
   const {
     calendarRef,
     setSelectedDate,
@@ -124,9 +127,13 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
     )
   }
 
+  interface ClickableHeaderElement extends HTMLElement {
+    __dayHeaderClickHandler?: EventListener
+  }
+
   const handleDayHeaderDidMount = (arg: DayHeaderMountArg): void => {
     if (arg.view.type === CALENDAR_VIEWS.timeGridWeek) {
-      const headerEl = arg.el
+      const headerEl = arg.el as ClickableHeaderElement
 
       const handleDayClick = (): void => {
         handleDayHeaderClick(arg)
@@ -138,12 +145,9 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
   }
 
   const handleDayHeaderWillUnmount = (arg: DayHeaderMountArg): void => {
-    const headerEl = arg.el
+    const headerEl = arg.el as ClickableHeaderElement
     if (headerEl.__dayHeaderClickHandler) {
-      headerEl.removeEventListener(
-        'click',
-        headerEl.__dayHeaderClickHandler as EventListener
-      )
+      headerEl.removeEventListener('click', headerEl.__dayHeaderClickHandler)
       delete headerEl.__dayHeaderClickHandler
     }
   }
@@ -185,6 +189,14 @@ export const createViewHandlers = (props: ViewHandlersProps) => {
   }
 
   const handleEventContent = (arg: EventContentArg): React.ReactElement => {
+    if (arg.view.type === CALENDAR_VIEWS.listWeek) {
+      return React.createElement(EventChipSchedule, {
+        arg,
+        calendars,
+        tempcalendars,
+        timezone
+      })
+    }
     return React.createElement(EventChip, {
       arg,
       calendars,

--- a/src/components/Calendar/hooks/useFindUpcommingEvent.tsx
+++ b/src/components/Calendar/hooks/useFindUpcommingEvent.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import { CALENDAR_VIEWS } from '../utils/constants'
+import { EventApi, EventInput } from '@fullcalendar/core'
+import { sortEventsByDateTime } from '../utils/calendarUtils'
+
+export const useFindUpcommingEvent = (
+  events: EventInput[],
+  currentView: string
+): string | undefined => {
+  const sortedEvents = useMemo(() => {
+    return [...events].sort((a, b) =>
+      sortEventsByDateTime(a as EventApi, b as EventApi)
+    )
+  }, [events])
+
+  return useMemo(() => {
+    if (currentView !== CALENDAR_VIEWS.listWeek) return undefined
+
+    const now = new Date().getTime()
+    let upcommingEventId: string | undefined = undefined
+    let minDiff = Infinity
+
+    for (const event of sortedEvents) {
+      if (!event.start || !event.uid) continue
+      const start = new Date(event.start as string)
+
+      const diff = start.getTime() - now
+
+      if (diff >= 0 && diff < minDiff) {
+        minDiff = diff
+        upcommingEventId = event.uid as string
+      }
+    }
+    return upcommingEventId
+  }, [sortedEvents, currentView])
+}

--- a/src/components/Calendar/hooks/usePreserveScrollPositionInScheduleView.tsx
+++ b/src/components/Calendar/hooks/usePreserveScrollPositionInScheduleView.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+import { CALENDAR_VIEWS } from '../utils/constants'
+
+export const usePreserveScrollPositionInScheduleView = (
+  openEventDisplay: boolean,
+  currentView: string
+): void => {
+  const savedScrollTop = useRef<number>(0)
+  const isTransitioning = useRef<boolean>(false)
+
+  // 1. TRACKING
+  useEffect(() => {
+    if (currentView !== CALENDAR_VIEWS.listWeek) {
+      savedScrollTop.current = 0
+      return
+    }
+
+    const handleScroll = (e: Event): void => {
+      if (isTransitioning.current) return
+
+      const target = e.target
+      const isListView =
+        target instanceof Element &&
+        target.classList.contains('fc-scroller') &&
+        target.closest('.fc-list')
+      if (isListView) {
+        savedScrollTop.current = target.scrollTop
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, true)
+    return (): void => window.removeEventListener('scroll', handleScroll, true)
+  }, [currentView])
+
+  // 2. RESTORING
+  useEffect(() => {
+    // Early exit: No need to lock or animate if scroll is 0
+    if (currentView !== CALENDAR_VIEWS.listWeek || savedScrollTop.current === 0)
+      return
+
+    isTransitioning.current = true
+    let frameId: number
+
+    // Helper to keep the DOM query DRY
+    const getScrollers = (): NodeListOf<HTMLElement> =>
+      document.querySelectorAll<HTMLElement>('.fc-list .fc-scroller')
+
+    const lockScroll = (): void => {
+      getScrollers().forEach(scroller => {
+        scroller.style.overflowY = 'hidden'
+        if (scroller.scrollTop !== savedScrollTop.current) {
+          scroller.scrollTop = savedScrollTop.current
+        }
+      })
+      frameId = requestAnimationFrame(lockScroll)
+    }
+
+    frameId = requestAnimationFrame(lockScroll)
+
+    const timeoutId = setTimeout(() => {
+      cancelAnimationFrame(frameId)
+      isTransitioning.current = false
+
+      getScrollers().forEach(scroller => {
+        scroller.style.overflowY = ''
+      })
+    }, 400)
+
+    return (): void => {
+      cancelAnimationFrame(frameId)
+      clearTimeout(timeoutId)
+      isTransitioning.current = false
+      getScrollers().forEach(scroller => {
+        scroller.style.overflowY = ''
+      })
+    }
+  }, [openEventDisplay, currentView])
+}

--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -8,7 +8,7 @@ import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
 import { getEffectiveEmail } from '@/utils/getEffectiveEmail'
 import { isEventOrganiser } from '@/utils/isEventOrganiser'
 import { convertEventDateTimeToISO } from '@/utils/timezone'
-import { EventInput, SlotLabelContentArg } from '@fullcalendar/core'
+import { EventApi, EventInput, SlotLabelContentArg } from '@fullcalendar/core'
 import moment from 'moment-timezone'
 
 export const updateSlotLabelVisibility = (
@@ -394,4 +394,29 @@ function privilegeToAccess(
     default:
       break
   }
+}
+
+const getTime = (date: Date | null): number => {
+  return date ? new Date(date).getTime() : 0
+}
+
+export const sortEventsByDateTime = (
+  curEvent: EventApi,
+  nextEvent: EventApi
+): number => {
+  const aStart = getTime(curEvent.start)
+  const bStart = getTime(nextEvent.start)
+  if (aStart !== bStart) return aStart - bStart
+
+  // Tiebreak by end time so longer events sort later
+  const aEnd = getTime(curEvent.end)
+  const bEnd = getTime(nextEvent.end)
+  if (aEnd !== bEnd) return aEnd - bEnd
+
+  // Final tiebreak by priority (personal events first)
+  const aPriority =
+    (curEvent.extendedProps as { priority?: number })?.priority ?? 0
+  const bPriority =
+    (nextEvent.extendedProps as { priority?: number })?.priority ?? 0
+  return aPriority - bPriority
 }

--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -10,7 +10,6 @@ import { isEventOrganiser } from '@/utils/isEventOrganiser'
 import { convertEventDateTimeToISO } from '@/utils/timezone'
 import { EventInput, SlotLabelContentArg } from '@fullcalendar/core'
 import moment from 'moment-timezone'
-import { useI18n } from 'twake-i18n'
 
 export const updateSlotLabelVisibility = (
   currentTime: Date,
@@ -191,6 +190,7 @@ export interface EventToFullCalendarFormatProps {
   userAddress: string | undefined
   pending: boolean
   calendars: Record<string, Calendar>
+  t: (key: string, options?: Record<string, unknown>) => string
 }
 
 export const eventToFullCalendarFormat = ({
@@ -199,10 +199,9 @@ export const eventToFullCalendarFormat = ({
   userId,
   userAddress,
   pending,
-  calendars
+  calendars,
+  t
 }: EventToFullCalendarFormatProps): EventInput[] => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { t } = useI18n()
   return filteredEvents
     .concat(filteredTempEvents.map(event => ({ ...event, temp: true })))
     .map(event =>

--- a/src/components/Calendar/utils/constants.ts
+++ b/src/components/Calendar/utils/constants.ts
@@ -1,5 +1,6 @@
 export const CALENDAR_VIEWS = {
   dayGridMonth: 'dayGridMonth',
   timeGridWeek: 'timeGridWeek',
-  timeGridDay: 'timeGridDay'
+  timeGridDay: 'timeGridDay',
+  listWeek: 'listWeek'
 }

--- a/src/components/Event/EventChip/EventChipSchedule.tsx
+++ b/src/components/Event/EventChip/EventChipSchedule.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { EventContentArg, EventApi } from '@fullcalendar/core'
 import moment from 'moment-timezone'
-import { Box } from '@linagora/twake-mui'
+import { alpha, Box, useTheme } from '@linagora/twake-mui'
 import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import { CalendarEvent } from '@/features/Events/EventsTypes'
@@ -17,12 +17,14 @@ import {
   RenderDayIndicator,
   RenderListEventTime
 } from '@/features/Search/listSearchResultsComponents'
+import { sortEventsByDateTime } from '@/components/Calendar/utils/calendarUtils'
 
 export interface EventChipScheduleProps {
   arg: EventContentArg
   calendars: Record<string, Calendar>
   tempcalendars: Record<string, Calendar>
   timezone: string
+  upcommingEventId?: string
 }
 
 const getEffectiveDayMoment = (
@@ -56,26 +58,15 @@ const isEventOnDay = (
   return false
 }
 
-const compareEvents = (a: EventApi, b: EventApi): number => {
-  const aStart = a.start?.getTime() ?? 0
-  const bStart = b.start?.getTime() ?? 0
-  if (aStart !== bStart) return aStart - bStart
-  const aEnd = a.end?.getTime() ?? aStart
-  const bEnd = b.end?.getTime() ?? bStart
-  if (aEnd !== bEnd) return aEnd - bEnd
-  const aPriority =
-    (a.extendedProps as unknown as { priority?: number }).priority ?? 0
-  const bPriority =
-    (b.extendedProps as unknown as { priority?: number }).priority ?? 0
-  return aPriority - bPriority
-}
-
-const getEventCompositeKey = (e: {
-  id: string
-  extendedProps: Record<string, unknown>
-}): string => {
+const getEventInstanceKey = (e: EventApi): string => {
+  // Use FullCalendar's internal instanceId (unique per occurrence) when available.
+  // This prevents recurring events sharing the same id/calId/start from all
+  // matching as the "first" event and showing the day indicator multiple times.
+  const instanceId = (e as unknown as { _instance?: { instanceId?: string } })
+    ._instance?.instanceId
+  if (instanceId) return instanceId
   const ext = e.extendedProps as unknown as CalendarEvent
-  return `${e.id}_${ext.calId ?? ''}`
+  return `${e.id}_${ext.calId ?? ''}_${e.start?.getTime() ?? ''}`
 }
 
 const buildListDayData = (
@@ -84,6 +75,7 @@ const buildListDayData = (
 ): {
   isFirstRow: boolean
   isToday: boolean
+  isInPast: boolean
   dayNum: string
   dayName: string
 } => {
@@ -93,21 +85,23 @@ const buildListDayData = (
   const allEvents = arg.view.calendar.getEvents()
   const sameDayEvents = allEvents
     .filter(e => isEventOnDay(e, dayKey, timezone))
-    .sort(compareEvents)
+    .sort(sortEventsByDateTime)
 
   const firstEvent = sameDayEvents[0]
 
   const isFirstRow = Boolean(
     firstEvent &&
-    getEventCompositeKey(firstEvent) === getEventCompositeKey(arg.event) &&
-    firstEvent.start &&
-    arg.event.start &&
-    firstEvent.start.getTime() === arg.event.start.getTime()
+    getEventInstanceKey(firstEvent) === getEventInstanceKey(arg.event)
   )
+
+  const now = moment().tz(timezone)
+  const isToday = effectiveDayMoment.isSame(now, 'day')
+  const isInPast = effectiveDayMoment.isBefore(now, 'day')
 
   return {
     isFirstRow,
-    isToday: effectiveDayMoment.isSame(moment().tz(timezone), 'day'),
+    isToday,
+    isInPast,
     dayNum: effectiveDayMoment.format('D'),
     dayName: effectiveDayMoment.format('ddd')
   }
@@ -117,9 +111,12 @@ export const EventChipSchedule: React.FC<EventChipScheduleProps> = ({
   arg,
   calendars,
   tempcalendars,
-  timezone
+  timezone,
+  upcommingEventId
 }) => {
   const { t } = useI18n()
+  const theme = useTheme()
+
   const ext = arg.event.extendedProps as CalendarEvent
   const { temp } = arg.event._def.extendedProps
   const isRecurrent = !!ext.repetition
@@ -130,8 +127,13 @@ export const EventChipSchedule: React.FC<EventChipScheduleProps> = ({
 
   const dayData = buildListDayData(arg, timezone)
 
+  if (dayData.isInPast) {
+    return null
+  }
+
   return (
     <Box
+      data-event-id={ext.uid}
       sx={{
         display: 'flex',
         flexDirection: 'row',
@@ -139,7 +141,11 @@ export const EventChipSchedule: React.FC<EventChipScheduleProps> = ({
         alignItems: 'center',
         textAlign: 'left',
         width: '100%',
-        p: 3
+        p: 3,
+        backgroundColor:
+          upcommingEventId === ext.uid
+            ? alpha(theme.palette.grey[200], 0.5)
+            : 'transparent'
       }}
     >
       <RenderDayIndicator {...dayData} />

--- a/src/components/Event/EventChip/EventChipSchedule.tsx
+++ b/src/components/Event/EventChip/EventChipSchedule.tsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { EventContentArg, EventApi } from '@fullcalendar/core'
+import moment from 'moment-timezone'
+import { Box } from '@linagora/twake-mui'
+import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
+import { Calendar } from '@/features/Calendars/CalendarTypes'
+import { CalendarEvent } from '@/features/Events/EventsTypes'
+import { useI18n } from 'twake-i18n'
+import { defaultColors } from '@/utils/defaultColors'
+import {
+  RenderOrganizer,
+  RenderVideoJoin,
+  RenderTitle,
+  RenderText
+} from '@/features/Search/searchResultsComponents'
+import {
+  RenderDayIndicator,
+  RenderListEventTime
+} from '@/features/Search/listSearchResultsComponents'
+
+export interface EventChipScheduleProps {
+  arg: EventContentArg
+  calendars: Record<string, Calendar>
+  tempcalendars: Record<string, Calendar>
+  timezone: string
+}
+
+const getEffectiveDayMoment = (
+  arg: EventContentArg,
+  timezone: string
+): moment.Moment => {
+  if (arg.isStart || !arg.event.end) {
+    return moment(arg.event.start).tz(timezone)
+  }
+  if (arg.isEnd) {
+    return moment(arg.event.end).tz(timezone)
+  }
+  return moment(arg.event.start).tz(timezone).add(1, 'day')
+}
+
+const isEventOnDay = (
+  e: EventApi,
+  dayKey: string,
+  timezone: string
+): boolean => {
+  if (!e.start) return false
+  const eStartDay = moment(e.start).tz(timezone).format('YYYY-MM-DD')
+  if (eStartDay === dayKey) return true
+  if (e.end) {
+    const eEndInclusiveDay = moment(e.end)
+      .tz(timezone)
+      .subtract(1, 'millisecond')
+      .format('YYYY-MM-DD')
+    return eStartDay < dayKey && eEndInclusiveDay >= dayKey
+  }
+  return false
+}
+
+const compareEvents = (a: EventApi, b: EventApi): number => {
+  const aStart = a.start?.getTime() ?? 0
+  const bStart = b.start?.getTime() ?? 0
+  if (aStart !== bStart) return aStart - bStart
+  const aEnd = a.end?.getTime() ?? aStart
+  const bEnd = b.end?.getTime() ?? bStart
+  if (aEnd !== bEnd) return aEnd - bEnd
+  const aPriority =
+    (a.extendedProps as unknown as { priority?: number }).priority ?? 0
+  const bPriority =
+    (b.extendedProps as unknown as { priority?: number }).priority ?? 0
+  return aPriority - bPriority
+}
+
+const getEventCompositeKey = (e: {
+  id: string
+  extendedProps: Record<string, unknown>
+}): string => {
+  const ext = e.extendedProps as unknown as CalendarEvent
+  return `${e.id}_${ext.calId ?? ''}`
+}
+
+const buildListDayData = (
+  arg: EventContentArg,
+  timezone: string
+): {
+  isFirstRow: boolean
+  isToday: boolean
+  dayNum: string
+  dayName: string
+} => {
+  const effectiveDayMoment = getEffectiveDayMoment(arg, timezone)
+  const dayKey = effectiveDayMoment.format('YYYY-MM-DD')
+
+  const allEvents = arg.view.calendar.getEvents()
+  const sameDayEvents = allEvents
+    .filter(e => isEventOnDay(e, dayKey, timezone))
+    .sort(compareEvents)
+
+  const firstEvent = sameDayEvents[0]
+
+  const isFirstRow = Boolean(
+    firstEvent &&
+    getEventCompositeKey(firstEvent) === getEventCompositeKey(arg.event) &&
+    firstEvent.start &&
+    arg.event.start &&
+    firstEvent.start.getTime() === arg.event.start.getTime()
+  )
+
+  return {
+    isFirstRow,
+    isToday: effectiveDayMoment.isSame(moment().tz(timezone), 'day'),
+    dayNum: effectiveDayMoment.format('D'),
+    dayName: effectiveDayMoment.format('ddd')
+  }
+}
+
+export const EventChipSchedule: React.FC<EventChipScheduleProps> = ({
+  arg,
+  calendars,
+  tempcalendars,
+  timezone
+}) => {
+  const { t } = useI18n()
+  const ext = arg.event.extendedProps as CalendarEvent
+  const { temp } = arg.event._def.extendedProps
+  const isRecurrent = !!ext.repetition
+  const videoUrl = ext.x_openpass_videoconference
+  const calendarsSource = temp ? tempcalendars : calendars
+  const calendar = calendarsSource[ext.calId]
+  const calendarColor = calendar?.color?.light ?? defaultColors[0].light
+
+  const dayData = buildListDayData(arg, timezone)
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        gap: 2,
+        alignItems: 'center',
+        textAlign: 'left',
+        width: '100%',
+        p: 3
+      }}
+    >
+      <RenderDayIndicator {...dayData} />
+      <RenderListEventTime
+        allDay={arg.event.allDay}
+        startDate={arg.event.start || new Date()}
+        endDate={arg.event.end || arg.event.start || new Date()}
+        timeZone={timezone}
+        t={t}
+        isStart={arg.isStart}
+        isEnd={arg.isEnd}
+      />
+      <SquareRoundedIcon
+        style={{ color: calendarColor, width: 24, height: 24, flexShrink: 0 }}
+      />
+      <RenderTitle summary={arg.event.title} isRecurrent={isRecurrent} t={t} />
+      <RenderOrganizer organizer={ext.organizer} />
+      <RenderText text={ext.location} />
+      <RenderText text={ext.description} />
+      <Box sx={{ ml: 'auto', flexShrink: 0 }}>
+        <RenderVideoJoin t={t} url={videoUrl} />
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/Event/EventChip/EventChipUtils.tsx
+++ b/src/components/Event/EventChip/EventChipUtils.tsx
@@ -38,7 +38,10 @@ export function getBestColor(colors: { light: string; dark: string }): string {
 export function getEventTimes(
   event: EventContentArg['event'],
   timeZone: string
-) {
+): {
+  startTime: string
+  endTime: string
+} {
   return {
     startTime: moment.tz(event.start, timeZone).format('HH:mm'),
     endTime: moment.tz(event.end, timeZone).format('HH:mm')
@@ -88,7 +91,9 @@ export function getTitleStyle(
   }
 }
 
-function getEventVariant(duration: number) {
+function getEventVariant(
+  duration: number
+): 'short' | 'medium' | 'long' | 'extraLong' {
   if (duration <= EVENT_DURATION.SHORT) return 'short'
   if (duration <= EVENT_DURATION.MEDIUM) return 'medium'
   if (duration <= EVENT_DURATION.LONG) return 'long'
@@ -174,7 +179,7 @@ export function getCardStyle(
 export function DisplayedIcons(
   IconDisplayed: IconDisplayConfig,
   iconColor?: string
-) {
+): React.ReactNode {
   if (!Object.values(IconDisplayed).find(b => b === true)) return
   const iconStyle: React.CSSProperties = {
     fontSize: '15px',
@@ -213,7 +218,7 @@ export function useCompactMode(
   useLayoutEffect(() => {
     if (!cardRef.current) return
 
-    const checkWidth = () => {
+    const checkWidth = (): void => {
       const width = cardRef.current?.offsetWidth ?? 0
       const newCompact = width < COMPACT_WIDTH_THRESHOLD
 
@@ -228,7 +233,7 @@ export function useCompactMode(
 
     resizeObserver.observe(cardRef.current)
 
-    return () => resizeObserver.disconnect()
+    return (): void => resizeObserver.disconnect()
   }, [cardRef])
 
   return showCompact

--- a/src/components/Event/hooks/useAutoScrollToUpcommingEvent.tsx
+++ b/src/components/Event/hooks/useAutoScrollToUpcommingEvent.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+
+export const useAutoScrollToUpcommingEvent = (
+  upcommingEventId: string | null | undefined
+): void => {
+  const hasScrolled = useRef<boolean>(false)
+
+  useEffect(() => {
+    if (!upcommingEventId || hasScrolled.current) {
+      return
+    }
+    const timeoutId = setTimeout(() => {
+      const el = document.querySelector(`[data-event-id="${upcommingEventId}"]`)
+      if (!el) return
+      hasScrolled.current = true
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 300)
+    return (): void => {
+      clearTimeout(timeoutId)
+      hasScrolled.current = false
+    }
+  }, [upcommingEventId])
+}

--- a/src/components/Menubar/SelectView.tsx
+++ b/src/components/Menubar/SelectView.tsx
@@ -2,13 +2,10 @@ import { FormControl, MenuItem, Select } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { CALENDAR_VIEWS } from '../Calendar/utils/constants'
 
-export function SelectView({
-  currentView,
-  onViewChange
-}: {
+export const SelectView: React.FC<{
   currentView: string
   onViewChange: (view: string) => void
-}) {
+}> = ({ currentView, onViewChange }) => {
   const { t } = useI18n()
   return (
     <FormControl
@@ -35,6 +32,9 @@ export function SelectView({
         </MenuItem>
         <MenuItem value={CALENDAR_VIEWS.timeGridDay}>
           {t('menubar.views.day')}
+        </MenuItem>
+        <MenuItem value={CALENDAR_VIEWS.listWeek}>
+          {t('menubar.views.schedule')}
         </MenuItem>
       </Select>
     </FormControl>

--- a/src/features/Search/DesktopResultItem.tsx
+++ b/src/features/Search/DesktopResultItem.tsx
@@ -1,0 +1,113 @@
+import { useAppSelector } from '@/app/hooks'
+import EventPreviewModal from '@/features/Events/EventPreview'
+import { defaultColors } from '@/utils/defaultColors'
+import { alpha, Box, useTheme } from '@linagora/twake-mui'
+import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
+import { useI18n } from 'twake-i18n'
+import { SearchEventResult } from './types/SearchEventResult'
+import { useEventPreview } from './useEventPreview'
+import {
+  RenderDate,
+  RenderText,
+  RenderOrganizer,
+  RenderTime,
+  RenderTitle,
+  RenderVideoJoin
+} from './searchResultsComponents'
+
+export default function DesktopResultItem({
+  eventData
+}: {
+  eventData: SearchEventResult
+}): JSX.Element {
+  const { t } = useI18n()
+  const theme = useTheme()
+  const startDate = new Date(eventData.data.start)
+  const endDate = eventData.data.end ? new Date(eventData.data.end) : startDate
+
+  const calendar = useAppSelector(
+    state =>
+      state.calendars.list[
+        `${eventData.data.userId}/${eventData.data.calendarId}`
+      ]
+  )
+  const calendarColor = calendar?.color?.light
+
+  const { openPreview, setOpenPreview, handleOpen, timeZone } = useEventPreview(
+    eventData,
+    calendar
+  )
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 2,
+          p: 3,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          cursor: 'pointer',
+          '&:hover': { backgroundColor: alpha(theme.palette.grey[200], 0.5) },
+          alignItems: 'center',
+          textAlign: 'left'
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={eventData.data.summary}
+        onClick={() => void handleOpen()}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            void handleOpen()
+          }
+        }}
+      >
+        <RenderDate
+          startDate={startDate}
+          endDate={endDate}
+          t={t}
+          timeZone={timeZone}
+        />
+        <RenderTime
+          startDate={startDate}
+          endDate={endDate}
+          allDay={!!eventData.data.allDay}
+          t={t}
+          timeZone={timeZone}
+        />
+        <SquareRoundedIcon
+          style={{
+            color: calendarColor ?? defaultColors[0].light,
+            width: 24,
+            height: 24,
+            flexShrink: 0
+          }}
+        />
+
+        <RenderTitle
+          summary={eventData.data.summary}
+          isRecurrent={!!eventData.data.isRecurrentMaster}
+          t={t}
+        />
+        <RenderOrganizer organizer={eventData.data.organizer} />
+        <RenderText text={eventData.data.location} />
+        <RenderText text={eventData.data.description} />
+        <RenderVideoJoin
+          t={t}
+          url={eventData.data['x-openpaas-videoconference']}
+        />
+      </Box>
+
+      {calendar?.events?.[eventData.data.uid] && (
+        <EventPreviewModal
+          eventId={eventData.data.uid}
+          calId={calendar.id}
+          open={openPreview}
+          onClose={() => setOpenPreview(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/features/Search/DesktopSearchResultsPage.tsx
+++ b/src/features/Search/DesktopSearchResultsPage.tsx
@@ -1,23 +1,11 @@
 import { useAppDispatch, useAppSelector } from '@/app/hooks'
-import EventPreviewModal from '@/features/Events/EventPreview'
-import { defaultColors } from '@/utils/defaultColors'
 import { Box, IconButton, Typography } from '@linagora/twake-mui'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
 import { useI18n } from 'twake-i18n'
 import { setView } from '../Settings/SettingsSlice'
 import { ResultsList } from './ResultsList'
 import './searchResult.styl'
-import {
-  RenderDate,
-  RenderText,
-  RenderOrganizer,
-  RenderTime,
-  RenderTitle,
-  RenderVideoJoin
-} from './searchResultsComponents'
-import { SearchEventResult } from './types/SearchEventResult'
-import { useEventPreview } from './useEventPreview'
+import DesktopResultItem from './DesktopResultItem'
 
 export default function DesktopSearchResultsPage(): JSX.Element {
   const { t } = useI18n()
@@ -60,93 +48,5 @@ export default function DesktopSearchResultsPage(): JSX.Element {
         stackSx={{ mt: 2 }}
       />
     </Box>
-  )
-}
-
-function DesktopResultItem({
-  eventData
-}: {
-  eventData: SearchEventResult
-}): JSX.Element {
-  const { t } = useI18n()
-  const startDate = new Date(eventData.data.start)
-  const endDate = eventData.data.end ? new Date(eventData.data.end) : startDate
-
-  const calendar = useAppSelector(
-    state =>
-      state.calendars.list[
-        `${eventData.data.userId}/${eventData.data.calendarId}`
-      ]
-  )
-  const calendarColor = calendar?.color?.light
-
-  const { openPreview, setOpenPreview, handleOpen, timeZone } = useEventPreview(
-    eventData,
-    calendar
-  )
-
-  return (
-    <>
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          gap: 2,
-          p: 3,
-          borderTop: '1px solid',
-          borderColor: 'divider',
-          cursor: 'pointer',
-          '&:hover': { backgroundColor: 'action.hover' },
-          alignItems: 'center',
-          textAlign: 'left',
-          maxWidth: '80vw'
-        }}
-        onClick={() => void handleOpen()}
-      >
-        <RenderDate
-          startDate={startDate}
-          endDate={endDate}
-          t={t}
-          timeZone={timeZone}
-        />
-        <RenderTime
-          startDate={startDate}
-          endDate={endDate}
-          allDay={!!eventData.data.allDay}
-          t={t}
-          timeZone={timeZone}
-        />
-        <SquareRoundedIcon
-          style={{
-            color: calendarColor ?? defaultColors[0].light,
-            width: 24,
-            height: 24,
-            flexShrink: 0
-          }}
-        />
-
-        <RenderTitle
-          summary={eventData.data.summary}
-          isRecurrent={!!eventData.data.isRecurrentMaster}
-          t={t}
-        />
-        <RenderOrganizer organizer={eventData.data.organizer} />
-        <RenderText text={eventData.data.location} />
-        <RenderText text={eventData.data.description} />
-        <RenderVideoJoin
-          t={t}
-          url={eventData.data['x-openpaas-videoconference']}
-        />
-      </Box>
-
-      {calendar?.events?.[eventData.data.uid] && (
-        <EventPreviewModal
-          eventId={eventData.data.uid}
-          calId={calendar.id}
-          open={openPreview}
-          onClose={() => setOpenPreview(false)}
-        />
-      )}
-    </>
   )
 }

--- a/src/features/Search/MobileSearchResultsPage.tsx
+++ b/src/features/Search/MobileSearchResultsPage.tsx
@@ -11,7 +11,7 @@ import './searchResult.styl'
 import {
   RenderMobileDate,
   RenderMobileEventCard
-} from './searchResultsComponents'
+} from './mobileSearchResultsComponents'
 import { SearchEventResult } from './types/SearchEventResult'
 import { useEventPreview } from './useEventPreview'
 

--- a/src/features/Search/listSearchResultsComponents.tsx
+++ b/src/features/Search/listSearchResultsComponents.tsx
@@ -1,0 +1,137 @@
+import { Box, Typography, useTheme } from '@linagora/twake-mui'
+import React from 'react'
+import { RenderTime } from './searchResultsComponents'
+
+interface DayIndicatorProps {
+  isFirstRow: boolean
+  isToday: boolean
+  dayNum: string
+  dayName: string
+}
+
+export const RenderDayIndicator: React.FC<DayIndicatorProps> = ({
+  isFirstRow,
+  isToday,
+  dayNum,
+  dayName
+}) => {
+  const theme = useTheme()
+
+  if (!isFirstRow) {
+    return <Box sx={{ width: '80px', flexShrink: 0 }} />
+  }
+
+  return (
+    <Box
+      sx={{
+        width: '80px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexShrink: 0
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {isToday ? (
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              bgcolor: '#FB9E3A',
+              color: '#FFF',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '22px',
+              flexShrink: 0
+            }}
+          >
+            {dayNum}
+          </Box>
+        ) : (
+          <Typography
+            sx={{
+              fontSize: '22px',
+              color: theme.palette.grey[900],
+              minWidth: '32px',
+              textAlign: 'center'
+            }}
+          >
+            {dayNum}
+          </Typography>
+        )}
+        <Typography
+          sx={{
+            fontSize: '14px',
+            color: theme.palette.grey[500],
+            textTransform: 'uppercase'
+          }}
+        >
+          {dayName}
+        </Typography>
+      </Box>
+    </Box>
+  )
+}
+
+interface ListEventTimeProps {
+  allDay: boolean
+  startDate: Date
+  endDate: Date
+  timeZone: string
+  t: (key: string) => string
+  isStart?: boolean
+  isEnd?: boolean
+}
+
+export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
+  allDay,
+  startDate,
+  endDate,
+  timeZone,
+  t,
+  isStart = true,
+  isEnd = true
+}) => {
+  const timeOpts: Intl.DateTimeFormatOptions = {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone
+  }
+
+  const isSingleDay = isStart && isEnd
+  const showNormalTime = isSingleDay && !allDay
+
+  if (showNormalTime) {
+    return (
+      <Box sx={{ width: '120px', flexShrink: 0 }}>
+        <RenderTime
+          startDate={startDate}
+          endDate={endDate}
+          allDay={false}
+          t={t}
+          timeZone={timeZone}
+        />
+      </Box>
+    )
+  }
+
+  const isMultiDayStart = isStart && !isEnd
+  const isMultiDayEnd = !isStart && isEnd
+
+  let timeText = t('event.form.allDay')
+  if (isMultiDayStart) {
+    timeText = startDate.toLocaleTimeString(t('locale'), timeOpts)
+  } else if (isMultiDayEnd) {
+    timeText = `${t('event.list.until')} ${endDate.toLocaleTimeString(t('locale'), timeOpts)}`
+  }
+
+  return (
+    <Typography
+      sx={{ fontSize: '16px', fontWeight: 400, width: '120px', flexShrink: 0 }}
+    >
+      {timeText}
+    </Typography>
+  )
+}

--- a/src/features/Search/mobileSearchResultsComponents.tsx
+++ b/src/features/Search/mobileSearchResultsComponents.tsx
@@ -1,0 +1,108 @@
+import {
+  getBestColor,
+  getTitleStyle
+} from '@/components/Event/EventChip/EventChipUtils'
+import { Calendar } from '@/features/Calendars/CalendarTypes'
+import { defaultColors } from '@/utils/defaultColors'
+import { Box, Card, CardHeader, Typography } from '@linagora/twake-mui'
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+import { SearchEventResult } from './types/SearchEventResult'
+
+interface MobileDateProps {
+  startDate: Date
+  t: (key: string) => string
+  timeZone: string
+}
+
+interface MobileEventCardProps {
+  eventData: SearchEventResult
+  calendar: Calendar | undefined
+  timeZone: string
+}
+
+export const RenderMobileDate: React.FC<MobileDateProps> = ({
+  startDate,
+  t,
+  timeZone
+}) => (
+  <Box sx={{ width: '100%' }}>
+    <Typography variant="h4" sx={{ fontWeight: 400 }}>
+      {startDate.toLocaleDateString(t('locale'), { day: '2-digit', timeZone })}
+    </Typography>
+    <Typography variant="caption" color="text.secondary">
+      {startDate
+        .toLocaleDateString(t('locale'), { weekday: 'short', timeZone })
+        .toUpperCase()}
+    </Typography>
+  </Box>
+)
+
+export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
+  eventData,
+  calendar,
+  timeZone
+}) => {
+  const { t } = useI18n()
+
+  const startDate = new Date(eventData.data.start)
+  const bestColor = calendar?.color
+    ? getBestColor(calendar.color as { light: string; dark: string })
+    : defaultColors[0].dark
+  const titleStyle = getTitleStyle(
+    bestColor,
+    'ACCEPTED',
+    calendar ?? ({} as Calendar),
+    false
+  )
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        height: 'stretch',
+        width: '100%',
+        borderRadius: '8px',
+        p: 1,
+        boxShadow: 'none',
+        backgroundColor: calendar?.color?.light,
+        color: calendar?.color?.dark,
+        border: '1px solid',
+        borderColor: 'background.paper',
+        display: 'flex'
+      }}
+      data-testid={`event-card-${eventData.data.uid}`}
+    >
+      <CardHeader
+        sx={{ p: '0px', '& .MuiCardHeader-content': { overflow: 'hidden' } }}
+        title={
+          <Typography variant="body2" noWrap style={titleStyle}>
+            {eventData.data.summary || t('event.untitled')}
+          </Typography>
+        }
+        subheader={
+          !eventData.data.allDay && (
+            <Typography
+              style={{
+                color: titleStyle.color,
+                opacity: '70%',
+                fontFamily: 'Inter',
+                fontWeight: '500',
+                fontSize: '10px',
+                lineHeight: '16px',
+                letterSpacing: '0%',
+                verticalAlign: 'middle'
+              }}
+            >
+              {startDate.toLocaleTimeString(t('locale'), {
+                hour: '2-digit',
+                minute: '2-digit',
+                timeZone: timeZone
+              })}
+            </Typography>
+          )
+        }
+      />
+    </Card>
+  )
+}

--- a/src/features/Search/searchResultsComponents.tsx
+++ b/src/features/Search/searchResultsComponents.tsx
@@ -4,7 +4,17 @@ import {
 } from '@/components/Event/EventChip/EventChipUtils'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import { defaultColors } from '@/utils/defaultColors'
-import { Box, Button, Card, CardHeader, Typography } from '@linagora/twake-mui'
+import {
+  alpha,
+  Avatar,
+  Box,
+  Button,
+  Card,
+  CardHeader,
+  radius,
+  Typography,
+  useTheme
+} from '@linagora/twake-mui'
 import RepeatIcon from '@mui/icons-material/Repeat'
 import VideocamIcon from '@mui/icons-material/Videocam'
 import React from 'react'
@@ -70,7 +80,7 @@ export const RenderDate: React.FC<DateProps> = ({
       timeZone
     })
   return (
-    <Typography variant="h4" sx={{ fontWeight: 400, minWidth: '90px' }}>
+    <Typography sx={{ fontSize: '22px', minWidth: '90px' }}>
       {startDate.toLocaleDateString(t('locale'), {
         day: '2-digit',
         month: 'short',
@@ -99,7 +109,7 @@ export const RenderTime: React.FC<TimeProps> = ({
 }) => {
   if (allDay) return null
   return (
-    <Typography variant="body1" sx={{ minWidth: '120px' }}>
+    <Typography sx={{ minWidth: '120px', fontSize: '16px', fontWeight: 400 }}>
       {startDate.toLocaleTimeString(t('locale'), {
         hour: '2-digit',
         minute: '2-digit',
@@ -119,30 +129,66 @@ export const RenderTitle: React.FC<TitleProps> = ({
   summary,
   isRecurrent,
   t
-}) => (
-  <Box display="flex" flexDirection="row" gap={1} sx={{ minWidth: 0 }}>
-    <Typography variant="h4" sx={{ fontWeight: 400 }}>
-      {summary || t('event.untitled')}
-    </Typography>
-    {isRecurrent && <RepeatIcon />}
-  </Box>
-)
+}) => {
+  const theme = useTheme()
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      gap={1}
+      sx={{ minWidth: 0, maxWidth: '150px', alignItems: 'center' }}
+    >
+      <Typography
+        sx={{
+          fontWeight: 500,
+          fontSize: '17px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap'
+        }}
+      >
+        {summary || t('event.untitled')}
+      </Typography>
+      {isRecurrent && (
+        <RepeatIcon
+          sx={{ flexShrink: 0, color: alpha(theme.palette.grey[900], 0.9) }}
+        />
+      )}
+    </Box>
+  )
+}
 
 export const RenderOrganizer: React.FC<OrganizerProps> = ({ organizer }) => {
   if (!organizer?.cn && !organizer?.email) return null
   return (
-    <Typography
-      variant="body1"
+    <Box
       sx={{
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
         minWidth: '150px',
         maxWidth: '150px'
       }}
     >
-      {organizer.cn || organizer.email}
-    </Typography>
+      <Avatar
+        alt={organizer.cn || organizer.email}
+        sx={{ width: 24, height: 24, fontSize: '0.75rem' }}
+      >
+        {(organizer.cn || organizer.email || '').charAt(0).toUpperCase()}
+      </Avatar>
+      <Typography
+        variant="body1"
+        sx={{
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          flex: 1
+        }}
+      >
+        {organizer.cn || organizer.email}
+      </Typography>
+    </Box>
   )
 }
 
@@ -156,8 +202,8 @@ export const RenderText: React.FC<{ text?: string }> = ({ text }) => {
         whiteSpace: 'nowrap',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
-        minWidth: '150px',
-        maxWidth: '250px'
+        minWidth: 0,
+        maxWidth: '200px'
       }}
     >
       {text.replace(/\n/g, ' ')}
@@ -166,11 +212,42 @@ export const RenderText: React.FC<{ text?: string }> = ({ text }) => {
 }
 
 export const RenderVideoJoin: React.FC<VideoJoinProps> = ({ url, t }) => {
+  const theme = useTheme()
+
   if (!url) return null
   return (
     <Button
-      startIcon={<VideocamIcon />}
-      sx={{ flexShrink: 0, ml: 'auto' }}
+      variant="contained"
+      disableElevation
+      startIcon={
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.palette.success.main,
+            borderRadius: '50%',
+            width: 20,
+            height: 20
+          }}
+        >
+          <VideocamIcon
+            sx={{ color: theme.palette.info.contrastText, fontSize: 14 }}
+          />
+        </Box>
+      }
+      sx={{
+        flexShrink: 0,
+        ml: 'auto',
+        backgroundColor: theme.palette.grey[200],
+        color: theme.palette.text.primary,
+        textTransform: 'none',
+        fontWeight: 500,
+        borderRadius: radius.md,
+        '&:hover': {
+          backgroundColor: theme.palette.grey[300]
+        }
+      }}
       onClick={e => {
         e.stopPropagation()
         try {
@@ -268,5 +345,121 @@ export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
         }
       />
     </Card>
+  )
+}
+
+interface DayIndicatorProps {
+  isFirstRow: boolean
+  isToday: boolean
+  dayNum: string
+  dayName: string
+}
+
+export const RenderDayIndicator: React.FC<DayIndicatorProps> = ({
+  isFirstRow,
+  isToday,
+  dayNum,
+  dayName
+}) => {
+  const theme = useTheme()
+
+  if (!isFirstRow) {
+    return <Box sx={{ width: '80px', flexShrink: 0 }} />
+  }
+
+  return (
+    <Box
+      sx={{
+        width: '80px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexShrink: 0
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {isToday ? (
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              bgcolor: '#FB9E3A',
+              color: '#FFF',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '22px',
+              flexShrink: 0
+            }}
+          >
+            {dayNum}
+          </Box>
+        ) : (
+          <Typography
+            sx={{
+              fontSize: '22px',
+              color: theme.palette.grey[900],
+              minWidth: '32px',
+              textAlign: 'center'
+            }}
+          >
+            {dayNum}
+          </Typography>
+        )}
+        <Typography
+          sx={{
+            fontSize: '14px',
+            color: theme.palette.grey[500],
+            textTransform: 'uppercase'
+          }}
+        >
+          {dayName}
+        </Typography>
+      </Box>
+    </Box>
+  )
+}
+
+interface ListEventTimeProps {
+  allDay: boolean
+  startDate: Date
+  endDate: Date
+  timeZone: string
+  t: (key: string) => string
+}
+
+export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
+  allDay,
+  startDate,
+  endDate,
+  timeZone,
+  t
+}) => {
+  if (allDay) {
+    return (
+      <Typography
+        sx={{
+          fontSize: '16px',
+          fontWeight: 400,
+          width: '120px',
+          flexShrink: 0
+        }}
+      >
+        {t('event.form.allDay')}
+      </Typography>
+    )
+  }
+
+  return (
+    <Box sx={{ width: '120px', flexShrink: 0 }}>
+      <RenderTime
+        startDate={startDate}
+        endDate={endDate}
+        allDay={false}
+        t={t}
+        timeZone={timeZone}
+      />
+    </Box>
   )
 }

--- a/src/features/Search/searchResultsComponents.tsx
+++ b/src/features/Search/searchResultsComponents.tsx
@@ -1,16 +1,8 @@
 import {
-  getBestColor,
-  getTitleStyle
-} from '@/components/Event/EventChip/EventChipUtils'
-import { Calendar } from '@/features/Calendars/CalendarTypes'
-import { defaultColors } from '@/utils/defaultColors'
-import {
   alpha,
   Avatar,
   Box,
   Button,
-  Card,
-  CardHeader,
   radius,
   Typography,
   useTheme
@@ -18,8 +10,6 @@ import {
 import RepeatIcon from '@mui/icons-material/Repeat'
 import VideocamIcon from '@mui/icons-material/Videocam'
 import React from 'react'
-import { useI18n } from 'twake-i18n'
-import { SearchEventResult } from './types/SearchEventResult'
 
 interface DateProps {
   startDate: Date
@@ -52,18 +42,6 @@ interface OrganizerProps {
 interface VideoJoinProps {
   url?: string
   t: (key: string) => string
-}
-
-interface MobileDateProps {
-  startDate: Date
-  t: (key: string) => string
-  timeZone: string
-}
-
-interface MobileEventCardProps {
-  eventData: SearchEventResult
-  calendar: Calendar | undefined
-  timeZone: string
 }
 
 export const RenderDate: React.FC<DateProps> = ({
@@ -262,204 +240,5 @@ export const RenderVideoJoin: React.FC<VideoJoinProps> = ({ url, t }) => {
     >
       {t('eventPreview.joinVideoShort')}
     </Button>
-  )
-}
-
-export const RenderMobileDate: React.FC<MobileDateProps> = ({
-  startDate,
-  t,
-  timeZone
-}) => (
-  <Box sx={{ width: '100%' }}>
-    <Typography variant="h4" sx={{ fontWeight: 400 }}>
-      {startDate.toLocaleDateString(t('locale'), { day: '2-digit', timeZone })}
-    </Typography>
-    <Typography variant="caption" color="text.secondary">
-      {startDate
-        .toLocaleDateString(t('locale'), { weekday: 'short', timeZone })
-        .toUpperCase()}
-    </Typography>
-  </Box>
-)
-
-export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
-  eventData,
-  calendar,
-  timeZone
-}) => {
-  const { t } = useI18n()
-
-  if (!calendar) return null
-
-  const startDate = new Date(eventData.data.start)
-  const bestColor = calendar.color
-    ? getBestColor(calendar.color as { light: string; dark: string })
-    : defaultColors[0].dark
-  const titleStyle = getTitleStyle(bestColor, 'ACCEPTED', calendar, false)
-
-  return (
-    <Card
-      variant="outlined"
-      sx={{
-        height: 'stretch',
-        width: '100%',
-        borderRadius: '8px',
-        p: 1,
-        boxShadow: 'none',
-        backgroundColor: calendar?.color?.light,
-        color: calendar?.color?.dark,
-        border: '1px solid',
-        borderColor: 'background.paper',
-        display: 'flex'
-      }}
-      data-testid={`event-card-${eventData.data.uid}`}
-    >
-      <CardHeader
-        sx={{ p: '0px', '& .MuiCardHeader-content': { overflow: 'hidden' } }}
-        title={
-          <Typography variant="body2" noWrap style={titleStyle}>
-            {eventData.data.summary || t('event.untitled')}
-          </Typography>
-        }
-        subheader={
-          !eventData.data.allDay && (
-            <Typography
-              style={{
-                color: titleStyle.color,
-                opacity: '70%',
-                fontFamily: 'Inter',
-                fontWeight: '500',
-                fontSize: '10px',
-                lineHeight: '16px',
-                letterSpacing: '0%',
-                verticalAlign: 'middle'
-              }}
-            >
-              {startDate.toLocaleTimeString(t('locale'), {
-                hour: '2-digit',
-                minute: '2-digit',
-                timeZone: timeZone
-              })}
-            </Typography>
-          )
-        }
-      />
-    </Card>
-  )
-}
-
-interface DayIndicatorProps {
-  isFirstRow: boolean
-  isToday: boolean
-  dayNum: string
-  dayName: string
-}
-
-export const RenderDayIndicator: React.FC<DayIndicatorProps> = ({
-  isFirstRow,
-  isToday,
-  dayNum,
-  dayName
-}) => {
-  const theme = useTheme()
-
-  if (!isFirstRow) {
-    return <Box sx={{ width: '80px', flexShrink: 0 }} />
-  }
-
-  return (
-    <Box
-      sx={{
-        width: '80px',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 1,
-        flexShrink: 0
-      }}
-    >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        {isToday ? (
-          <Box
-            sx={{
-              width: 32,
-              height: 32,
-              borderRadius: '50%',
-              bgcolor: '#FB9E3A',
-              color: '#FFF',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: '22px',
-              flexShrink: 0
-            }}
-          >
-            {dayNum}
-          </Box>
-        ) : (
-          <Typography
-            sx={{
-              fontSize: '22px',
-              color: theme.palette.grey[900],
-              minWidth: '32px',
-              textAlign: 'center'
-            }}
-          >
-            {dayNum}
-          </Typography>
-        )}
-        <Typography
-          sx={{
-            fontSize: '14px',
-            color: theme.palette.grey[500],
-            textTransform: 'uppercase'
-          }}
-        >
-          {dayName}
-        </Typography>
-      </Box>
-    </Box>
-  )
-}
-
-interface ListEventTimeProps {
-  allDay: boolean
-  startDate: Date
-  endDate: Date
-  timeZone: string
-  t: (key: string) => string
-}
-
-export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
-  allDay,
-  startDate,
-  endDate,
-  timeZone,
-  t
-}) => {
-  if (allDay) {
-    return (
-      <Typography
-        sx={{
-          fontSize: '16px',
-          fontWeight: 400,
-          width: '120px',
-          flexShrink: 0
-        }}
-      >
-        {t('event.form.allDay')}
-      </Typography>
-    )
-  }
-
-  return (
-    <Box sx={{ width: '120px', flexShrink: 0 }}>
-      <RenderTime
-        startDate={startDate}
-        endDate={endDate}
-        allDay={false}
-        t={t}
-        timeZone={timeZone}
-      />
-    </Box>
   )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -109,6 +109,10 @@
     "updateEvent": "Update Event",
     "organizer": "Organizer",
     "untitled": "Untitled",
+    "noEventsToDisplay": "No events to display",
+    "list": {
+      "until": "Until"
+    },
     "repeat": {
       "repeatEvery": "Repeat every",
       "frequency": {
@@ -256,7 +260,8 @@
     "views": {
       "month": "Month",
       "week": "Week",
-      "day": "Day"
+      "day": "Day",
+      "schedule": "Schedule"
     },
     "apps": "Apps",
     "userProfile": "User profile",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -110,6 +110,10 @@
     "updateEvent": "Mettre à jour un événement",
     "organizer": "Organisateur",
     "untitled": "Sans titre",
+    "noEventsToDisplay": "Aucun événement à afficher",
+    "list": {
+      "until": "Jusqu'à"
+    },
     "repeat": {
       "repeatEvery": "Répéter tous les",
       "frequency": {
@@ -256,7 +260,8 @@
     "views": {
       "month": "Mois",
       "week": "Semaine",
-      "day": "Jour"
+      "day": "Jour",
+      "schedule": "Programme"
     },
     "apps": "Applications",
     "userProfile": "Profil utilisateur",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -110,6 +110,10 @@
     "updateEvent": "Обновить событие",
     "organizer": "Организатор",
     "untitled": "Без названия",
+    "noEventsToDisplay": "Нет событий для отображения",
+    "list": {
+      "until": "До"
+    },
     "repeat": {
       "repeatEvery": "Повторять каждые",
       "frequency": {
@@ -256,7 +260,8 @@
     "views": {
       "month": "Месяц",
       "week": "Неделя",
-      "day": "День"
+      "day": "День",
+      "schedule": "Расписание"
     },
     "apps": "Приложения",
     "userProfile": "Профиль",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -108,6 +108,10 @@
     "updateEvent": "Cập nhật sự kiện",
     "organizer": "Người tổ chức",
     "untitled": "Không có tiêu đề",
+    "noEventsToDisplay": "Không có sự kiện để hiển thị",
+    "list": {
+      "until": "Đến"
+    },
     "repeat": {
       "repeatEvery": "Lặp lại mỗi",
       "frequency": {
@@ -254,7 +258,8 @@
     "views": {
       "month": "Tháng",
       "week": "Tuần",
-      "day": "Ngày"
+      "day": "Ngày",
+      "schedule": "Lịch trình"
     },
     "apps": "Ứng dụng",
     "userProfile": "Hồ sơ người dùng",


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/882

https://github.com/linagora/twake-calendar-frontend/issues/883

<img width="1512" height="808" alt="image" src="https://github.com/user-attachments/assets/5c3efcb4-f7bc-4d4c-b830-5d3bccd78d8b" />

<img width="1512" height="809" alt="image" src="https://github.com/user-attachments/assets/65c70250-057b-4f2d-89c9-e6c358e24615" />

Currently, the schedule view only available in desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Schedule (listWeek) calendar view, a schedule-style event chip, new desktop/mobile list renderers, and search result item with richer previews and video join links; hooks to find/upcoming events and auto-scroll/restore list scroll.

* **Improvements**
  * Events now sort by start→end→priority; list-week filters out past events; loading shows spinner while pending; view selector and list styling updated.

* **Localization**
  * Added schedule/list-related strings in EN/FR/RU/VI.

* **Tests**
  * Made event formatting deterministic in tests by supplying an explicit translation callback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->