### PR TITLE
[#908] added option to hide connected user from search result

### DIFF
--- a/src/components/Attendees/AttendeeSearch.tsx
+++ b/src/components/Attendees/AttendeeSearch.tsx
@@ -174,6 +174,7 @@ export const AttendeeSearch: React.FC<{
   return (
     <PeopleSearch
       selectedUsers={selectedUsers}
+      showCurrentUser
       objectTypes={['user', 'contact']}
       disabled={disabled}
       inputSlot={inputSlot}

--- a/src/components/Attendees/PeopleSearch.tsx
+++ b/src/components/Attendees/PeopleSearch.tsx
@@ -28,6 +28,7 @@ import { usePasteHandler } from './usePasteHandler'
 import { User } from './types'
 import { AttendeeChip } from './AttendeeChip'
 import { SearchState } from '../Calendar/utils/tempSearchUtil'
+import { useAppSelector } from '@/app/hooks'
 
 export interface ExtendedAutocompleteRenderInputParams extends AutocompleteRenderInputParams {
   error?: boolean
@@ -58,6 +59,7 @@ export interface PeopleSearchProps {
   }
   getChipIcon?: (user: User) => ReactElement
   hideOptions?: boolean
+  showCurrentUser?: boolean
   onSearchStateChange?: (state: SearchState) => void
   inputValue?: string
   inputStyles?: SxProps
@@ -76,6 +78,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
   customSlotProps,
   getChipIcon,
   hideOptions,
+  showCurrentUser,
   onSearchStateChange,
   inputValue,
   inputStyles
@@ -85,6 +88,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
   const errorMessage = t('peopleSearch.searchError')
 
   const lastQueryTimeRef = useRef(0)
+  const currentUser = useAppSelector(state => state.user?.userData)
 
   const {
     query,
@@ -101,7 +105,12 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
     snackbarMessage,
     setSnackbarMessage,
     queryTime
-  } = useUserSearch<User>({ objectTypes, errorMessage })
+  } = useUserSearch<User>({
+    objectTypes,
+    errorMessage,
+    showCurrentUser,
+    currentUser
+  })
 
   const onSearchStateChangeRef = useRef(onSearchStateChange)
   useEffect(() => {
@@ -336,6 +345,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
               (user, index, self) =>
                 self.findIndex(u => u.email === user.email) === index
             )
+
           onChange(event, mapped)
         }}
         slotProps={{

--- a/src/components/Attendees/PeopleSearch.tsx
+++ b/src/components/Attendees/PeopleSearch.tsx
@@ -17,7 +17,6 @@ import {
   ReactElement,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   type ReactNode,
   type SyntheticEvent
@@ -162,13 +161,24 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
     t
   })
 
+  const handleAutocompleteChange = useCallback(
+    (event: SyntheticEvent, value: (string | User)[]) => {
+      const last = value[value.length - 1]
+      if (typeof last === 'string' && !isValidEmail(last.trim())) {
+        setInputError(t('peopleSearch.invalidEmail').replace('%{email}', last))
+        return
+      }
+      setInputError(null)
+      onChange(event, dedupeByEmail(value.map(normaliseUser)))
+    },
+    [onChange, setInputError, t]
+  )
+
   const defaultRenderInput = useCallback(
     (params: AutocompleteRenderInputParams) => {
       const inputProps = {
         ...params.InputProps,
-        startAdornment: params.InputProps.startAdornment ? (
-          params.InputProps.startAdornment
-        ) : (
+        startAdornment: params.InputProps.startAdornment ?? (
           <PeopleOutlineOutlinedIcon
             fontSize="small"
             sx={{ mr: 1, color: 'action.active' }}
@@ -263,23 +273,15 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
     ]
   )
 
-  const isOpenOptions = useMemo(() => {
-    if (hideOptions) return false
-    if (customRenderInput) {
-      return (
-        isOpen && !!query && ((loading && hasSearched) || options.length > 0)
-      )
-    }
-    return isOpen && !!query && (loading || hasSearched)
-  }, [
-    customRenderInput,
-    hasSearched,
+  const isOpenOptions = resolveIsOpen({
     hideOptions,
     isOpen,
+    query,
     loading,
-    options.length,
-    query
-  ])
+    hasSearched,
+    options,
+    hasCustomRenderInput: !!customRenderInput
+  })
 
   return (
     <>
@@ -300,13 +302,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
         fullWidth
         noOptionsText={t('peopleSearch.noResults')}
         loadingText={t('peopleSearch.loading')}
-        getOptionLabel={option => {
-          if (typeof option === 'object') {
-            return option.displayName || option.email
-          } else {
-            return option
-          }
-        }}
+        getOptionLabel={getOptionLabel}
         sx={{
           '& .MuiAutocomplete-inputRoot.MuiOutlinedInput-root': {
             py: 0,
@@ -324,30 +320,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
         value={selectedUsers}
         inputValue={query}
         onInputChange={(_event, value) => setQuery(value)}
-        onChange={(event, value) => {
-          const last = value[value.length - 1]
-          if (typeof last === 'string' && !isValidEmail(last.trim())) {
-            const invalidEmailMessage = t('peopleSearch.invalidEmail').replace(
-              '%{email}',
-              last
-            )
-            setInputError(invalidEmailMessage)
-            return
-          }
-          setInputError(null)
-          const mapped = value
-            .map((v: string | User) =>
-              typeof v === 'string'
-                ? { email: v.trim(), displayName: v.trim() }
-                : v
-            )
-            .filter(
-              (user, index, self) =>
-                self.findIndex(u => u.email === user.email) === index
-            )
-
-          onChange(event, mapped)
-        }}
+        onChange={handleAutocompleteChange}
         slotProps={{
           ...customSlotProps,
           popper: {
@@ -397,4 +370,39 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
       />
     </>
   )
+}
+
+export const getOptionLabel = (option: User | string): string => {
+  if (typeof option === 'string') return option
+  return option.displayName || option.email
+}
+
+export const normaliseUser = (v: string | User): User =>
+  typeof v === 'string' ? { email: v.trim(), displayName: v.trim() } : v
+
+export const dedupeByEmail = (users: User[]): User[] =>
+  users.filter((u, i, arr) => arr.findIndex(x => x.email === u.email) === i)
+
+export const resolveIsOpen = ({
+  hideOptions,
+  isOpen,
+  query,
+  loading,
+  hasSearched,
+  options,
+  hasCustomRenderInput
+}: {
+  hideOptions?: boolean
+  isOpen: boolean
+  query: string
+  loading: boolean
+  hasSearched: boolean
+  options: unknown[]
+  hasCustomRenderInput: boolean
+}): boolean => {
+  if (hideOptions) return false
+  if (!isOpen || !query) return false
+  if (hasCustomRenderInput)
+    return (loading && hasSearched) || options.length > 0
+  return loading || hasSearched
 }

--- a/src/components/Attendees/useUserSearch.ts
+++ b/src/components/Attendees/useUserSearch.ts
@@ -95,7 +95,7 @@ export function useUserSearch<T>({
       cancelled = true
       clearTimeout(delayDebounceFn)
     }
-  }, [objectTypesRef, query, errorMessage])
+  }, [objectTypesRef, query, errorMessage, showCurrentUser, currentUser])
 
   return {
     query,

--- a/src/components/Attendees/useUserSearch.ts
+++ b/src/components/Attendees/useUserSearch.ts
@@ -1,14 +1,19 @@
 import { useState, useEffect, useRef } from 'react'
 import { searchUsers } from '@/features/User/userAPI'
+import { userData } from '@/features/User/userDataTypes'
 
 export interface UseUserSearchProps {
   objectTypes: string[]
   errorMessage: string
+  showCurrentUser?: boolean
+  currentUser?: userData
 }
 
 export function useUserSearch<T>({
   objectTypes,
-  errorMessage
+  errorMessage,
+  showCurrentUser,
+  currentUser
 }: UseUserSearchProps): {
   query: string
   setQuery: (query: string) => void
@@ -64,7 +69,11 @@ export function useUserSearch<T>({
       try {
         const res = await searchUsers(query, objectTypesRef.current)
         if (cancelled) return
-        setOptions(res as unknown as T[])
+        setOptions(
+          (showCurrentUser || !currentUser
+            ? res
+            : res.filter(o => o.email !== currentUser.email)) as unknown as T[]
+        )
         setHasSearched(true)
       } catch {
         setHasSearched(false)

--- a/src/components/Menubar/EventSearchBar.tsx
+++ b/src/components/Menubar/EventSearchBar.tsx
@@ -202,6 +202,7 @@ const SearchBar: React.FC<{
         {extended && (
           <PeopleSearch
             selectedUsers={selectedContacts}
+            showCurrentUser
             onChange={(_event, users) => {
               handleContactSelect(users)
             }}

--- a/src/components/Menubar/MobileEventSearchBar.tsx
+++ b/src/components/Menubar/MobileEventSearchBar.tsx
@@ -35,6 +35,7 @@ const MobileSearchBar: React.FC = () => {
           selectedUsers={selectedContacts}
           onChange={(_event, users) => handleContactSelect(users)}
           hideOptions
+          showCurrentUser
           inputValue={inputQuery}
           onSearchStateChange={handleSearchChange}
           objectTypes={SEARCH_OBJECT_TYPES}

--- a/src/features/Search/MobileFilterPicker.tsx
+++ b/src/features/Search/MobileFilterPicker.tsx
@@ -77,6 +77,7 @@ const FilterDrawer: React.FC<FilterDrawerProps> = ({
             onClose()
           }}
           hideOptions
+          showCurrentUser
           inputValue={inputQuery}
           onSearchStateChange={handleSearchChange}
           objectTypes={objectTypes}


### PR DESCRIPTION
resolves #908 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can choose whether their own account appears in people/attendee searches across desktop and mobile.
* **Improvements**
  * Autocomplete now validates email input, normalizes entries, and deduplicates results by email for cleaner selections.
  * Autocomplete open/close behavior improved for more consistent option visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->