### PR TITLE
884 responsive for scheduling view

### DIFF
--- a/src/components/Calendar/CalendarLayout.tsx
+++ b/src/components/Calendar/CalendarLayout.tsx
@@ -31,15 +31,22 @@ export default function CalendarLayout(): JSX.Element {
       : CALENDAR_VIEWS.timeGridWeek
   )
 
+  const currentViewModeRef = useRef<string>()
+
   useEffect(() => {
-    const setView = (): void =>
-      setCurrentView(
+    const setView = (): void => {
+      if (currentViewModeRef.current) return
+      const storedView =
         isTablet || isMobile
           ? CALENDAR_VIEWS.timeGridDay
           : CALENDAR_VIEWS.timeGridWeek
-      )
+      setCurrentView(storedView)
+      currentViewModeRef.current = storedView
+    }
+
     setView()
   }, [isTablet, isMobile])
+
   const isInIframe = useMemo(() => new CozyBridge().isInIframe(), [])
 
   const handleRefresh = async (): Promise<void> => {

--- a/src/components/Calendar/Sidebar/ViewSwitcher.tsx
+++ b/src/components/Calendar/Sidebar/ViewSwitcher.tsx
@@ -9,6 +9,7 @@ import {
 import CalendarViewDayOutlinedIcon from '@mui/icons-material/CalendarViewDayOutlined'
 import CalendarViewMonthOutlinedIcon from '@mui/icons-material/CalendarViewMonthOutlined'
 import CalendarViewWeekOutlinedIcon from '@mui/icons-material/CalendarViewWeekOutlined'
+import ScheduleOutlinedIcon from '@mui/icons-material/ScheduleOutlined'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from '../../Event/components/FieldWithLabel'
 import { CALENDAR_VIEWS } from '../utils/constants'
@@ -29,6 +30,11 @@ const VIEW_OPTIONS = [
     label: 'menubar.views.month',
     value: CALENDAR_VIEWS.dayGridMonth,
     icon: <CalendarViewMonthOutlinedIcon />
+  },
+  {
+    label: 'menubar.views.schedule',
+    value: CALENDAR_VIEWS.listWeek,
+    icon: <ScheduleOutlinedIcon />
   }
 ]
 

--- a/src/components/Event/EventChip/DesktopEventChipSchedule.tsx
+++ b/src/components/Event/EventChip/DesktopEventChipSchedule.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { EventContentArg } from '@fullcalendar/core'
+import { alpha, Box, useTheme } from '@linagora/twake-mui'
+import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
+import { Calendar } from '@/features/Calendars/CalendarTypes'
+import { CalendarEvent } from '@/features/Events/EventsTypes'
+import { useI18n } from 'twake-i18n'
+import { defaultColors } from '@/utils/defaultColors'
+import {
+  RenderOrganizer,
+  RenderVideoJoin,
+  RenderTitle,
+  RenderText
+} from '@/features/Search/searchResultsComponents'
+import {
+  RenderDayIndicator,
+  RenderListEventTime
+} from '@/features/Search/listSearchResultsComponents'
+import { type EventChipScheduleProps } from './EventChipSchedule'
+
+export interface DesktopEventChipScheduleProps extends EventChipScheduleProps {
+  arg: EventContentArg
+  calendars: Record<string, Calendar>
+  tempcalendars: Record<string, Calendar>
+  timezone: string
+  dayData: {
+    isFirstRow: boolean
+    isToday: boolean
+    dayNum: string
+    dayName: string
+  }
+  upcommingEventId?: string
+}
+
+export const DesktopEventChipSchedule: React.FC<
+  DesktopEventChipScheduleProps
+> = ({
+  arg,
+  calendars,
+  tempcalendars,
+  timezone,
+  dayData,
+  upcommingEventId
+}) => {
+  const { t } = useI18n()
+  const theme = useTheme()
+
+  const ext = arg.event.extendedProps as CalendarEvent
+  const { temp } = arg.event._def.extendedProps
+  const isRecurrent = !!ext.repetition
+  const videoUrl = ext.x_openpass_videoconference
+  const calendarsSource = temp ? tempcalendars : calendars
+  const calendar = calendarsSource[ext.calId]
+  const calendarColor = calendar?.color?.light ?? defaultColors[0].light
+
+  return (
+    <Box
+      data-event-id={ext.uid}
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        gap: 2,
+        alignItems: 'center',
+        textAlign: 'left',
+        width: '100%',
+        p: 3,
+        backgroundColor:
+          upcommingEventId === ext.uid
+            ? alpha(theme.palette.grey[200], 0.5)
+            : 'transparent'
+      }}
+    >
+      <RenderDayIndicator {...dayData} />
+      <RenderListEventTime
+        allDay={arg.event.allDay}
+        startDate={arg.event.start || new Date()}
+        endDate={arg.event.end || arg.event.start || new Date()}
+        timeZone={timezone}
+        t={t}
+        isStart={arg.isStart}
+        isEnd={arg.isEnd}
+      />
+      <SquareRoundedIcon
+        style={{ color: calendarColor, width: 24, height: 24, flexShrink: 0 }}
+      />
+      <RenderTitle summary={arg.event.title} isRecurrent={isRecurrent} t={t} />
+      <RenderOrganizer organizer={ext.organizer} />
+      <RenderText text={ext.location} />
+      <RenderText text={ext.description} />
+      <Box sx={{ ml: 'auto', flexShrink: 0 }}>
+        <RenderVideoJoin t={t} url={videoUrl} />
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/Event/EventChip/EventChipSchedule.tsx
+++ b/src/components/Event/EventChip/EventChipSchedule.tsx
@@ -1,23 +1,12 @@
 import React from 'react'
 import { EventContentArg, EventApi } from '@fullcalendar/core'
 import moment from 'moment-timezone'
-import { alpha, Box, useTheme } from '@linagora/twake-mui'
-import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
+import { sortEventsByDateTime } from '@/components/Calendar/utils/calendarUtils'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import { CalendarEvent } from '@/features/Events/EventsTypes'
-import { useI18n } from 'twake-i18n'
-import { defaultColors } from '@/utils/defaultColors'
-import {
-  RenderOrganizer,
-  RenderVideoJoin,
-  RenderTitle,
-  RenderText
-} from '@/features/Search/searchResultsComponents'
-import {
-  RenderDayIndicator,
-  RenderListEventTime
-} from '@/features/Search/listSearchResultsComponents'
-import { sortEventsByDateTime } from '@/components/Calendar/utils/calendarUtils'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
+import { DesktopEventChipSchedule } from './DesktopEventChipSchedule'
+import { MobileEventChipSchedule } from './MobileEventChipSchedule'
 
 export interface EventChipScheduleProps {
   arg: EventContentArg
@@ -114,60 +103,26 @@ export const EventChipSchedule: React.FC<EventChipScheduleProps> = ({
   timezone,
   upcommingEventId
 }) => {
-  const { t } = useI18n()
-  const theme = useTheme()
-
-  const ext = arg.event.extendedProps as CalendarEvent
-  const { temp } = arg.event._def.extendedProps
-  const isRecurrent = !!ext.repetition
-  const videoUrl = ext.x_openpass_videoconference
-  const calendarsSource = temp ? tempcalendars : calendars
-  const calendar = calendarsSource[ext.calId]
-  const calendarColor = calendar?.color?.light ?? defaultColors[0].light
-
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
   const dayData = buildListDayData(arg, timezone)
 
-  if (dayData.isInPast) {
-    return null
-  }
-
-  return (
-    <Box
-      data-event-id={ext.uid}
-      sx={{
-        display: 'flex',
-        flexDirection: 'row',
-        gap: 2,
-        alignItems: 'center',
-        textAlign: 'left',
-        width: '100%',
-        p: 3,
-        backgroundColor:
-          upcommingEventId === ext.uid
-            ? alpha(theme.palette.grey[200], 0.5)
-            : 'transparent'
-      }}
-    >
-      <RenderDayIndicator {...dayData} />
-      <RenderListEventTime
-        allDay={arg.event.allDay}
-        startDate={arg.event.start || new Date()}
-        endDate={arg.event.end || arg.event.start || new Date()}
-        timeZone={timezone}
-        t={t}
-        isStart={arg.isStart}
-        isEnd={arg.isEnd}
-      />
-      <SquareRoundedIcon
-        style={{ color: calendarColor, width: 24, height: 24, flexShrink: 0 }}
-      />
-      <RenderTitle summary={arg.event.title} isRecurrent={isRecurrent} t={t} />
-      <RenderOrganizer organizer={ext.organizer} />
-      <RenderText text={ext.location} />
-      <RenderText text={ext.description} />
-      <Box sx={{ ml: 'auto', flexShrink: 0 }}>
-        <RenderVideoJoin t={t} url={videoUrl} />
-      </Box>
-    </Box>
+  return isMobile ? (
+    <MobileEventChipSchedule
+      arg={arg}
+      calendars={calendars}
+      tempcalendars={tempcalendars}
+      timezone={timezone}
+      dayData={dayData}
+      upcommingEventId={upcommingEventId}
+    />
+  ) : (
+    <DesktopEventChipSchedule
+      arg={arg}
+      calendars={calendars}
+      tempcalendars={tempcalendars}
+      timezone={timezone}
+      dayData={dayData}
+      upcommingEventId={upcommingEventId}
+    />
   )
 }

--- a/src/components/Event/EventChip/MobileEventChipSchedule.tsx
+++ b/src/components/Event/EventChip/MobileEventChipSchedule.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+import { EventContentArg } from '@fullcalendar/core'
+import { alpha, Box, useTheme } from '@linagora/twake-mui'
+import { Calendar } from '@/features/Calendars/CalendarTypes'
+import { CalendarEvent } from '@/features/Events/EventsTypes'
+import { type EventChipScheduleProps } from './EventChipSchedule'
+import {
+  RenderDayIndicator,
+  RenderListEventTime
+} from '@/features/Search/listSearchResultsComponents'
+import { RenderMobileEventCard } from '@/features/Search/mobileSearchResultsComponents'
+import { SearchEventResult } from '@/features/Search/types/SearchEventResult'
+import { useI18n } from 'twake-i18n'
+
+export interface MobileEventChipScheduleProps extends EventChipScheduleProps {
+  arg: EventContentArg
+  calendars: Record<string, Calendar>
+  tempcalendars: Record<string, Calendar>
+  timezone: string
+  dayData: {
+    isFirstRow: boolean
+    isToday: boolean
+    dayNum: string
+    dayName: string
+  }
+  upcommingEventId?: string
+}
+
+const parseEventToSearchResult = (
+  arg: EventContentArg,
+  ext: CalendarEvent,
+  videoUrl: string | undefined
+): SearchEventResult => {
+  const eventData: SearchEventResult = {
+    data: {
+      uid: ext.uid || arg.event.id || '',
+      userId: '',
+      calendarId: ext.calId || '',
+      start: (arg.event.start ?? new Date()).toISOString(),
+      end: arg.event.end ? arg.event.end.toISOString() : undefined,
+      allDay: arg.event.allDay,
+      summary: arg.event.title,
+      description: ext.description,
+      location: ext.location,
+      ['x-openpaas-videoconference']: videoUrl
+    },
+    _links: {
+      self: {
+        href: ''
+      }
+    }
+  }
+  return eventData
+}
+
+export const MobileEventChipSchedule: React.FC<
+  MobileEventChipScheduleProps
+> = ({
+  arg,
+  calendars,
+  tempcalendars,
+  timezone,
+  dayData,
+  upcommingEventId
+}) => {
+  const { t } = useI18n()
+  const theme = useTheme()
+
+  const ext = arg.event.extendedProps as CalendarEvent
+  const { temp } = arg.event._def.extendedProps
+  const calendarsSource = temp ? tempcalendars : calendars
+  const calendar = calendarsSource[ext.calId]
+  const videoUrl = ext.x_openpass_videoconference
+
+  if (!calendar) return null
+
+  const eventData: SearchEventResult = parseEventToSearchResult(
+    arg,
+    ext,
+    videoUrl
+  )
+
+  return (
+    <Box
+      data-event-id={ext.uid}
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        textAlign: 'left',
+        width: '100%',
+        py: 0.5,
+        px: 1,
+        backgroundColor:
+          upcommingEventId === ext.uid
+            ? alpha(theme.palette.grey[200], 0.5)
+            : 'transparent'
+      }}
+    >
+      <RenderDayIndicator {...dayData} isMobile={true} />
+      <RenderMobileEventCard
+        eventData={eventData}
+        calendar={calendar}
+        timeZone={timezone}
+        customSubHeader={(titleStyle: React.CSSProperties) => (
+          <RenderListEventTime
+            allDay={arg.event.allDay}
+            startDate={arg.event.start || new Date()}
+            endDate={arg.event.end || arg.event.start || new Date()}
+            timeZone={timezone}
+            t={t}
+            isStart={arg.isStart}
+            isEnd={arg.isEnd}
+            styles={{
+              color: titleStyle.color,
+              opacity: '70%',
+              fontFamily: 'Inter',
+              fontWeight: '500',
+              fontSize: '10px',
+              lineHeight: '16px',
+              letterSpacing: '0%',
+              verticalAlign: 'middle'
+            }}
+          />
+        )}
+      />
+    </Box>
+  )
+}

--- a/src/features/Search/listSearchResultsComponents.tsx
+++ b/src/features/Search/listSearchResultsComponents.tsx
@@ -7,31 +7,40 @@ interface DayIndicatorProps {
   isToday: boolean
   dayNum: string
   dayName: string
+  isMobile?: boolean
 }
 
 export const RenderDayIndicator: React.FC<DayIndicatorProps> = ({
   isFirstRow,
   isToday,
   dayNum,
-  dayName
+  dayName,
+  isMobile
 }) => {
   const theme = useTheme()
 
   if (!isFirstRow) {
-    return <Box sx={{ width: '80px', flexShrink: 0 }} />
+    return <Box sx={{ width: isMobile ? '60px' : '80px', flexShrink: 0 }} />
   }
 
   return (
     <Box
       sx={{
-        width: '80px',
+        width: isMobile ? '60px' : '80px',
         display: 'flex',
         alignItems: 'center',
         gap: 1,
         flexShrink: 0
       }}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: isMobile ? 0 : 1,
+          flexDirection: isMobile ? 'column' : 'row'
+        }}
+      >
         {isToday ? (
           <Box
             sx={{
@@ -83,6 +92,7 @@ interface ListEventTimeProps {
   t: (key: string) => string
   isStart?: boolean
   isEnd?: boolean
+  styles?: React.CSSProperties
 }
 
 export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
@@ -92,7 +102,8 @@ export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
   timeZone,
   t,
   isStart = true,
-  isEnd = true
+  isEnd = true,
+  styles
 }) => {
   const timeOpts: Intl.DateTimeFormatOptions = {
     hour: '2-digit',
@@ -112,6 +123,7 @@ export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
           allDay={false}
           t={t}
           timeZone={timeZone}
+          styles={styles}
         />
       </Box>
     )
@@ -129,7 +141,13 @@ export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
 
   return (
     <Typography
-      sx={{ fontSize: '16px', fontWeight: 400, width: '120px', flexShrink: 0 }}
+      sx={{
+        fontSize: '16px',
+        fontWeight: 400,
+        width: '120px',
+        flexShrink: 0,
+        ...(styles || {})
+      }}
     >
       {timeText}
     </Typography>

--- a/src/features/Search/mobileSearchResultsComponents.tsx
+++ b/src/features/Search/mobileSearchResultsComponents.tsx
@@ -19,6 +19,7 @@ interface MobileEventCardProps {
   eventData: SearchEventResult
   calendar: Calendar | undefined
   timeZone: string
+  customSubHeader?: (titleStyle: React.CSSProperties) => React.ReactNode
 }
 
 export const RenderMobileDate: React.FC<MobileDateProps> = ({
@@ -38,15 +39,50 @@ export const RenderMobileDate: React.FC<MobileDateProps> = ({
   </Box>
 )
 
+const getCardSx = (calendar: Calendar): React.CSSProperties => ({
+  height: 'stretch',
+  minHeight: '58px',
+  width: '100%',
+  borderRadius: '8px',
+  padding: 1,
+  boxShadow: 'none',
+  backgroundColor: calendar.color?.light,
+  color: calendar.color?.dark,
+  border: '1px solid',
+  borderColor: 'background.paper',
+  display: 'flex'
+})
+
+const headerSx = {
+  p: '0px',
+  '& .MuiCardHeader-content': { overflow: 'hidden' }
+}
+
+const getSubheaderStyle = (color?: string): React.CSSProperties => ({
+  color,
+  opacity: '70%',
+  fontFamily: 'Inter',
+  fontWeight: '500',
+  fontSize: '10px',
+  lineHeight: '16px',
+  letterSpacing: '0%',
+  verticalAlign: 'middle'
+})
+
 export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
   eventData,
   calendar,
-  timeZone
+  timeZone,
+  customSubHeader
 }) => {
   const { t } = useI18n()
 
-  const startDate = new Date(eventData.data.start)
-  const bestColor = calendar?.color
+  if (!calendar) return null
+
+  const { start, allDay, summary, uid } = eventData.data
+  const startDate = new Date(start)
+
+  const bestColor = calendar.color
     ? getBestColor(calendar.color as { light: string; dark: string })
     : defaultColors[0].dark
   const titleStyle = getTitleStyle(
@@ -56,51 +92,31 @@ export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
     false
   )
 
+  const defaultSubHeader = !allDay && (
+    <Typography style={getSubheaderStyle(titleStyle.color)}>
+      {startDate.toLocaleTimeString(t('locale'), {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone
+      })}
+    </Typography>
+  )
+
   return (
     <Card
       variant="outlined"
-      sx={{
-        height: 'stretch',
-        width: '100%',
-        borderRadius: '8px',
-        p: 1,
-        boxShadow: 'none',
-        backgroundColor: calendar?.color?.light,
-        color: calendar?.color?.dark,
-        border: '1px solid',
-        borderColor: 'background.paper',
-        display: 'flex'
-      }}
-      data-testid={`event-card-${eventData.data.uid}`}
+      sx={getCardSx(calendar)}
+      data-testid={`event-card-${uid}`}
     >
       <CardHeader
-        sx={{ p: '0px', '& .MuiCardHeader-content': { overflow: 'hidden' } }}
+        sx={headerSx}
         title={
           <Typography variant="body2" noWrap style={titleStyle}>
-            {eventData.data.summary || t('event.untitled')}
+            {summary || t('event.untitled')}
           </Typography>
         }
         subheader={
-          !eventData.data.allDay && (
-            <Typography
-              style={{
-                color: titleStyle.color,
-                opacity: '70%',
-                fontFamily: 'Inter',
-                fontWeight: '500',
-                fontSize: '10px',
-                lineHeight: '16px',
-                letterSpacing: '0%',
-                verticalAlign: 'middle'
-              }}
-            >
-              {startDate.toLocaleTimeString(t('locale'), {
-                hour: '2-digit',
-                minute: '2-digit',
-                timeZone: timeZone
-              })}
-            </Typography>
-          )
+          customSubHeader ? customSubHeader(titleStyle) : defaultSubHeader
         }
       />
     </Card>

--- a/src/features/Search/searchResultsComponents.tsx
+++ b/src/features/Search/searchResultsComponents.tsx
@@ -24,6 +24,7 @@ interface TimeProps {
   allDay: boolean
   t: (key: string) => string
   timeZone: string
+  styles?: React.CSSProperties
 }
 
 interface TitleProps {
@@ -83,11 +84,19 @@ export const RenderTime: React.FC<TimeProps> = ({
   endDate,
   allDay,
   t,
-  timeZone
+  timeZone,
+  styles
 }) => {
   if (allDay) return null
   return (
-    <Typography sx={{ minWidth: '120px', fontSize: '16px', fontWeight: 400 }}>
+    <Typography
+      sx={{
+        minWidth: '120px',
+        fontSize: '16px',
+        fontWeight: 400,
+        ...(styles || {})
+      }}
+    >
       {startDate.toLocaleTimeString(t('locale'), {
         hour: '2-digit',
         minute: '2-digit',

--- a/src/features/Search/searchResultsComponents.tsx
+++ b/src/features/Search/searchResultsComponents.tsx
@@ -242,3 +242,119 @@ export const RenderVideoJoin: React.FC<VideoJoinProps> = ({ url, t }) => {
     </Button>
   )
 }
+
+interface DayIndicatorProps {
+  isFirstRow: boolean
+  isToday: boolean
+  dayNum: string
+  dayName: string
+}
+
+export const RenderDayIndicator: React.FC<DayIndicatorProps> = ({
+  isFirstRow,
+  isToday,
+  dayNum,
+  dayName
+}) => {
+  const theme = useTheme()
+
+  if (!isFirstRow) {
+    return <Box sx={{ width: '80px', flexShrink: 0 }} />
+  }
+
+  return (
+    <Box
+      sx={{
+        width: '80px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        flexShrink: 0
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {isToday ? (
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              bgcolor: '#FB9E3A',
+              color: '#FFF',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '22px',
+              flexShrink: 0
+            }}
+          >
+            {dayNum}
+          </Box>
+        ) : (
+          <Typography
+            sx={{
+              fontSize: '22px',
+              color: theme.palette.grey[900],
+              minWidth: '32px',
+              textAlign: 'center'
+            }}
+          >
+            {dayNum}
+          </Typography>
+        )}
+        <Typography
+          sx={{
+            fontSize: '14px',
+            color: theme.palette.grey[500],
+            textTransform: 'uppercase'
+          }}
+        >
+          {dayName}
+        </Typography>
+      </Box>
+    </Box>
+  )
+}
+
+interface ListEventTimeProps {
+  allDay: boolean
+  startDate: Date
+  endDate: Date
+  timeZone: string
+  t: (key: string) => string
+}
+
+export const RenderListEventTime: React.FC<ListEventTimeProps> = ({
+  allDay,
+  startDate,
+  endDate,
+  timeZone,
+  t
+}) => {
+  if (allDay) {
+    return (
+      <Typography
+        sx={{
+          fontSize: '16px',
+          fontWeight: 400,
+          width: '120px',
+          flexShrink: 0
+        }}
+      >
+        {t('event.form.allDay')}
+      </Typography>
+    )
+  }
+
+  return (
+    <Box sx={{ width: '120px', flexShrink: 0 }}>
+      <RenderTime
+        startDate={startDate}
+        endDate={endDate}
+        allDay={false}
+        t={t}
+        timeZone={timeZone}
+      />
+    </Box>
+  )
+}


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Schedule" calendar view.
  * New mobile and desktop schedule event cards with day indicators, time display, organizer, location, description, and video-join area.
  * Improved timezone-aware time rendering for list and schedule displays.

* **Refactor**
  * Event schedule rendering split into mobile/desktop components for consistent layout and selection behavior.
  * Calendar view initialization logic adjusted to avoid unexpected resets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->