### PR TITLE
[#922] soften validation of past events

### DIFF
--- a/__test__/components/Event/utils/formValidation.test.ts
+++ b/__test__/components/Event/utils/formValidation.test.ts
@@ -17,7 +17,6 @@ const baseParams = (
   endDate: TOMORROW,
   endTime: '11:00',
   allday: false,
-  showValidationErrors: true,
   hasEndDateChanged: false,
   showMore: false,
   ...overrides
@@ -77,12 +76,12 @@ describe('validateEventForm — start date', () => {
     expect(result.errors.date.start).toBe('event.validation.startRequired')
   })
 
-  it('is invalid when startDate is in the past', () => {
+  it('has warning when startDate is in the past', () => {
     const result = validateEventForm(
       baseParams({ startDate: YESTERDAY, endDate: YESTERDAY })
     )
-    expect(result.isValid).toBe(false)
-    expect(result.errors.date.start).toBe('event.validation.startDateInPast')
+    expect(result.isValid).toBe(true)
+    expect(result.warnings.date.start).toBe('event.validation.startDateInPast')
   })
 
   it('is valid when startDate is today', () => {
@@ -102,15 +101,6 @@ describe('validateEventForm — start date', () => {
     const result = validateEventForm(baseParams())
     expect(result.isValid).toBe(true)
     expect(result.errors.date.start).toBe('')
-  })
-
-  it('does not expose errors when showValidationErrors is false', () => {
-    const result = validateEventForm(
-      baseParams({ startDate: YESTERDAY, showValidationErrors: false })
-    )
-    expect(result.isValid).toBe(false)
-    expect(result.errors.date.start).toBe('')
-    expect(result.errors.time.start).toBe('')
   })
 })
 
@@ -320,35 +310,5 @@ describe('validateEventForm — all-day events', () => {
       alldayParams({ startDate: TOMORROW, endDate: '2025-06-20' })
     )
     expect(result.isValid).toBe(true)
-  })
-})
-
-describe('validateEventForm — error visibility', () => {
-  beforeEach(() => {
-    jest.useFakeTimers()
-    jest.setSystemTime(FROZEN_DATE)
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
-  })
-
-  it('hides all error strings when showValidationErrors=false even if invalid', () => {
-    const result = validateEventForm(
-      baseParams({
-        startDate: '',
-        showValidationErrors: false
-      })
-    )
-    expect(result.isValid).toBe(false)
-    expect(result.errors.date.start).toBe('')
-    expect(result.errors.time.start).toBe('')
-  })
-
-  it('exposes error strings when showValidationErrors=true', () => {
-    const result = validateEventForm(
-      baseParams({ startDate: '', showValidationErrors: true })
-    )
-    expect(result.errors.date.start).not.toBe('')
   })
 })

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -64,7 +64,6 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
     const calList = useAppSelector(state => state.calendars.list)
     const userOrganizer = useAppSelector(state => state.user.organiserData)
 
-    const [showValidationErrors, setShowValidationErrors] = useState(false)
     const [isFormValid, setIsFormValid] = useState(false)
 
     const timezoneList = useMemo(
@@ -136,9 +135,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
 
     useImperativeHandle(ref, () => ({
       submit: async (): Promise<void> => {
-        setShowValidationErrors(true)
         if (!isFormValid) return
-        setShowValidationErrors(false)
 
         const values = { ...latestValuesRef.current }
 
@@ -189,7 +186,6 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
           showRepeat={v.showRepeat}
           setShowRepeat={setShowRepeat}
           showMore={showMore}
-          showValidationErrors={showValidationErrors}
           timezoneList={timezoneList}
           typeOfAction={typeOfAction}
           onStartChange={onStartChange}

--- a/src/components/Event/components/DateTimeFields/DateTimeError.tsx
+++ b/src/components/Event/components/DateTimeFields/DateTimeError.tsx
@@ -4,9 +4,13 @@ import { useI18n } from 'twake-i18n'
 
 export interface DateTimeErrorProps {
   message: string
+  warning?: boolean
 }
 
-export const DateTimeError: React.FC<DateTimeErrorProps> = ({ message }) => {
+export const DateTimeError: React.FC<DateTimeErrorProps> = ({
+  message,
+  warning
+}) => {
   const { t } = useI18n()
   if (!message) {
     return null
@@ -15,7 +19,10 @@ export const DateTimeError: React.FC<DateTimeErrorProps> = ({ message }) => {
     <Box display="flex" gap={1} flexDirection="row">
       <Box sx={{ width: '1%' }} />
       <Box>
-        <Typography variant="caption" sx={{ color: 'error.main' }}>
+        <Typography
+          variant="caption"
+          sx={{ color: warning ? 'warning.dark' : 'error.main' }}
+        >
           {t(message)}
         </Typography>
       </Box>

--- a/src/components/Event/components/DateTimeFields/DateTimeExpanded.tsx
+++ b/src/components/Event/components/DateTimeFields/DateTimeExpanded.tsx
@@ -183,7 +183,6 @@ export const DateTimeExpanded: React.FC<
     | 'showRepeat'
     | 'setShowRepeat'
     | 'showMore'
-    | 'showValidationErrors'
     | 'timezoneList'
     | 'typeOfAction'
     | 'onStartChange'
@@ -217,7 +216,6 @@ export const DateTimeExpanded: React.FC<
   showMore,
   hasEndDateChanged,
   setHasEndDateChanged,
-  showValidationErrors,
   timezoneList,
   typeOfAction,
   onStartChange,
@@ -254,7 +252,6 @@ export const DateTimeExpanded: React.FC<
     endDate,
     endTime,
     allday,
-    showValidationErrors,
     hasEndDateChanged,
     showMore
   })

--- a/src/components/Event/components/DateTimeFields/DateTimeFields.tsx
+++ b/src/components/Event/components/DateTimeFields/DateTimeFields.tsx
@@ -11,7 +11,11 @@ import 'dayjs/locale/vi'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 import React, { useMemo } from 'react'
 import { useI18n } from 'twake-i18n'
-import { DateTimeErrors } from '../../utils/formValidation'
+import {
+  DateTimeErrors,
+  DateTimeWarnings,
+  ValidationResult
+} from '../../utils/formValidation'
 import { DateTimeError } from './DateTimeError'
 import { DateTimeLayoutContent } from './DateTimeLayoutContent'
 import { useDateTimeHandlers } from './useDateTimeHandlers'
@@ -30,9 +34,7 @@ export interface DateTimeFieldsProps {
   hasEndDateChanged: boolean
   showEndDate: boolean
   onToggleEndDate: () => void
-  validation: {
-    errors: DateTimeErrors
-  }
+  validation: ValidationResult
   onStartDateChange: (date: string) => void
   onStartTimeChange: (time: string) => void
   onEndDateChange: (date: string, time?: string) => void
@@ -145,7 +147,21 @@ export const DateTimeFields: React.FC<DateTimeFieldsProps> = ({
           startTimeValue={startTimeValue}
           endDateValue={endDateValue}
           endTimeValue={endTimeValue}
-          errors={validation.errors}
+          errors={{
+            date: {
+              start:
+                validation.errors?.date?.start ||
+                validation.warnings?.date?.start,
+              end:
+                validation.errors?.date?.end ||
+                validation.warnings?.date?.end ||
+                ''
+            },
+            time: {
+              start: validation.errors?.time?.start,
+              end: validation.errors?.time?.end
+            }
+          }}
           isMobile={isMobile}
           allday={allday}
           startDateLabel={startDateLabel}
@@ -155,13 +171,31 @@ export const DateTimeFields: React.FC<DateTimeFieldsProps> = ({
           onEndDateChange={handleEndDateChange}
           onEndTimeChange={handleEndTimeChange}
         />
-        <DateTimeError message={displayError(validation)} />
+        <DateTimeError
+          message={displayError(validation)}
+          warning={displayAsWarning(validation)}
+        />
       </Box>
     </LocalizationProvider>
   )
 }
 
-function displayError(validation: { errors: DateTimeErrors }): string {
+function displayAsWarning(validation: ValidationResult): boolean | undefined {
+  if (
+    validation.errors.date?.start ||
+    validation.errors.date?.end ||
+    validation.errors.time?.start ||
+    validation.errors.time?.end
+  ) {
+    return false
+  }
+  return !!validation.warnings?.date?.start || !!validation.warnings?.date?.end
+}
+
+function displayError(validation: {
+  errors: DateTimeErrors
+  warnings: DateTimeWarnings
+}): string {
   if (validation?.errors?.date?.start) {
     return validation.errors.date.start
   }
@@ -173,6 +207,12 @@ function displayError(validation: { errors: DateTimeErrors }): string {
   }
   if (validation?.errors?.time?.start) {
     return validation.errors.time.start
+  }
+  if (validation?.warnings?.date?.start) {
+    return validation.warnings.date.start
+  }
+  if (validation?.warnings?.date?.end) {
+    return validation.warnings.date.end
   }
   return ''
 }

--- a/src/components/Event/components/DateTimeSummary.tsx
+++ b/src/components/Event/components/DateTimeSummary.tsx
@@ -164,7 +164,7 @@ export const DateTimeSummary: React.FC<DateTimeSummaryProps> = ({
         {startDateInPast && (
           <Typography
             variant="caption"
-            sx={{ color: 'error.main', display: 'block', mt: 0.5 }}
+            sx={{ color: 'warning.dark', display: 'block', mt: 0.5 }}
           >
             {t('event.validation.startDateInPast')}
           </Typography>

--- a/src/components/Event/fields/DateTimeField.types.ts
+++ b/src/components/Event/fields/DateTimeField.types.ts
@@ -27,7 +27,6 @@ export interface EventDateTimeFieldProps {
   /** Whether the full (expanded) dialog mode is active */
   showMore: boolean
   /** show/hide validation error messages */
-  showValidationErrors: boolean
   timezoneList: TimezoneListResult
   typeOfAction?: 'solo' | 'all'
   /** Optional callbacks for calendar preview sync (EventModal only) */

--- a/src/components/Event/fields/EventDateTimeField.tsx
+++ b/src/components/Event/fields/EventDateTimeField.tsx
@@ -21,7 +21,6 @@ export const EventDateTimeField: React.FC<EventDateTimeFieldProps> = ({
   showRepeat,
   setShowRepeat,
   showMore,
-  showValidationErrors,
   timezoneList,
   typeOfAction,
   onStartChange,
@@ -60,7 +59,6 @@ export const EventDateTimeField: React.FC<EventDateTimeFieldProps> = ({
     showMore,
     hasEndDateChanged,
     setHasEndDateChanged,
-    showValidationErrors,
     onEndChange,
     setEnd,
     onHasEndDateChangedChange,
@@ -104,7 +102,6 @@ export const EventDateTimeField: React.FC<EventDateTimeFieldProps> = ({
             showMore={showMore}
             hasEndDateChanged={hasEndDateChanged}
             setHasEndDateChanged={setHasEndDateChanged}
-            showValidationErrors={showValidationErrors}
             timezoneList={timezoneList}
             typeOfAction={typeOfAction}
             onStartChange={onStartChange}

--- a/src/components/Event/hooks/useDateTimeSplit.ts
+++ b/src/components/Event/hooks/useDateTimeSplit.ts
@@ -10,7 +10,6 @@ interface UseDateTimeSplitParams {
   showMore: boolean
   hasEndDateChanged: boolean
   setHasEndDateChanged: (value: boolean) => void
-  showValidationErrors: boolean
   onEndChange?: (newEnd: string) => void
   setEnd: (value: string) => void
   onHasEndDateChangedChange?: (has: boolean) => void
@@ -47,7 +46,6 @@ export function useDateTimeSplit({
   showMore,
   hasEndDateChanged,
   setHasEndDateChanged,
-  showValidationErrors,
   onEndChange,
   setEnd,
   onHasEndDateChangedChange,
@@ -74,7 +72,6 @@ export function useDateTimeSplit({
     endDate,
     endTime,
     allday,
-    showValidationErrors,
     hasEndDateChanged,
     showMore
   }).isValid

--- a/src/components/Event/utils/formValidation.ts
+++ b/src/components/Event/utils/formValidation.ts
@@ -9,7 +9,6 @@ export interface ValidationParams {
   endDate: string
   endTime: string
   allday: boolean
-  showValidationErrors: boolean
   hasEndDateChanged?: boolean
   showMore?: boolean
 }
@@ -20,6 +19,7 @@ export interface ValidationParams {
 export interface ValidationResult {
   isValid: boolean
   errors: DateTimeErrors
+  warnings: DateTimeWarnings
 }
 
 export interface DateTimeErrors {
@@ -27,32 +27,57 @@ export interface DateTimeErrors {
   time: { start: string; end: string }
 }
 
-/**
- * Validate event form fields
- * @param params - Validation parameters
- * @returns Validation result with errors
- */
-export function validateEventForm(params: ValidationParams): ValidationResult {
+export interface DateTimeWarnings {
+  date: { start: string; end?: string }
+}
+
+function validateStartDate(startDate: string): {
+  error: string
+  warning: string
+} {
+  if (!startDate || startDate.trim() === '') {
+    return { error: 'event.validation.startRequired', warning: '' }
+  }
+  if (isDateInPast(startDate)) {
+    return { error: '', warning: 'event.validation.startDateInPast' }
+  }
+  return { error: '', warning: '' }
+}
+
+function validateStartTime(
+  startTime: string,
+  allday: boolean
+): {
+  error: string
+} {
+  if (!allday && (!startTime || startTime.trim() === '')) {
+    return { error: 'event.validation.startRequired' }
+  }
+  return { error: '' }
+}
+
+function validateEndDateTime(
+  params: Pick<
+    ValidationParams,
+    | 'startDate'
+    | 'startTime'
+    | 'endDate'
+    | 'endTime'
+    | 'allday'
+    | 'hasEndDateChanged'
+    | 'showMore'
+  >
+): { errors: Partial<DateTimeErrors>; isValid: boolean } {
   const {
     startDate,
     startTime,
     endDate,
     endTime,
     allday,
-    showValidationErrors,
     hasEndDateChanged = false,
     showMore = false
   } = params
 
-  const state = {
-    isDateTimeValid: true,
-    timeStartError: '',
-    timeEndError: '',
-    dateStartError: '',
-    dateEndError: ''
-  }
-
-  // Determine which fields are visible based on UI mode
   const showFullFields =
     showMore ||
     allday ||
@@ -60,57 +85,64 @@ export function validateEventForm(params: ValidationParams): ValidationResult {
     (!showMore && !allday && startDate !== endDate)
   const showTimeOnly = !allday && !showFullFields
 
-  // Validate start date
-  if (!startDate || startDate.trim() === '') {
-    state.isDateTimeValid = false
-    state.dateStartError = 'event.validation.startRequired'
-  }
-  // Validate start date is not before today's beginning
-  else if (isDateInPast(startDate)) {
-    state.isDateTimeValid = false
-    state.dateStartError = 'event.validation.startDateInPast'
-  }
-  // Validate start time (if not all-day)
-  else if (!allday && (!startTime || startTime.trim() === '')) {
-    state.isDateTimeValid = false
-    state.timeStartError = 'event.validation.startRequired'
-  }
-  // Validate end fields based on UI mode
-  else if (showFullFields) {
-    const { isValid, errors } = validateFullFields({
+  if (showFullFields)
+    return validateFullFields({
       startDate,
       startTime,
       endDate,
       endTime,
       allday
     })
-    if (!isValid) {
-      state.isDateTimeValid = false
-      state.timeStartError = errors.time?.start ?? ''
-      state.timeEndError = errors.time?.end ?? ''
-      state.dateStartError = errors.date?.start ?? ''
-      state.dateEndError = errors.date?.end ?? ''
-    }
-  } else if (showTimeOnly) {
-    const { isValid, errors } = validateTimeOnlyFields(startTime, endTime)
-    if (!isValid) {
-      state.isDateTimeValid = false
-      state.timeStartError = errors.time?.start ?? ''
-      state.timeEndError = errors.time?.end ?? ''
-    }
+  if (showTimeOnly) return validateTimeOnlyFields(startTime, endTime)
+  return {
+    isValid: true,
+    errors: { date: { start: '', end: '' }, time: { start: '', end: '' } }
   }
-  const isValid = state.isDateTimeValid
+}
+
+export function validateEventForm(params: ValidationParams): ValidationResult {
+  const {
+    startDate,
+    startTime,
+    endDate,
+    endTime,
+    allday,
+    hasEndDateChanged,
+    showMore
+  } = params
+
+  const startDateResult = validateStartDate(startDate)
+  const startTimeResult = validateStartTime(startTime, allday)
+  const allFieldsResult = validateEndDateTime({
+    startDate,
+    startTime,
+    endDate,
+    endTime,
+    allday,
+    hasEndDateChanged,
+    showMore
+  })
+
+  const isValid =
+    !startDateResult.error && !startTimeResult.error && allFieldsResult.isValid
 
   return {
     isValid,
     errors: {
-      time: {
-        start: showValidationErrors ? state.timeStartError : '',
-        end: showValidationErrors ? state.timeEndError : ''
-      },
       date: {
-        start: showValidationErrors ? state.dateStartError : '',
-        end: showValidationErrors ? state.dateEndError : ''
+        start:
+          startDateResult.error || allFieldsResult.errors.date?.start || '',
+        end: allFieldsResult.errors.date?.end || ''
+      },
+      time: {
+        start:
+          startTimeResult.error || allFieldsResult.errors.time?.start || '',
+        end: allFieldsResult.errors.time?.end || ''
+      }
+    },
+    warnings: {
+      date: {
+        start: startDateResult.warning
       }
     }
   }
@@ -146,7 +178,6 @@ export function validateEventFormValues(
     endDate,
     endTime,
     allday: values.allday,
-    showValidationErrors: false,
     hasEndDateChanged: values.hasEndDateChanged,
     showMore
   }).isValid

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,7 +214,7 @@
       "endRequired": "End date/time is required",
       "invalidEnd": "Invalid end date/time",
       "endAfterStart": "End time must be after start time",
-      "startDateInPast": "Start date cannot be in the past",
+      "startDateInPast": "Start date is in the past",
       "invalidDate": "Invalid date",
       "invalidDateTime": "Invalid date/time",
       "invalidTimeFormat": "Invalid time format"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -215,7 +215,7 @@
       "endRequired": "La date/heure de fin est obligatoire",
       "invalidEnd": "Date/heure de fin invalide",
       "endAfterStart": "L'heure de fin doit être après l'heure de début",
-      "startDateInPast": "La date de début ne peut pas être dans le passé",
+      "startDateInPast": "La date de début est dans le passé",
       "invalidDate": "Date invalide",
       "invalidDateTime": "Date/heure invalide",
       "invalidTimeFormat": "Format d'heure invalide"


### PR DESCRIPTION
resolves #922 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Event form validation for "start date in the past" now displays as a warning instead of a blocking error, allowing you to submit forms while being alerted to the timing issue.
  * Warning messages now use distinct visual styling to clearly differentiate them from critical errors.
  * Updated validation messaging in English and French locales for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->