### PR TITLE
[#250] added modal for event personal settings

### DIFF
--- a/src/components/Calendar/handlers/eventHandlers.ts
+++ b/src/components/Calendar/handlers/eventHandlers.ts
@@ -222,11 +222,14 @@ export const createEventHandlers = (
           .add(seriesDeltaMs, 'ms')
           .add(moment(computedNewEnd).diff(moment(computedNewStart)))
 
-    const shiftedMasterEvent = {
-      ...master,
-      start: formatLocalDateTime(masterStart.toDate(), masterTz),
-      end: formatLocalDateTime(masterEnd.toDate(), masterTz)
-    }
+    const shiftedMasterEvent = updateAttendeesAfterTimeChange(
+      {
+        ...master,
+        start: formatLocalDateTime(masterStart.toDate(), masterTz),
+        end: formatLocalDateTime(masterEnd.toDate(), masterTz)
+      },
+      true
+    )
 
     await handleUpdateRecurringSeries({
       dispatch,

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -119,11 +119,13 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       [onValidationChange]
     )
 
-    const { organizer } = useEventOrganizer({
+    const { organizer, isOrganizer } = useEventOrganizer({
       calendarid: formValues.calendarid,
+      eventId,
       calList,
       userOrganizer
     })
+
     // Keep organizer in a ref so submit() can read it synchronously
     const organizerRef = useRef(organizer)
     useEffect(() => {
@@ -196,6 +198,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
             eventClass={v.eventClass}
             setEventClass={setEventClass}
             showMore={showMore}
+            isOrganizer={isOrganizer}
           />
         </React.Fragment>
       )

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -186,7 +186,6 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
               setCalendarid={setCalendarid}
               userPersonalCalendars={userPersonalCalendars}
               showMore={showMore}
-              onCalendarChange={setCalendarid}
               defaultExpanded
             />
           )}

--- a/src/components/Event/EventFormFields.tsx
+++ b/src/components/Event/EventFormFields.tsx
@@ -1,40 +1,43 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-  useMemo
-} from 'react'
-import { useI18n } from 'twake-i18n'
 import { useAppSelector } from '@/app/hooks'
-import AttendeeSelector from '../Attendees/AttendeeSearch'
-import { FieldWithLabel } from './components/FieldWithLabel'
-import { AddDescButton } from './AddDescButton'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
-import { CalendarSelectField } from './fields/CalendarSelectField'
-import { EventDateTimeField } from './fields/EventDateTimeField'
-import { VideoConferenceField } from './fields/VideoConferenceField'
-import { EventFormFieldsExpanded } from './components/EventFormFieldsExpanded'
-import LocationField from './fields/LocationField'
-import { TitleField } from './fields/TitleField'
-import { saveEventFormDataToTemp } from '@/utils/eventFormTempStorage'
 import { useEventOrganizer } from '@/features/Events/useEventOrganizer'
-import { useEventFormValues } from './hooks/useEventFormValues'
-import { validateEventFormValues } from './utils/formValidation'
-import { TIMEZONES } from '@/utils/timezone-data'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
+import { saveEventFormDataToTemp } from '@/utils/eventFormTempStorage'
 import {
   browserDefaultTimeZone,
   getTimezoneOffset,
   resolveTimezone
 } from '@/utils/timezone'
+import { TIMEZONES } from '@/utils/timezone-data'
+import { Box, TextField, Typography } from '@linagora/twake-mui'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { useI18n } from 'twake-i18n'
+import AttendeeSelector from '../Attendees/AttendeeSearch'
+import { AddDescButton } from './AddDescButton'
+import { EventFormFieldsExpanded } from './components/EventFormFieldsExpanded'
+import { EventFormFieldsSpecific } from './components/EventFormFieldsSpecific'
+import { FieldWithLabel } from './components/FieldWithLabel'
 import {
   EventFormFieldsProps,
   EventFormHandle,
   EventFormValues
 } from './EventFormFields.types'
-import { TextField } from '@linagora/twake-mui'
+import { CalendarSelectField } from './fields/CalendarSelectField'
+import { EventDateTimeField } from './fields/EventDateTimeField'
+import LocationField from './fields/LocationField'
+import { TitleField } from './fields/TitleField'
+import { VideoConferenceField } from './fields/VideoConferenceField'
+import { useEventFormValues } from './hooks/useEventFormValues'
+import { validateEventFormValues } from './utils/formValidation'
+import { EventTimeSubtitle } from '@/features/Events/EventPreview/EventTimeSubtitle'
+import { formatEventChipTitle } from '../Calendar/utils/calendarUtils'
 
 const showInputLabel = (showMore: boolean, label: string): string =>
   showMore ? label : ''
@@ -46,6 +49,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       showMore,
       isOpen = false,
       typeOfAction,
+      isSpecific = false,
       eventId,
       userPersonalCalendars,
       onSubmit,
@@ -135,7 +139,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
 
     useImperativeHandle(ref, () => ({
       submit: async (): Promise<void> => {
-        if (!isFormValid) return
+        if (!isFormValid && !isSpecific) return
 
         const values = { ...latestValuesRef.current }
 
@@ -159,7 +163,43 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
 
     const v = formValues
     const isExpanded = showMore && !isMobile
+    if (isSpecific) {
+      return (
+        <React.Fragment>
+          <Box display="flex" alignItems="center" gap={1} mb={2}>
+            <Typography
+              variant="h3"
+              sx={{
+                wordBreak: 'break-word'
+              }}
+            >
+              {formatEventChipTitle(v, t)}
+            </Typography>
+          </Box>
+          <EventTimeSubtitle event={v} timezone={v.timezone} />
 
+          {typeOfAction !== 'solo' && (
+            <CalendarSelectField
+              calendarid={v.calendarid}
+              setCalendarid={setCalendarid}
+              userPersonalCalendars={userPersonalCalendars}
+              showMore={showMore}
+              onCalendarChange={setCalendarid}
+              defaultExpanded
+            />
+          )}
+          <EventFormFieldsSpecific
+            alarm={v.alarm}
+            setAlarm={setAlarm}
+            busy={v.busy}
+            setBusy={setBusy}
+            eventClass={v.eventClass}
+            setEventClass={setEventClass}
+            showMore={showMore}
+          />
+        </React.Fragment>
+      )
+    }
     return (
       <React.Fragment>
         <TitleField

--- a/src/components/Event/EventFormFields.types.ts
+++ b/src/components/Event/EventFormFields.types.ts
@@ -81,6 +81,7 @@ export interface EventFormFieldsProps {
 
   isOpen?: boolean
   typeOfAction?: 'solo' | 'all'
+  isSpecific?: boolean
   eventId?: string | null
 
   // Data needed for rendering

--- a/src/components/Event/components/EventFormFieldsExpanded.tsx
+++ b/src/components/Event/components/EventFormFieldsExpanded.tsx
@@ -38,7 +38,7 @@ export const EventFormFieldsExpanded: React.FC<
 
   return (
     <>
-      {showMore && !window.HIDE_RESOURCES && (
+      {!window.HIDE_RESOURCES && (
         <FieldWithLabel
           label={t('event.form.resource')}
           isExpanded={showMore && !isMobile}

--- a/src/components/Event/components/EventFormFieldsExpanded.tsx
+++ b/src/components/Event/components/EventFormFieldsExpanded.tsx
@@ -1,12 +1,10 @@
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 import { FormControl, TextField } from '@linagora/twake-mui'
 import React from 'react'
 import { useI18n } from 'twake-i18n'
-import { FieldWithLabel } from './FieldWithLabel'
 import { Resource, ResourceSearch } from '../../Attendees/ResourceSearch'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
-import { FreeBusyField } from '../fields/FreeBusyField'
-import { NotificationField } from '../fields/NotificationField'
-import { VisibilityField } from '../fields/VisibilityField'
+import { EventFormFieldsSpecific } from './EventFormFieldsSpecific'
+import { FieldWithLabel } from './FieldWithLabel'
 
 interface EventFormFieldsExpandedProps {
   alarm: string
@@ -36,6 +34,8 @@ export const EventFormFieldsExpanded: React.FC<
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
+  if (!showMore) return null
+
   return (
     <>
       {showMore && !window.HIDE_RESOURCES && (
@@ -57,21 +57,15 @@ export const EventFormFieldsExpanded: React.FC<
         </FieldWithLabel>
       )}
 
-      <NotificationField
+      <EventFormFieldsSpecific
         alarm={alarm}
         setAlarm={setAlarm}
+        busy={busy}
+        setBusy={setBusy}
+        eventClass={eventClass}
+        setEventClass={setEventClass}
         showMore={showMore}
       />
-
-      <FreeBusyField busy={busy} setBusy={setBusy} showMore={showMore} />
-
-      {!window.DISABLE_PUBLIC_VISIBILITY && (
-        <VisibilityField
-          eventClass={eventClass}
-          setEventClass={setEventClass}
-          showMore={showMore}
-        />
-      )}
     </>
   )
 }

--- a/src/components/Event/components/EventFormFieldsSpecific.tsx
+++ b/src/components/Event/components/EventFormFieldsSpecific.tsx
@@ -11,6 +11,7 @@ interface EventFormFieldsSpecificProps {
   eventClass: 'PUBLIC' | 'PRIVATE' | 'CONFIDENTIAL'
   setEventClass: (v: 'PUBLIC' | 'PRIVATE' | 'CONFIDENTIAL') => void
   showMore: boolean
+  isOrganizer?: boolean
 }
 
 export const EventFormFieldsSpecific: React.FC<
@@ -22,7 +23,8 @@ export const EventFormFieldsSpecific: React.FC<
   setBusy,
   eventClass,
   setEventClass,
-  showMore
+  showMore,
+  isOrganizer
 }) => {
   return (
     <>
@@ -31,15 +33,18 @@ export const EventFormFieldsSpecific: React.FC<
         setAlarm={setAlarm}
         showMore={showMore}
       />
+      {!isOrganizer && (
+        <>
+          <FreeBusyField busy={busy} setBusy={setBusy} showMore={showMore} />
 
-      <FreeBusyField busy={busy} setBusy={setBusy} showMore={showMore} />
-
-      {!window.DISABLE_PUBLIC_VISIBILITY && (
-        <VisibilityField
-          eventClass={eventClass}
-          setEventClass={setEventClass}
-          showMore={showMore}
-        />
+          {!window.DISABLE_PUBLIC_VISIBILITY && (
+            <VisibilityField
+              eventClass={eventClass}
+              setEventClass={setEventClass}
+              showMore={showMore}
+            />
+          )}
+        </>
       )}
     </>
   )

--- a/src/components/Event/components/EventFormFieldsSpecific.tsx
+++ b/src/components/Event/components/EventFormFieldsSpecific.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { FreeBusyField } from '../fields/FreeBusyField'
+import { NotificationField } from '../fields/NotificationField'
+import { VisibilityField } from '../fields/VisibilityField'
+
+interface EventFormFieldsSpecificProps {
+  alarm: string
+  setAlarm: (v: string) => void
+  busy: string
+  setBusy: (v: string) => void
+  eventClass: 'PUBLIC' | 'PRIVATE' | 'CONFIDENTIAL'
+  setEventClass: (v: 'PUBLIC' | 'PRIVATE' | 'CONFIDENTIAL') => void
+  showMore: boolean
+}
+
+export const EventFormFieldsSpecific: React.FC<
+  EventFormFieldsSpecificProps
+> = ({
+  alarm,
+  setAlarm,
+  busy,
+  setBusy,
+  eventClass,
+  setEventClass,
+  showMore
+}) => {
+  return (
+    <>
+      <NotificationField
+        alarm={alarm}
+        setAlarm={setAlarm}
+        showMore={showMore}
+      />
+
+      <FreeBusyField busy={busy} setBusy={setBusy} showMore={showMore} />
+
+      {!window.DISABLE_PUBLIC_VISIBILITY && (
+        <VisibilityField
+          eventClass={eventClass}
+          setEventClass={setEventClass}
+          showMore={showMore}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/Event/fields/CalendarSelectField.tsx
+++ b/src/components/Event/fields/CalendarSelectField.tsx
@@ -25,6 +25,7 @@ export interface CalendarSelectFieldProps {
   userPersonalCalendars: Calendar[]
   showMore: boolean
   disabled?: boolean
+  defaultExpanded?: boolean
   /** Optional callback for additional logic on change (e.g. UpdateModal tracks newCalId) */
   onCalendarChange?: (newCalendarId: string) => void
 }
@@ -144,6 +145,7 @@ export const CalendarSelectField: React.FC<CalendarSelectFieldProps> = ({
   setCalendarid,
   userPersonalCalendars,
   showMore,
+  defaultExpanded,
   onCalendarChange,
   disabled
 }) => {
@@ -164,7 +166,7 @@ export const CalendarSelectField: React.FC<CalendarSelectFieldProps> = ({
     }
 
     openSelectAfterClick()
-  }, [hasClickedCalendarSection])
+  }, [hasClickedCalendarSection, defaultExpanded])
 
   const selectedCalendar = userPersonalCalendars.find(
     cal => cal.id === calendarid
@@ -174,7 +176,8 @@ export const CalendarSelectField: React.FC<CalendarSelectFieldProps> = ({
     : ''
   const isSelectedDelegated = !!selectedCalendar?.delegated
 
-  const isCollapsed = !showMore && !hasClickedCalendarSection
+  const isCollapsed =
+    !showMore && !hasClickedCalendarSection && !defaultExpanded
 
   return (
     <FieldWithLabel

--- a/src/components/Event/fields/FreeBusyField.tsx
+++ b/src/components/Event/fields/FreeBusyField.tsx
@@ -1,3 +1,4 @@
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 import {
   FormControl,
   MenuItem,
@@ -20,9 +21,13 @@ export const FreeBusyField: React.FC<FreeBusyFieldProps> = ({
   showMore
 }) => {
   const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
 
   return (
-    <FieldWithLabel label={t('event.form.showMeAs')} isExpanded={showMore}>
+    <FieldWithLabel
+      label={t('event.form.showMeAs')}
+      isExpanded={showMore && !isMobile}
+    >
       <FormControl fullWidth margin="dense" size="small">
         <Select
           labelId="busy"

--- a/src/components/Event/fields/FreeBusyField.tsx
+++ b/src/components/Event/fields/FreeBusyField.tsx
@@ -6,7 +6,6 @@ import {
 } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from '../components/FieldWithLabel'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
 export interface FreeBusyFieldProps {
   busy: string
@@ -21,12 +20,9 @@ export const FreeBusyField: React.FC<FreeBusyFieldProps> = ({
   showMore
 }) => {
   const { t } = useI18n()
-  const { isTooSmall: isMobile } = useScreenSizeDetection()
-
-  if (!showMore) return null
 
   return (
-    <FieldWithLabel label={t('event.form.showMeAs')} isExpanded={!isMobile}>
+    <FieldWithLabel label={t('event.form.showMeAs')} isExpanded={showMore}>
       <FormControl fullWidth margin="dense" size="small">
         <Select
           labelId="busy"

--- a/src/components/Event/fields/NotificationField.tsx
+++ b/src/components/Event/fields/NotificationField.tsx
@@ -6,6 +6,7 @@ import {
 } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from '../components/FieldWithLabel'
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
 export interface NotificationFieldProps {
   alarm: string
@@ -20,9 +21,13 @@ export const NotificationField: React.FC<NotificationFieldProps> = ({
   showMore
 }) => {
   const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
 
   return (
-    <FieldWithLabel label={t('event.form.notification')} isExpanded={showMore}>
+    <FieldWithLabel
+      label={t('event.form.notification')}
+      isExpanded={showMore && !isMobile}
+    >
       <FormControl fullWidth margin="dense" size="small">
         <Select
           labelId="notification"

--- a/src/components/Event/fields/NotificationField.tsx
+++ b/src/components/Event/fields/NotificationField.tsx
@@ -6,7 +6,6 @@ import {
 } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from '../components/FieldWithLabel'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
 export interface NotificationFieldProps {
   alarm: string
@@ -21,12 +20,9 @@ export const NotificationField: React.FC<NotificationFieldProps> = ({
   showMore
 }) => {
   const { t } = useI18n()
-  const { isTooSmall: isMobile } = useScreenSizeDetection()
-
-  if (!showMore) return null
 
   return (
-    <FieldWithLabel label={t('event.form.notification')} isExpanded={!isMobile}>
+    <FieldWithLabel label={t('event.form.notification')} isExpanded={showMore}>
       <FormControl fullWidth margin="dense" size="small">
         <Select
           labelId="notification"

--- a/src/components/Event/fields/VisibilityField.tsx
+++ b/src/components/Event/fields/VisibilityField.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
 import { ToggleButton, ToggleButtonGroup } from '@linagora/twake-mui'
 import { Public as PublicIcon } from '@mui/icons-material'
 import LockOutlineIcon from '@mui/icons-material/LockOutline'
+import React from 'react'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from '../components/FieldWithLabel'
-import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 
 export interface VisibilityFieldProps {
   eventClass: 'PUBLIC' | 'PRIVATE' | 'CONFIDENTIAL'
@@ -19,12 +18,9 @@ export const VisibilityField: React.FC<VisibilityFieldProps> = ({
   showMore
 }) => {
   const { t } = useI18n()
-  const { isTooSmall: isMobile } = useScreenSizeDetection()
-
-  if (!showMore) return null
 
   return (
-    <FieldWithLabel label={t('event.form.visibleTo')} isExpanded={!isMobile}>
+    <FieldWithLabel label={t('event.form.visibleTo')} isExpanded={showMore}>
       <ToggleButtonGroup
         value={eventClass}
         exclusive

--- a/src/components/Event/fields/VisibilityField.tsx
+++ b/src/components/Event/fields/VisibilityField.tsx
@@ -1,3 +1,4 @@
+import { useScreenSizeDetection } from '@/useScreenSizeDetection'
 import { ToggleButton, ToggleButtonGroup } from '@linagora/twake-mui'
 import { Public as PublicIcon } from '@mui/icons-material'
 import LockOutlineIcon from '@mui/icons-material/LockOutline'
@@ -18,9 +19,13 @@ export const VisibilityField: React.FC<VisibilityFieldProps> = ({
   showMore
 }) => {
   const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
 
   return (
-    <FieldWithLabel label={t('event.form.visibleTo')} isExpanded={showMore}>
+    <FieldWithLabel
+      label={t('event.form.visibleTo')}
+      isExpanded={showMore && !isMobile}
+    >
       <ToggleButtonGroup
         value={eventClass}
         exclusive

--- a/src/features/Events/EventPreview/EventPreviewActionMenu.tsx
+++ b/src/features/Events/EventPreview/EventPreviewActionMenu.tsx
@@ -5,7 +5,7 @@ import { CalendarEvent } from '../EventsTypes'
 
 interface EventPreviewActionMenuProps {
   anchorEl: Element | null
-  isOwn: boolean
+  isEditable: boolean
   event: CalendarEvent
   userEmail: string
   onClose: () => void
@@ -15,7 +15,7 @@ interface EventPreviewActionMenuProps {
 
 export const EventPreviewActionMenu: React.FC<EventPreviewActionMenuProps> = ({
   anchorEl,
-  isOwn,
+  isEditable,
   event,
   userEmail,
   onClose,
@@ -32,7 +32,7 @@ export const EventPreviewActionMenu: React.FC<EventPreviewActionMenuProps> = ({
 
   return (
     <Menu open={Boolean(anchorEl)} onClose={onClose} anchorEl={anchorEl}>
-      {isOwn && (
+      {isEditable && (
         <MenuItem
           onClick={() => {
             onClose()

--- a/src/features/Events/EventPreview/EventPreviewActionMenu.tsx
+++ b/src/features/Events/EventPreview/EventPreviewActionMenu.tsx
@@ -5,19 +5,23 @@ import { CalendarEvent } from '../EventsTypes'
 
 interface EventPreviewActionMenuProps {
   anchorEl: Element | null
+  isOwn: boolean
   event: CalendarEvent
   userEmail: string
   onClose: () => void
   onDuplicate: () => void
+  onEdit: () => void
 }
 
-export function EventPreviewActionMenu({
+export const EventPreviewActionMenu: React.FC<EventPreviewActionMenuProps> = ({
   anchorEl,
+  isOwn,
   event,
   userEmail,
   onClose,
-  onDuplicate
-}: EventPreviewActionMenuProps) {
+  onDuplicate,
+  onEdit
+}) => {
   const { t } = useI18n()
   const mailSpaUrl = window.MAIL_SPA_URL ?? null
 
@@ -28,6 +32,16 @@ export function EventPreviewActionMenu({
 
   return (
     <Menu open={Boolean(anchorEl)} onClose={onClose} anchorEl={anchorEl}>
+      {isOwn && (
+        <MenuItem
+          onClick={() => {
+            onClose()
+            onEdit()
+          }}
+        >
+          {t('eventPreview.editEventSpecificSettings')}
+        </MenuItem>
+      )}
       {mailSpaUrl && otherAttendees.length > 0 && (
         <MenuItem
           onClick={() =>

--- a/src/features/Events/EventPreview/EventPreviewModal.tsx
+++ b/src/features/Events/EventPreview/EventPreviewModal.tsx
@@ -226,7 +226,9 @@ const EventPreviewModal: React.FC<{
       {/* Action menu (more vert) */}
       <EventPreviewActionMenu
         anchorEl={toggleActionMenu}
-        isEditable={isOwn || isWriteDelegated}
+        isEditable={
+          (isOwn || isWriteDelegated) && (event?.attendee?.length ?? 0) > 1
+        }
         event={event}
         userEmail={user.email}
         onClose={() => setToggleActionMenu(null)}

--- a/src/features/Events/EventPreview/EventPreviewModal.tsx
+++ b/src/features/Events/EventPreview/EventPreviewModal.tsx
@@ -226,7 +226,7 @@ const EventPreviewModal: React.FC<{
       {/* Action menu (more vert) */}
       <EventPreviewActionMenu
         anchorEl={toggleActionMenu}
-        isOwn={isOwn}
+        isEditable={isOwn || isWriteDelegated}
         event={event}
         userEmail={user.email}
         onClose={() => setToggleActionMenu(null)}

--- a/src/features/Events/EventPreview/EventPreviewModal.tsx
+++ b/src/features/Events/EventPreview/EventPreviewModal.tsx
@@ -7,7 +7,7 @@ import { DateSelectArg } from '@fullcalendar/core'
 import { Box, Chip, Typography } from '@linagora/twake-mui'
 import CircleIcon from '@mui/icons-material/Circle'
 import LockOutlineIcon from '@mui/icons-material/LockOutline'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useI18n } from 'twake-i18n'
 import { AttendanceValidation } from '../AttendanceValidation/AttendanceValidation'
 import EventPopover from '../EventModal'
@@ -122,7 +122,7 @@ const EventPreviewModal: React.FC<{
     handleCalendarMove,
     userPersonalCalendars
   } = useEventPreviewState(eventId, calId, tempEvent, open, onClose)
-
+  const isSpecificRef = useRef(false)
   useEffect(
     () => {
       if (open && (!event || !calendar)) {
@@ -226,10 +226,15 @@ const EventPreviewModal: React.FC<{
       {/* Action menu (more vert) */}
       <EventPreviewActionMenu
         anchorEl={toggleActionMenu}
+        isOwn={isOwn}
         event={event}
         userEmail={user.email}
         onClose={() => setToggleActionMenu(null)}
         onDuplicate={handleDuplicateClick}
+        onEdit={() => {
+          isSpecificRef.current = true
+          handleEditClick()
+        }}
       />
 
       {/* Recurring edit/delete mode picker */}
@@ -245,6 +250,7 @@ const EventPreviewModal: React.FC<{
       {/* Edit modal */}
       <EventUpdateModal
         open={openUpdateModal}
+        isSpecific={isSpecificRef.current}
         onClose={() => {
           setOpenUpdateModal(false)
           setHidePreview(false)

--- a/src/features/Events/EventUpdateModal.tsx
+++ b/src/features/Events/EventUpdateModal.tsx
@@ -1,21 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppSelector } from '@/app/hooks'
 import { ResponsiveDialog } from '@/components/Dialog'
 import EventFormFields from '@/components/Event/EventFormFields'
-import type { EventFormHandle } from '@/components/Event/EventFormFields.types'
-import {
-  clearEventFormTempData,
-  EventFormContext
-} from '@/utils/eventFormTempStorage'
-import { useI18n } from 'twake-i18n'
-import { CalendarEvent } from './EventsTypes'
 import { useScreenSizeDetection } from '@/useScreenSizeDetection'
-import { EventActions } from './EventActions'
-import { useBuildInitialValues } from '@/components/Event/hooks/useBuildInitialValues'
-import { useSubmitUpdateEvent } from '@/features/Events/hooks/useSubmitUpdateEvent'
-import { useMasterEvent } from '@/features/Events/hooks/useMasterEvent'
-import { useUserPersonalCalendars } from '@/features/Calendars/hooks/useUserPersonalCalendars'
 import type { SxProps } from '@mui/material/styles'
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+import { EventActions } from './EventActions'
+import { CalendarEvent } from './EventsTypes'
+import { useEventUpdateModal } from './useEventUpdateModal'
 
 const dialogPaddingStyles = (isMobile: boolean): SxProps => ({
   '& .MuiDialogActions-root': {
@@ -24,7 +16,7 @@ const dialogPaddingStyles = (isMobile: boolean): SxProps => ({
   }
 })
 
-interface EventUpdateModalProps {
+export interface EventUpdateModalProps {
   eventId: string
   calId: string
   open: boolean
@@ -37,79 +29,31 @@ interface EventUpdateModalProps {
 
 const EventUpdateModalInternal: React.FC<
   EventUpdateModalProps & { event: CalendarEvent }
-> = ({
-  eventId,
-  calId,
-  open,
-  onClose,
-  isSpecific,
-  onCloseAll,
-  event,
-  typeOfAction
-}) => {
+> = props => {
+  const { open, isSpecific, event, typeOfAction } = props
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
-  const calList = useAppSelector(state => state.calendars.list)
-  const user = useAppSelector(state => state.user)
 
-  const userPersonalCalendars = useUserPersonalCalendars(
-    calList,
-    user.userData?.openpaasId
-  )
-
-  const [showMore, setShowMore] = useState(false)
-  const formRef = useRef<EventFormHandle>(null)
-
-  const { masterEvent, effectiveEvent } = useMasterEvent(
-    event,
-    open,
-    typeOfAction
-  )
-
-  const initialValues = useBuildInitialValues({
-    event: effectiveEvent || null,
-    calId,
-    selectedRange: null
-  })
-
-  useEffect(() => {
-    const resetShowMore = (): void => {
-      if (!open) setShowMore(false)
-    }
-    resetShowMore()
-  }, [open])
-
-  const handleClose = useCallback((): void => {
-    clearEventFormTempData('update')
-    if (onCloseAll) onCloseAll()
-    else onClose({}, 'backdropClick')
-    setShowMore(false)
-  }, [onClose, onCloseAll])
-
-  const { handleSubmit } = useSubmitUpdateEvent({
-    event,
-    calId,
-    eventId,
-    typeOfAction,
-    masterEvent,
+  const {
+    userPersonalCalendars,
     showMore,
-    onClose: handleClose
-  })
-
-  const tempContext: EventFormContext = { eventId, calId, typeOfAction }
-
-  const handleExpandToggle = !isSpecific
-    ? (): void => setShowMore(s => !s)
-    : undefined
+    setShowMore,
+    formRef,
+    effectiveEvent,
+    initialValues,
+    handleClose,
+    handleSubmit,
+    handleExpandToggle,
+    handleSave,
+    tempContext
+  } = useEventUpdateModal(props)
 
   const actions = (
     <EventActions
       showExpandedBtn={!showMore && !isSpecific}
       isEdit
       onClose={handleClose}
-      onSave={async () => {
-        await formRef.current?.submit()
-      }}
+      onSave={handleSave}
       onExpanded={() => setShowMore(s => !s)}
     />
   )

--- a/src/features/Events/EventUpdateModal.tsx
+++ b/src/features/Events/EventUpdateModal.tsx
@@ -98,24 +98,29 @@ const EventUpdateModalInternal: React.FC<
 
   const tempContext: EventFormContext = { eventId, calId, typeOfAction }
 
+  const handleExpandToggle = !isSpecific
+    ? (): void => setShowMore(s => !s)
+    : undefined
+
+  const actions = (
+    <EventActions
+      showExpandedBtn={!showMore && !isSpecific}
+      isEdit
+      onClose={handleClose}
+      onSave={async () => {
+        await formRef.current?.submit()
+      }}
+      onExpanded={() => setShowMore(s => !s)}
+    />
+  )
   return (
     <ResponsiveDialog
       open={open}
       onClose={handleClose}
       title={t('event.updateEvent')}
       isExpanded={showMore}
-      onExpandToggle={!isSpecific ? () => setShowMore(s => !s) : undefined}
-      actions={
-        <EventActions
-          showExpandedBtn={!showMore && !isSpecific}
-          isEdit
-          onClose={handleClose}
-          onSave={async () => {
-            await formRef.current?.submit()
-          }}
-          onExpanded={() => setShowMore(s => !s)}
-        />
-      }
+      onExpandToggle={handleExpandToggle}
+      actions={actions}
       sx={dialogPaddingStyles(isMobile)}
       expandText={t('tooltip.moreEventOptions')}
     >

--- a/src/features/Events/EventUpdateModal.tsx
+++ b/src/features/Events/EventUpdateModal.tsx
@@ -29,6 +29,7 @@ interface EventUpdateModalProps {
   calId: string
   open: boolean
   onClose: (event: unknown, reason: 'backdropClick' | 'escapeKeyDown') => void
+  isSpecific?: boolean
   onCloseAll?: () => void
   eventData?: CalendarEvent | null
   typeOfAction?: 'solo' | 'all'
@@ -36,7 +37,16 @@ interface EventUpdateModalProps {
 
 const EventUpdateModalInternal: React.FC<
   EventUpdateModalProps & { event: CalendarEvent }
-> = ({ eventId, calId, open, onClose, onCloseAll, event, typeOfAction }) => {
+> = ({
+  eventId,
+  calId,
+  open,
+  onClose,
+  isSpecific,
+  onCloseAll,
+  event,
+  typeOfAction
+}) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
   const calList = useAppSelector(state => state.calendars.list)
@@ -115,6 +125,7 @@ const EventUpdateModalInternal: React.FC<
         initialValues={initialValues}
         showMore={showMore}
         isOpen={open}
+        isSpecific={isSpecific}
         typeOfAction={typeOfAction}
         eventId={event.uid}
         userPersonalCalendars={userPersonalCalendars}

--- a/src/features/Events/EventUpdateModal.tsx
+++ b/src/features/Events/EventUpdateModal.tsx
@@ -104,10 +104,10 @@ const EventUpdateModalInternal: React.FC<
       onClose={handleClose}
       title={t('event.updateEvent')}
       isExpanded={showMore}
-      onExpandToggle={() => setShowMore(s => !s)}
+      onExpandToggle={!isSpecific ? () => setShowMore(s => !s) : undefined}
       actions={
         <EventActions
-          showExpandedBtn={!showMore}
+          showExpandedBtn={!showMore && !isSpecific}
           isEdit
           onClose={handleClose}
           onSave={async () => {

--- a/src/features/Events/hooks/submitUpdateHelpers/types.ts
+++ b/src/features/Events/hooks/submitUpdateHelpers/types.ts
@@ -49,6 +49,7 @@ export interface PrepareUpdateDataParams {
   calId: string
   eventId: string
   typeOfAction?: 'all' | 'solo'
+  masterEvent?: CalendarEvent | null
 }
 
 export interface HandleUpdateSubmitParams extends PrepareUpdateDataParams {

--- a/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -7,7 +7,6 @@ import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
 import { Resource } from '@/components/Attendees/ResourceSearch'
 import { userAttendee } from '@/features/User/models/attendee'
 import { PrepareUpdateDataResult, PrepareUpdateDataParams } from './types'
-
 export function getSeriesInstances(
   targetCalendar: Calendar,
   baseUID: string
@@ -108,8 +107,9 @@ export function prepareUpdateData({
   showMore,
   calId,
   eventId,
-  typeOfAction
-}: PrepareUpdateDataParams): PrepareUpdateDataResult | null {
+  typeOfAction,
+  masterEvent
+}: PrepareUpdateDataParams): Promise<PrepareUpdateDataResult | null> {
   const targetCalendar = calList[values.calendarid]
   if (!targetCalendar) return null
 
@@ -123,8 +123,10 @@ export function prepareUpdateData({
     showMore,
     hasEndDateChanged: values.hasEndDateChanged
   })
-
-  const timeChanged = hasEventTimeChanged(event, startISO, endISO)
+  console.log(masterEvent)
+  const referenceEvent =
+    typeOfAction === 'all' && masterEvent ? masterEvent : event
+  const timeChanged = hasEventTimeChanged(referenceEvent, startISO, endISO)
   const newCalId = values.calendarid
 
   const newEvent = prepareUpdatedEvent({

--- a/src/features/Events/useEventOrganizer.ts
+++ b/src/features/Events/useEventOrganizer.ts
@@ -43,7 +43,7 @@ export function useEventOrganizer({
       selectedCalendar?.events[eventId]?.organizer?.cal_address ===
       organizer?.cal_address
     )
-  }, [selectedCalendar, eventId, userOrganizer])
+  }, [selectedCalendar, eventId, organizer?.cal_address])
 
   return { organizer, selectedCalendar, isOrganizer }
 }

--- a/src/features/Events/useEventOrganizer.ts
+++ b/src/features/Events/useEventOrganizer.ts
@@ -6,15 +6,18 @@ import { userOrganiser } from '../User/userDataTypes'
 // Update event organizer accordingly to selected calendar's delegated status
 export function useEventOrganizer({
   calendarid,
+  eventId,
   calList,
   userOrganizer
 }: {
   calendarid: string
+  eventId: string | null | undefined
   calList: Record<string, Calendar>
   userOrganizer: userOrganiser
 }): {
   organizer: userOrganiser
   selectedCalendar: Calendar
+  isOrganizer: boolean
 } {
   const selectedCalendar = useMemo(
     () => calList?.[calendarid],
@@ -34,5 +37,13 @@ export function useEventOrganizer({
     return userOrganizer
   }, [selectedCalendar, userOrganizer])
 
-  return { organizer, selectedCalendar }
+  const isOrganizer = useMemo(() => {
+    if (!eventId) return false
+    return (
+      selectedCalendar?.events[eventId]?.organizer?.cal_address ===
+      organizer?.cal_address
+    )
+  }, [selectedCalendar, eventId, userOrganizer])
+
+  return { organizer, selectedCalendar, isOrganizer }
 }

--- a/src/features/Events/useEventUpdateModal.tsx
+++ b/src/features/Events/useEventUpdateModal.tsx
@@ -1,0 +1,115 @@
+import { useAppSelector } from '@/app/hooks'
+import type {
+  EventFormHandle,
+  EventFormValues
+} from '@/components/Event/EventFormFields.types'
+import { useBuildInitialValues } from '@/components/Event/hooks/useBuildInitialValues'
+import {
+  clearEventFormTempData,
+  EventFormContext
+} from '@/utils/eventFormTempStorage'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Calendar } from '../Calendars/CalendarTypes'
+import { useUserPersonalCalendars } from '../Calendars/hooks/useUserPersonalCalendars'
+import { CalendarEvent } from './EventsTypes'
+import { EventUpdateModalProps } from './EventUpdateModal'
+import { useMasterEvent } from './hooks/useMasterEvent'
+import { useSubmitUpdateEvent } from './hooks/useSubmitUpdateEvent'
+
+export function useEventUpdateModal(
+  props: EventUpdateModalProps & { event: CalendarEvent }
+): {
+  userPersonalCalendars: Calendar[]
+  showMore: boolean
+  setShowMore: React.Dispatch<React.SetStateAction<boolean>>
+  formRef: React.RefObject<EventFormHandle>
+  effectiveEvent: CalendarEvent | undefined | null
+  initialValues: ReturnType<typeof useBuildInitialValues>
+  handleClose: () => void
+  handleSubmit: (values: EventFormValues) => Promise<void>
+  handleExpandToggle: (() => void) | undefined
+  handleSave: () => Promise<void>
+  tempContext: EventFormContext
+} {
+  const {
+    eventId,
+    calId,
+    open,
+    onClose,
+    onCloseAll,
+    event,
+    typeOfAction,
+    isSpecific
+  } = props
+
+  const calList = useAppSelector(state => state.calendars.list)
+  const user = useAppSelector(state => state.user)
+
+  const userPersonalCalendars = useUserPersonalCalendars(
+    calList,
+    user.userData?.openpaasId
+  )
+
+  const [showMore, setShowMore] = useState(false)
+  const formRef = useRef<EventFormHandle>(null)
+
+  const { masterEvent, effectiveEvent } = useMasterEvent(
+    event,
+    open,
+    typeOfAction
+  )
+
+  const initialValues = useBuildInitialValues({
+    event: effectiveEvent || null,
+    calId,
+    selectedRange: null
+  })
+
+  useEffect(() => {
+    const resetShowMore = (): void => {
+      if (!open) setShowMore(false)
+    }
+    resetShowMore()
+  }, [open])
+
+  const handleClose = useCallback((): void => {
+    clearEventFormTempData('update')
+    if (onCloseAll) onCloseAll()
+    else onClose({}, 'backdropClick')
+    setShowMore(false)
+  }, [onClose, onCloseAll])
+
+  const { handleSubmit } = useSubmitUpdateEvent({
+    event,
+    calId,
+    eventId,
+    typeOfAction,
+    masterEvent,
+    showMore,
+    onClose: handleClose
+  })
+
+  const tempContext: EventFormContext = { eventId, calId, typeOfAction }
+
+  const handleExpandToggle = !isSpecific
+    ? (): void => setShowMore(s => !s)
+    : undefined
+
+  const handleSave = useCallback(async () => {
+    await formRef.current?.submit()
+  }, [])
+
+  return {
+    userPersonalCalendars,
+    showMore,
+    setShowMore,
+    formRef,
+    effectiveEvent,
+    initialValues,
+    handleClose,
+    handleSubmit,
+    handleExpandToggle,
+    handleSave,
+    tempContext
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -305,6 +305,7 @@
   "eventPreview": {
     "emailAttendees": "Email attendees",
     "deleteEvent": "Delete event",
+    "editEventSpecificSettings": "Edit personal event settings",
     "privateEvent": {
       "tooltipOwn": "Only you and attendees can see the details of this event.",
       "hiddenDetails": "This is a private event. Details are hidden."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -96,6 +96,7 @@
       "accessRights": "Droits d'accès",
       "viewAllEvents": "Voir tous les événements",
       "editor": "Éditeur",
+      "owner": "Propriétaire",
       "administrator": "Administrateur"
     }
   },
@@ -306,6 +307,7 @@
   "eventPreview": {
     "emailAttendees": "Envoyer un e-mail aux participants",
     "deleteEvent": "Supprimer l'événement",
+    "editEventSpecificSettings": "Modifier les paramètres personnels de l'événement",
     "privateEvent": {
       "tooltipOwn": "Seuls vous et les participants pouvez voir les détails de cet événement.",
       "hiddenDetails": "Ceci est un événement privé. Les détails sont masqués."

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -96,6 +96,7 @@
       "accessRights": "Права доступа",
       "viewAllEvents": "Просмотр всех событий",
       "editor": "Редактор",
+      "owner": "Владелец",
       "administrator": "Администратор"
     }
   },
@@ -306,6 +307,7 @@
   "eventPreview": {
     "emailAttendees": "Написать участникам",
     "deleteEvent": "Удалить",
+    "editEventSpecificSettings": "Редактировать персональные настройки события",
     "privateEvent": {
       "tooltipOwn": "Детали видны только вам и участникам",
       "hiddenDetails": "Это приватное событие. Подробности скрыты."

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -94,6 +94,7 @@
       "accessRights": "Quyền truy cập",
       "viewAllEvents": "Xem tất cả sự kiện",
       "editor": "Biên tập viên",
+      "owner": "Chủ sở hữu",
       "administrator": "Quản trị viên"
     }
   },
@@ -304,6 +305,7 @@
   "eventPreview": {
     "emailAttendees": "Gửi email cho người tham gia",
     "deleteEvent": "Xóa sự kiện",
+    "editEventSpecificSettings": "Chỉnh sửa cài đặt sự kiện cá nhân",
     "privateEvent": {
       "tooltipOwn": "Chỉ bạn và người tham gia có thể xem chi tiết của sự kiện này.",
       "hiddenDetails": "Đây là sự kiện riêng tư. Chi tiết bị ẩn."


### PR DESCRIPTION
resolves #250 

Still need to address recurring events modifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Edit personal event settings" action that opens a compact personal-only edit mode.

* **Behavior Changes**
  * Compact mode shows a streamlined title/time view, hides expand-more controls, and limits fields to personal settings based on organizer status.
  * Form submission now only blocks when the full editor is invalid.

* **UI/UX Improvements**
  * Consistent expand/collapse behavior for notification/availability/visibility; calendar selector can default to expanded.

* **Localization**
  * Added translations for the new menu item and an "owner" label in multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->