### PR TITLE
#913 set websocket debounce for each calendar

### DIFF
--- a/__test__/features/websocket/utils/notificationStorm.test.tsx
+++ b/__test__/features/websocket/utils/notificationStorm.test.tsx
@@ -40,15 +40,18 @@ const mockState = {
 const mockAccumulators: {
   calendarsToRefresh: Map<string, any>
   calendarsToHide: Set<string>
-  debouncedUpdateFn?: (dispatch: AppDispatch) => void
+  debouncedUpdateFns: Map<string, (dispatch: AppDispatch) => void>
+  debouncedListUpdateFn?: (dispatch: AppDispatch) => void
   shouldRefreshCalendarListRef: React.MutableRefObject<boolean>
   currentDebouncePeriod?: number
+  delayedRefreshTimers?: Map<string, ReturnType<typeof setTimeout>>
 } = {
   calendarsToRefresh: new Map<string, any>(),
   calendarsToHide: new Set(),
+  debouncedUpdateFns: new Map(),
   shouldRefreshCalendarListRef: { current: false },
   currentDebouncePeriod: 0,
-  debouncedUpdateFn: undefined
+  delayedRefreshTimers: new Map()
 }
 
 describe('websocket messages storm', () => {
@@ -63,10 +66,11 @@ describe('websocket messages storm', () => {
     window.WS_SKIP_DELAY_MS = 0
     mockAccumulators.calendarsToRefresh = new Map<string, any>()
     mockAccumulators.calendarsToHide = new Set()
+    mockAccumulators.debouncedUpdateFns = new Map()
+    mockAccumulators.debouncedListUpdateFn = undefined
     mockAccumulators.shouldRefreshCalendarListRef.current = false
     mockAccumulators.currentDebouncePeriod = 0
-
-    mockAccumulators.debouncedUpdateFn = undefined
+    mockAccumulators.delayedRefreshTimers = new Map()
   })
   it('debounces calendar updates during message storm', () => {
     const mockMessage = {
@@ -112,14 +116,14 @@ describe('websocket messages storm', () => {
         )
     }
 
-    // Dispatch called once because of leading edge
-    expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
+    // Each calendar's leading edge triggers immediately (3 calendars)
+    expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(3)
 
     // Trailing edge
     jest.advanceTimersByTime(500)
 
-    // Trailing edge updates once per calendar + the original leading edge
-    expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(4)
+    // Trailing edge updates once per calendar (3 calls) + the 3 leading edge calls = 6 calls
+    expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(6)
   })
 
   it('executes immediately when debounce is disabled', () => {
@@ -132,5 +136,66 @@ describe('websocket messages storm', () => {
     )
 
     expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
+  })
+
+  it('bypasses skip delay for non-owned calendars and applies delay to owned calendars', () => {
+    window.WS_DEBOUNCE_PERIOD_MS = 0
+    window.WS_SKIP_DELAY_MS = 2000
+
+    const customState = {
+      user: { userData: { openpaasId: 'user1' } },
+      calendars: {
+        list: {
+          'user1/cal1': {
+            id: 'user1/cal1',
+            name: 'Own Calendar',
+            syncToken: 1
+          },
+          'user2/cal2': {
+            id: 'user2/cal2',
+            name: 'Other Calendar',
+            syncToken: 1
+          }
+        },
+        templist: {}
+      }
+    } as unknown as RootState
+
+    ;(store.getState as jest.Mock).mockReturnValue(customState)
+
+    updateCalendars(
+      {
+        '/calendars/user1/cal1': { syncToken: 'abc' },
+        '/calendars/user2/cal2': { syncToken: 'xyz' }
+      },
+      mockDispatch,
+      mockAccumulators
+    )
+
+    // user2/cal2 (non-owned) should refresh immediately
+    expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(1)
+    expect(refreshCalendarWithSyncToken).toHaveBeenCalledWith({
+      calendar: customState.calendars.list['user2/cal2'],
+      calType: undefined,
+      calendarRange: mockRange
+    })
+
+    // user1/cal1 (owned) should not refresh immediately
+    expect(refreshCalendarWithSyncToken).not.toHaveBeenCalledWith({
+      calendar: customState.calendars.list['user1/cal1'],
+      calType: undefined,
+      calendarRange: mockRange
+    })
+
+    // Advance timer by 2 seconds
+    jest.advanceTimersByTime(2000)
+
+    // Now user1/cal1 (owned) should also have refreshed
+    expect(refreshCalendarWithSyncToken).toHaveBeenCalledTimes(2)
+    expect(refreshCalendarWithSyncToken).toHaveBeenCalledWith({
+      calendar: customState.calendars.list['user1/cal1'],
+      calType: undefined,
+      calendarRange: mockRange
+    })
   })
 })

--- a/__test__/features/websocket/utils/updateCalendars.test.tsx
+++ b/__test__/features/websocket/utils/updateCalendars.test.tsx
@@ -4,9 +4,28 @@ import { getDisplayedCalendarRange } from '@/utils/CalendarRangeManager'
 import { updateCalendars } from '@/websocket/messaging/updateCalendars'
 import { WS_INBOUND_EVENTS } from '@/websocket/protocols'
 import { waitFor } from '@testing-library/dom'
+import { getCalendarDetailAsync } from '@/features/Calendars/services/getCalendarDetailAsync'
+import { emptyEventsCal } from '@/features/Calendars/CalendarSlice'
+import { formatDateToYYYYMMDDTHHMMSS } from '@/utils/dateUtils'
 
 jest.mock('@/features/Calendars/services/refreshCalendar')
 jest.mock('@/utils/CalendarRangeManager')
+jest.mock('@/features/Calendars/services/getCalendarDetailAsync', () => ({
+  getCalendarDetailAsync: jest.fn(args => ({
+    type: 'mock/getCalendarDetailAsync',
+    payload: args
+  }))
+}))
+jest.mock('@/features/Calendars/CalendarSlice', () => {
+  const original = jest.requireActual('@/features/Calendars/CalendarSlice')
+  return {
+    ...original,
+    emptyEventsCal: jest.fn(args => ({
+      type: 'mock/emptyEventsCal',
+      payload: args
+    }))
+  }
+})
 jest.mock('@/app/store', () => ({
   store: {
     getState: jest.fn()
@@ -32,15 +51,16 @@ describe('updateCalendars', () => {
   const mockAccumulators: {
     calendarsToRefresh: Map<string, any>
     calendarsToHide: Set<string>
-    debouncedUpdateFn?: (dispatch: AppDispatch) => void
+    debouncedUpdateFns: Map<string, (dispatch: AppDispatch) => void>
+    debouncedListUpdateFn?: (dispatch: AppDispatch) => void
     shouldRefreshCalendarListRef: React.MutableRefObject<boolean>
     currentDebouncePeriod?: number
   } = {
     calendarsToRefresh: new Map<string, any>(),
     calendarsToHide: new Set(),
+    debouncedUpdateFns: new Map(),
     shouldRefreshCalendarListRef: { current: false },
-    currentDebouncePeriod: 0,
-    debouncedUpdateFn: jest.fn()
+    currentDebouncePeriod: 0
   }
 
   beforeEach(() => {
@@ -50,9 +70,10 @@ describe('updateCalendars', () => {
     ;(store.getState as jest.Mock).mockReturnValue(mockState)
     mockAccumulators.calendarsToRefresh = new Map<string, any>()
     mockAccumulators.calendarsToHide = new Set()
+    mockAccumulators.debouncedUpdateFns = new Map()
+    mockAccumulators.debouncedListUpdateFn = undefined
     mockAccumulators.currentDebouncePeriod = 0
     mockAccumulators.shouldRefreshCalendarListRef.current = false
-    mockAccumulators.debouncedUpdateFn = jest.fn()
     window.WS_SKIP_DELAY_MS = 0
   })
 
@@ -140,6 +161,42 @@ describe('updateCalendars', () => {
     }
 
     updateCalendars(message, mockDispatch, mockAccumulators)
+
+    expect(refreshCalendarWithSyncToken).not.toHaveBeenCalled()
+  })
+
+  it('should fall back to getCalendarDetailAsync when calendar has no syncToken', async () => {
+    const stateWithoutSyncToken = {
+      calendars: {
+        list: {
+          'cal1/entry1': { id: 'cal1/entry1', name: 'Calendar 1' }
+        },
+        templist: {}
+      }
+    } as unknown as RootState
+
+    ;(store.getState as jest.Mock).mockReturnValue(stateWithoutSyncToken)
+
+    const message = {
+      '/calendars/cal1/entry1': {}
+    }
+
+    updateCalendars(message, mockDispatch, mockAccumulators)
+
+    await waitFor(() => {
+      expect(emptyEventsCal).toHaveBeenCalledWith({
+        calId: 'cal1/entry1',
+        calType: undefined
+      })
+      expect(getCalendarDetailAsync).toHaveBeenCalledWith({
+        calId: 'cal1/entry1',
+        match: {
+          start: formatDateToYYYYMMDDTHHMMSS(mockRange.start),
+          end: formatDateToYYYYMMDDTHHMMSS(mockRange.end)
+        },
+        calType: undefined
+      })
+    })
 
     expect(refreshCalendarWithSyncToken).not.toHaveBeenCalled()
   })

--- a/src/websocket/WebSocketGate.tsx
+++ b/src/websocket/WebSocketGate.tsx
@@ -5,6 +5,7 @@ import { useSelectedCalendars } from '@/utils/storage/useSelectedCalendars'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import type { WebSocketWithCleanup } from './connection'
+import { DebouncedFunc } from 'lodash'
 import { closeWebSocketConnection } from './connection/lifecycle/closeWebSocketConnection'
 import { establishWebSocketConnection } from './connection/lifecycle/establishWebSocketConnection'
 import {
@@ -20,16 +21,16 @@ import { updateCalendars } from './messaging/updateCalendars'
 import { syncCalendarRegistrations } from './operations'
 import { WebSocketStatusSnackbar } from './WebSocketStatusSnackbar'
 
-export function WebSocketGate() {
+export function WebSocketGate(): JSX.Element | null {
   const socketRef = useRef<WebSocketWithCleanup | null>(null)
   const previousCalendarListRef = useRef<string[]>([])
   const previousTempCalendarListRef = useRef<string[]>([])
-  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const reconnectAttemptsRef = useRef(0)
   const isConnectingRef = useRef(false)
   const pingCleanupRef = useRef<PingCleanup | null>(null)
 
-  const connectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const didConnectTimeoutRef = useRef(false)
   const CONNECT_TIMEOUT_MS = 10_000
 
@@ -62,10 +63,16 @@ export function WebSocketGate() {
   >(new Map())
   const calendarsToHideRef = useRef<Set<string>>(new Set())
   const shouldRefreshCalendarListRef = useRef<boolean>(false)
-  const debouncedUpdateFnRef = useRef<
-    ((dispatch: AppDispatch) => void) | undefined
-  >()
+  const debouncedUpdateFnsRef = useRef<
+    Map<string, DebouncedFunc<(dispatch: AppDispatch) => void>>
+  >(new Map())
+  const debouncedListUpdateFnRef = useRef<
+    DebouncedFunc<(dispatch: AppDispatch) => void> | undefined
+  >(undefined)
   const currentDebouncePeriodRef = useRef<number | undefined>()
+  const delayedRefreshTimersRef = useRef<
+    Map<string, ReturnType<typeof setTimeout>>
+  >(new Map())
 
   const onMessage = useCallback(
     (message: unknown) => {
@@ -73,12 +80,14 @@ export function WebSocketGate() {
         calendarsToRefresh: calendarsToRefreshRef.current,
         calendarsToHide: calendarsToHideRef.current,
         shouldRefreshCalendarListRef,
-        debouncedUpdateFn: debouncedUpdateFnRef.current,
-        currentDebouncePeriod: currentDebouncePeriodRef.current
+        debouncedUpdateFns: debouncedUpdateFnsRef.current,
+        debouncedListUpdateFn: debouncedListUpdateFnRef.current,
+        currentDebouncePeriod: currentDebouncePeriodRef.current,
+        delayedRefreshTimers: delayedRefreshTimersRef.current
       }
       updateCalendars(message, dispatch, accumulators)
       // Persist any mutations back to refs
-      debouncedUpdateFnRef.current = accumulators.debouncedUpdateFn
+      debouncedListUpdateFnRef.current = accumulators.debouncedListUpdateFn
       currentDebouncePeriodRef.current = accumulators.currentDebouncePeriod
     },
     [dispatch]
@@ -162,13 +171,16 @@ export function WebSocketGate() {
   useEffect(() => {
     const abortController = new AbortController()
 
-    const cleanup = () => {
+    const cleanup = (): void => {
       if (connectTimeoutRef.current) {
         clearTimeout(connectTimeoutRef.current)
         connectTimeoutRef.current = null
       }
       closeWebSocketConnection(socketRef, setIsSocketOpen)
+      delete window.__ws
       clearReconnectTimeout()
+      delayedRefreshTimersRef.current.forEach(timer => clearTimeout(timer))
+      delayedRefreshTimersRef.current.clear()
     }
 
     if (!isAuthenticated) {
@@ -179,7 +191,7 @@ export function WebSocketGate() {
       return
     }
 
-    const connect = async () => {
+    const connect = async (): Promise<void> => {
       if (isConnectingRef.current || isSocketOpen) return
       isConnectingRef.current = true
       setWebSocketConnecting(true)
@@ -204,6 +216,9 @@ export function WebSocketGate() {
           setIsSocketOpen,
           abortController.signal
         )
+        if (socketRef.current) {
+          window.__ws = socketRef.current
+        }
       } catch (err) {
         console.warn('WebSocket establishment failed:', err)
 
@@ -222,9 +237,9 @@ export function WebSocketGate() {
       }
     }
 
-    connect()
+    void connect()
 
-    return () => {
+    return (): void => {
       abortController.abort()
       cleanup()
     }
@@ -268,7 +283,7 @@ export function WebSocketGate() {
 
   // Handle browser online/offline events
   useEffect(() => {
-    const handleOnline = () => {
+    const handleOnline = (): void => {
       if (!isSocketOpen && isAuthenticatedRef.current) {
         reconnectAttemptsRef.current = 0
         clearReconnectTimeout()
@@ -276,23 +291,25 @@ export function WebSocketGate() {
       }
     }
 
-    const handleOffline = () => {
+    const handleOffline = (): void => {
       cleanupConnection()
     }
 
-    const cleanupConnection = () => {
+    const cleanupConnection = (): void => {
       closeWebSocketConnection(socketRef, setIsSocketOpen)
       clearReconnectTimeout()
       if (connectTimeoutRef.current) {
         clearTimeout(connectTimeoutRef.current)
         connectTimeoutRef.current = null
       }
+      delayedRefreshTimersRef.current.forEach(timer => clearTimeout(timer))
+      delayedRefreshTimersRef.current.clear()
     }
 
     window.addEventListener('online', handleOnline)
     window.addEventListener('offline', handleOffline)
 
-    return () => {
+    return (): void => {
       window.removeEventListener('online', handleOnline)
       window.removeEventListener('offline', handleOffline)
     }
@@ -326,7 +343,7 @@ export function WebSocketGate() {
 
     pingCleanupRef.current = pingCleanup
 
-    return () => {
+    return (): void => {
       if (pingCleanupRef.current) {
         pingCleanupRef.current.stop()
         pingCleanupRef.current = null
@@ -343,6 +360,14 @@ export function WebSocketGate() {
   useEffect(() => {
     registerWebSocketState(socketRef, triggerReconnect)
   }, [triggerReconnect])
+
+  // Clean up delayed refresh timers on unmount
+  useEffect(() => {
+    return (): void => {
+      delayedRefreshTimersRef.current.forEach(timer => clearTimeout(timer))
+      delayedRefreshTimersRef.current.clear()
+    }
+  }, [])
 
   return websocketStatus ? (
     <WebSocketStatusSnackbar

--- a/src/websocket/connection/lifecycle/pingWebSocket.ts
+++ b/src/websocket/connection/lifecycle/pingWebSocket.ts
@@ -54,12 +54,12 @@ export function setupWebSocketPing(
     onPongReceived
   } = config
 
-  let pingIntervalId: NodeJS.Timeout | null = null
-  let pongTimeoutId: NodeJS.Timeout | null = null
+  let pingIntervalId: ReturnType<typeof setInterval> | null = null
+  let pongTimeoutId: ReturnType<typeof setTimeout> | null = null
   let isWaitingForPong = false
   let isStopped = false
 
-  const cleanup = () => {
+  const cleanup = (): void => {
     if (pingIntervalId) {
       clearInterval(pingIntervalId)
       pingIntervalId = null
@@ -71,7 +71,7 @@ export function setupWebSocketPing(
     isWaitingForPong = false
   }
 
-  const sendPing = () => {
+  const sendPing = (): void => {
     if (isStopped || !socket || socket.readyState !== WebSocket.OPEN) {
       return
     }
@@ -109,7 +109,7 @@ export function setupWebSocketPing(
     }
   }
 
-  const handlePong = () => {
+  const handlePong = (): void => {
     if (pongTimeoutId) {
       clearTimeout(pongTimeoutId)
       pongTimeoutId = null
@@ -119,7 +119,7 @@ export function setupWebSocketPing(
   }
 
   // Start ping interval
-  const startPinging = () => {
+  const startPinging = (): void => {
     if (!socket || socket.readyState !== WebSocket.OPEN) {
       console.warn('Cannot start pinging: socket is not open')
       return
@@ -163,7 +163,7 @@ export function setupWebSocketPing(
   startPinging()
 
   return {
-    stop: () => {
+    stop: (): void => {
       isStopped = true
       cleanup()
       // Restore original onmessage handler
@@ -171,7 +171,7 @@ export function setupWebSocketPing(
         socket.onmessage = originalOnMessage ?? null
       }
     },
-    sendPing: () => {
+    sendPing: (): void => {
       if (!isStopped) {
         sendPing()
       }

--- a/src/websocket/connection/lifecycle/useWebSocketReconnect.ts
+++ b/src/websocket/connection/lifecycle/useWebSocketReconnect.ts
@@ -8,11 +8,14 @@ export const RECONNECT_CONFIG: RetryBackoffConfig = {
 export const MAX_RECONNECT_ATTEMPTS = 10
 
 export function useWebSocketReconnect(
-  reconnectTimeoutRef: MutableRefObject<NodeJS.Timeout | null>,
+  reconnectTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>,
   isAuthenticatedRef: MutableRefObject<boolean>,
   reconnectAttemptsRef: MutableRefObject<number>,
   setShouldConnect: Dispatch<SetStateAction<boolean>>
-) {
+): {
+  scheduleReconnect: () => void
+  clearReconnectTimeout: () => void
+} {
   const clearReconnectTimeout = useCallback(() => {
     if (reconnectTimeoutRef.current) {
       clearTimeout(reconnectTimeoutRef.current)

--- a/src/websocket/messaging/type/UpdateCalendarsAccumulators.ts
+++ b/src/websocket/messaging/type/UpdateCalendarsAccumulators.ts
@@ -1,10 +1,16 @@
 import { AppDispatch } from '@/app/store'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
+import { DebouncedFunc } from 'lodash'
 
 export interface UpdateCalendarsAccumulators {
   calendarsToRefresh: Map<string, { calendar: Calendar; type?: 'temp' }>
   calendarsToHide: Set<string>
   shouldRefreshCalendarListRef: React.MutableRefObject<boolean>
-  debouncedUpdateFn?: (dispatch: AppDispatch) => void
+  debouncedUpdateFns: Map<
+    string,
+    DebouncedFunc<(dispatch: AppDispatch) => void>
+  >
+  debouncedListUpdateFn?: DebouncedFunc<(dispatch: AppDispatch) => void>
   currentDebouncePeriod?: number
+  delayedRefreshTimers?: Map<string, ReturnType<typeof setTimeout>>
 }

--- a/src/websocket/messaging/updateCalendars.ts
+++ b/src/websocket/messaging/updateCalendars.ts
@@ -3,11 +3,15 @@ import { store } from '@/app/store'
 import { Calendar } from '@/features/Calendars/CalendarTypes'
 import {
   getCalendarsListAsync,
-  refreshCalendarWithSyncToken
+  refreshCalendarWithSyncToken,
+  getCalendarDetailAsync
 } from '@/features/Calendars/services'
+import { emptyEventsCal } from '@/features/Calendars/CalendarSlice'
+import { formatDateToYYYYMMDDTHHMMSS } from '@/utils/dateUtils'
 import { findCalendarById, getDisplayedCalendarRange } from '@/utils'
 import { setSelectedCalendars } from '@/utils/storage/setSelectedCalendars'
-import { debounce } from 'lodash'
+import type { MutableRefObject } from 'react'
+import { debounce, DebouncedFunc } from 'lodash'
 import { parseCalendarPath } from './parseCalendarPath'
 import { parseMessage } from './parseMessage'
 import { UpdateCalendarsAccumulators } from './type/UpdateCalendarsAccumulators'
@@ -15,39 +19,50 @@ import { UpdateCalendarsAccumulators } from './type/UpdateCalendarsAccumulators'
 const DEFAULT_DEBOUNCE_MS = 0
 const DEFAULT_WS_SKIP_DELAY_MS = 2000
 
-function createDebouncedUpdate(
-  debouncePeriodMs: number,
-  getCalendarsToRefresh: () => Map<
-    string,
-    { calendar: Calendar; type?: 'temp' }
-  >,
-  getCalendarsToHide: () => Set<string>,
-  getShouldRefreshCalendarList: () => boolean,
-  resetShouldRefreshCalendarList: () => void
-) {
+function createDebouncedCalendarUpdate({
+  calId,
+  debouncePeriodMs,
+  calendarsToRefresh,
+  calendarsToHide,
+  delayedRefreshTimers
+}: {
+  calId: string
+  debouncePeriodMs: number
+  calendarsToRefresh: Map<string, { calendar: Calendar; type?: 'temp' }>
+  calendarsToHide: Set<string>
+  delayedRefreshTimers?: Map<string, ReturnType<typeof setTimeout>>
+}): DebouncedFunc<(dispatch: AppDispatch) => void> {
   return debounce(
-    (dispatch: AppDispatch) => {
+    (dispatch: AppDispatch): void => {
       const currentRange = getDisplayedCalendarRange()
 
-      // Snapshot state
-      const calendarsToProcess = new Map(getCalendarsToRefresh())
-      const calendarsToHideSnapshot = new Set(getCalendarsToHide())
-      const shouldRefresh = getShouldRefreshCalendarList()
+      // Snapshot individual calendar states
+      const refreshInfo = calendarsToRefresh.get(calId)
+      const shouldHide = calendarsToHide.has(calId)
 
-      // Clear accumulators
-      getCalendarsToRefresh().clear()
-      getCalendarsToHide().clear()
-      resetShouldRefreshCalendarList()
+      // Clear the individual calendar from accumulators
+      calendarsToRefresh.delete(calId)
+      calendarsToHide.delete(calId)
 
       try {
-        scheduleCalendarsRefresh(dispatch, currentRange, calendarsToProcess)
-        processCalendarsToHide(calendarsToHideSnapshot)
-
-        if (shouldRefresh) {
-          dispatch(getCalendarsListAsync())
+        if (refreshInfo) {
+          const calendarsMap = new Map([[calId, refreshInfo]])
+          scheduleCalendarsRefresh(
+            dispatch,
+            currentRange,
+            calendarsMap,
+            delayedRefreshTimers
+          )
+        }
+        if (shouldHide) {
+          const hideSet = new Set([calId])
+          processCalendarsToHide(hideSet)
         }
       } catch (error) {
-        console.warn('Error processing accumulated calendar updates:', error)
+        console.warn(
+          `Error processing accumulated calendar updates for ${calId}:`,
+          error
+        )
       }
     },
     debouncePeriodMs,
@@ -55,11 +70,128 @@ function createDebouncedUpdate(
   )
 }
 
+function createDebouncedListUpdate(
+  debouncePeriodMs: number,
+  shouldRefreshCalendarListRef: MutableRefObject<boolean>
+): DebouncedFunc<(dispatch: AppDispatch) => void> {
+  return debounce(
+    (dispatch: AppDispatch): void => {
+      const shouldRefresh = shouldRefreshCalendarListRef.current
+
+      // Clear accumulator
+      shouldRefreshCalendarListRef.current = false
+
+      try {
+        if (shouldRefresh) {
+          void dispatch(getCalendarsListAsync())
+        }
+      } catch (error) {
+        console.warn(
+          'Error processing accumulated calendar list update:',
+          error
+        )
+      }
+    },
+    debouncePeriodMs,
+    { leading: true, trailing: true }
+  )
+}
+
+function processDebouncedUpdates({
+  dispatch,
+  accumulators,
+  debouncePeriod,
+  shouldRefreshCalendarList,
+  calendarsToRefresh,
+  calendarsToHide
+}: {
+  dispatch: AppDispatch
+  accumulators: UpdateCalendarsAccumulators
+  debouncePeriod: number
+  shouldRefreshCalendarList: boolean
+  calendarsToRefresh: Set<string>
+  calendarsToHide: Set<string>
+}): void {
+  if (accumulators.currentDebouncePeriod !== debouncePeriod) {
+    accumulators.debouncedUpdateFns.forEach(fn => fn.cancel())
+    accumulators.debouncedUpdateFns.clear()
+    accumulators.debouncedListUpdateFn?.cancel()
+    accumulators.debouncedListUpdateFn = undefined
+    accumulators.currentDebouncePeriod = debouncePeriod
+  }
+
+  const uniqueCalIds = new Set<string>()
+  calendarsToRefresh.forEach(path => {
+    const calId = parseCalendarPath(path)
+    if (calId) uniqueCalIds.add(calId)
+  })
+  calendarsToHide.forEach(path => {
+    const calId = parseCalendarPath(path)
+    if (calId) uniqueCalIds.add(calId)
+  })
+
+  uniqueCalIds.forEach(calendarId => {
+    let debouncedFn = accumulators.debouncedUpdateFns.get(calendarId)
+    if (!debouncedFn) {
+      debouncedFn = createDebouncedCalendarUpdate({
+        calId: calendarId,
+        debouncePeriodMs: debouncePeriod,
+        calendarsToRefresh: accumulators.calendarsToRefresh,
+        calendarsToHide: accumulators.calendarsToHide,
+        delayedRefreshTimers: accumulators.delayedRefreshTimers
+      })
+      accumulators.debouncedUpdateFns.set(calendarId, debouncedFn)
+    }
+    debouncedFn(dispatch)
+  })
+
+  if (shouldRefreshCalendarList) {
+    let debouncedListFn = accumulators.debouncedListUpdateFn
+    if (!debouncedListFn) {
+      debouncedListFn = createDebouncedListUpdate(
+        debouncePeriod,
+        accumulators.shouldRefreshCalendarListRef
+      )
+      accumulators.debouncedListUpdateFn = debouncedListFn
+    }
+    debouncedListFn(dispatch)
+  }
+}
+
+function processImmediateUpdates(
+  dispatch: AppDispatch,
+  accumulators: UpdateCalendarsAccumulators,
+  shouldRefreshCalendarList: boolean
+): void {
+  const currentRange = getDisplayedCalendarRange()
+  const calendarsToProcess = new Map(accumulators.calendarsToRefresh)
+  const calendarsToHideSnapshot = new Set(accumulators.calendarsToHide)
+
+  accumulators.calendarsToRefresh.clear()
+  accumulators.calendarsToHide.clear()
+  accumulators.shouldRefreshCalendarListRef.current = false
+
+  try {
+    scheduleCalendarsRefresh(
+      dispatch,
+      currentRange,
+      calendarsToProcess,
+      accumulators.delayedRefreshTimers
+    )
+    processCalendarsToHide(calendarsToHideSnapshot)
+    if (shouldRefreshCalendarList) {
+      void dispatch(getCalendarsListAsync())
+    }
+  } catch (error) {
+    console.warn('Error processing calendar updates:', error)
+  }
+}
+
 export function updateCalendars(
   message: unknown,
   dispatch: AppDispatch,
   accumulators: UpdateCalendarsAccumulators
-) {
+): void {
   const state = store.getState()
   const { calendarsToRefresh, calendarsToHide, shouldRefreshCalendarList } =
     parseMessage(message)
@@ -72,58 +204,143 @@ export function updateCalendars(
   )
   accumulateCalendarsToHide(calendarsToHide, accumulators.calendarsToHide)
 
-  accumulators.shouldRefreshCalendarListRef.current ||=
+  // Cancel delayed refresh timers for any calendars that are being hidden/removed
+  calendarsToHide.forEach(path => {
+    const calId = parseCalendarPath(path)
+    if (calId) {
+      const timer = accumulators.delayedRefreshTimers?.get(calId)
+      if (timer) {
+        clearTimeout(timer)
+        accumulators.delayedRefreshTimers?.delete(calId)
+      }
+    }
+  })
+
+  accumulators.shouldRefreshCalendarListRef.current =
+    accumulators.shouldRefreshCalendarListRef.current ||
     shouldRefreshCalendarList
 
   const debouncePeriod = window.WS_DEBOUNCE_PERIOD_MS ?? DEFAULT_DEBOUNCE_MS
 
   if (debouncePeriod > 0) {
-    if (
-      !accumulators.debouncedUpdateFn ||
-      accumulators.currentDebouncePeriod !== debouncePeriod
-    ) {
-      accumulators.debouncedUpdateFn = createDebouncedUpdate(
-        debouncePeriod,
-        () => accumulators.calendarsToRefresh,
-        () => accumulators.calendarsToHide,
-        () => accumulators.shouldRefreshCalendarListRef.current,
-        () => {
-          accumulators.shouldRefreshCalendarListRef.current = false
-        }
-      )
-      accumulators.currentDebouncePeriod = debouncePeriod
-    }
-    accumulators.debouncedUpdateFn(dispatch)
-    return
-  }
-
-  // Immediate processing if debounce disabled
-  const currentRange = getDisplayedCalendarRange()
-  const calendarsToProcess = new Map(accumulators.calendarsToRefresh)
-  const calendarsToHideSnapshot = new Set(accumulators.calendarsToHide)
-
-  accumulators.calendarsToRefresh.clear()
-  accumulators.calendarsToHide.clear()
-  accumulators.shouldRefreshCalendarListRef.current = false
-
-  try {
-    scheduleCalendarsRefresh(dispatch, currentRange, calendarsToProcess)
-    processCalendarsToHide(calendarsToHideSnapshot)
-    if (shouldRefreshCalendarList) {
-      dispatch(getCalendarsListAsync())
-    }
-  } catch (error) {
-    console.warn('Error processing calendar updates:', error)
+    processDebouncedUpdates({
+      dispatch,
+      accumulators,
+      debouncePeriod,
+      shouldRefreshCalendarList,
+      calendarsToRefresh,
+      calendarsToHide
+    })
+  } else {
+    processImmediateUpdates(dispatch, accumulators, shouldRefreshCalendarList)
   }
 }
 
 // --- Helpers ---
+function triggerCalendarRefresh(
+  dispatch: AppDispatch,
+  calendar: Calendar,
+  type: 'temp' | undefined,
+  range: { start: Date; end: Date }
+): void {
+  if (calendar.syncToken) {
+    void dispatch(
+      refreshCalendarWithSyncToken({
+        calendar,
+        calType: type,
+        calendarRange: range
+      })
+    )
+  } else {
+    dispatch(emptyEventsCal({ calId: calendar.id, calType: type }))
+    void dispatch(
+      getCalendarDetailAsync({
+        calId: calendar.id,
+        match: {
+          start: formatDateToYYYYMMDDTHHMMSS(range.start),
+          end: formatDateToYYYYMMDDTHHMMSS(range.end)
+        },
+        calType: type
+      })
+    )
+  }
+}
+
+interface CalendarGroup {
+  immediate: Map<string, { calendar: Calendar; type?: 'temp' }>
+  delayed: Map<string, { calendar: Calendar; type?: 'temp' }>
+}
+
+function groupCalendarsByOwner(
+  calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>,
+  currentUserId?: string
+): CalendarGroup {
+  const immediate = new Map<string, { calendar: Calendar; type?: 'temp' }>()
+  const delayed = new Map<string, { calendar: Calendar; type?: 'temp' }>()
+
+  calendarsMap.forEach((val, calId) => {
+    const ownerId = calId.split('/')[0]
+    const isOwnCalendar = Boolean(currentUserId && ownerId === currentUserId)
+    if (isOwnCalendar) {
+      delayed.set(calId, val)
+    } else {
+      immediate.set(calId, val)
+    }
+  })
+
+  return { immediate, delayed }
+}
+
+function processDelayedCalendars(
+  dispatch: AppDispatch,
+  delayedCalendars: Map<string, { calendar: Calendar; type?: 'temp' }>
+): void {
+  const stateAfterDelay = store.getState()
+  const rangeAfterDelay = getDisplayedCalendarRange()
+
+  delayedCalendars.forEach(({ calendar, type }, calId) => {
+    const current = findCalendarById(stateAfterDelay, calId)
+    if (current && current.calendar.syncToken !== calendar.syncToken) return
+    triggerCalendarRefresh(
+      dispatch,
+      current?.calendar ?? calendar,
+      type,
+      rangeAfterDelay
+    )
+  })
+}
+
+function scheduleDelayedUpdateForOwnCalendars(
+  delayed: Map<string, { calendar: Calendar; type?: 'temp' }>,
+  dispatch: AppDispatch,
+  skipDelayMs: number,
+  delayedRefreshTimers?: Map<string, ReturnType<typeof setTimeout>>
+): void {
+  delayed.forEach((val, calId) => {
+    // Clear any existing timer for this calendar to avoid duplicates
+    const existing = delayedRefreshTimers?.get(calId)
+    if (existing) {
+      clearTimeout(existing)
+    }
+
+    const timer = setTimeout(() => {
+      delayedRefreshTimers?.delete(calId)
+      processDelayedCalendars(dispatch, new Map([[calId, val]]))
+    }, skipDelayMs)
+
+    delayedRefreshTimers?.set(calId, timer)
+  })
+}
 
 function scheduleCalendarsRefresh(
   dispatch: AppDispatch,
   currentRange: { start: Date; end: Date },
-  calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>
-) {
+  calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>,
+  delayedRefreshTimers?: Map<string, ReturnType<typeof setTimeout>>
+): void {
+  const state = store.getState()
+  const currentUserId = state.user?.userData?.openpaasId
+
   const skipDelayMs = window.WS_SKIP_DELAY_MS ?? DEFAULT_WS_SKIP_DELAY_MS
 
   if (skipDelayMs === 0) {
@@ -131,36 +348,34 @@ function scheduleCalendarsRefresh(
     return
   }
 
-  setTimeout(() => {
-    const stateAfterDelay = store.getState()
-    const rangeAfterDelay = getDisplayedCalendarRange()
-    calendarsMap.forEach(({ calendar, type }, calId) => {
-      const current = findCalendarById(stateAfterDelay, calId)
-      if (current && current.calendar.syncToken !== calendar.syncToken) return
-      dispatch(
-        refreshCalendarWithSyncToken({
-          calendar: current?.calendar ?? calendar,
-          calType: type,
-          calendarRange: rangeAfterDelay
-        })
-      )
-    })
-  }, skipDelayMs)
+  const { immediate, delayed } = groupCalendarsByOwner(
+    calendarsMap,
+    currentUserId
+  )
+
+  // Dispatch immediate updates
+  if (immediate.size > 0) {
+    dispatchCalendarsRefresh(dispatch, currentRange, immediate)
+  }
+
+  if (delayed.size <= 0) return
+
+  // Schedule delayed updates for own calendars
+  scheduleDelayedUpdateForOwnCalendars(
+    delayed,
+    dispatch,
+    skipDelayMs,
+    delayedRefreshTimers
+  )
 }
 
 function dispatchCalendarsRefresh(
   dispatch: AppDispatch,
   currentRange: { start: Date; end: Date },
   calendarsMap: Map<string, { calendar: Calendar; type?: 'temp' }>
-) {
+): void {
   calendarsMap.forEach(({ calendar, type }) => {
-    dispatch(
-      refreshCalendarWithSyncToken({
-        calendar,
-        calType: type,
-        calendarRange: currentRange
-      })
-    )
+    triggerCalendarRefresh(dispatch, calendar, type, currentRange)
   })
 }
 
@@ -168,7 +383,7 @@ function accumulateCalendarsToRefresh(
   state: ReturnType<typeof store.getState>,
   calendarPaths: Set<string>,
   calendarsToRefreshMap: Map<string, { calendar: Calendar; type?: 'temp' }>
-) {
+): void {
   calendarPaths.forEach(calendarPath => {
     const calendarId = parseCalendarPath(calendarPath)
     if (!calendarId) {
@@ -187,7 +402,7 @@ function accumulateCalendarsToRefresh(
 function accumulateCalendarsToHide(
   calendarPaths: Set<string>,
   calendarsToHideSet: Set<string>
-) {
+): void {
   calendarPaths.forEach(calendarPath => {
     const calendarId = parseCalendarPath(calendarPath)
     if (calendarId) {
@@ -196,14 +411,14 @@ function accumulateCalendarsToHide(
   })
 }
 
-function processCalendarsToHide(calendarsToHideSnapshot: Set<string>) {
+function processCalendarsToHide(calendarsToHideSnapshot: Set<string>): void {
   if (calendarsToHideSnapshot.size === 0) return
 
   let currentSelectedCalendars: string[]
 
   try {
     const stored = localStorage.getItem('selectedCalendars') ?? '[]'
-    currentSelectedCalendars = JSON.parse(stored)
+    currentSelectedCalendars = JSON.parse(stored) as string[]
   } catch (error) {
     console.warn('Failed to parse selectedCalendars from localStorage:', error)
     return

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -45,5 +45,7 @@ declare global {
     TOOLTIP_DELAY_MS: number
 
     displayOrgAvatar: boolean
+
+    __ws?: WebSocket
   }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved websocket calendar refresh handling for owned vs. non-owned calendars with proper timing delays.
  * Fixed fallback behavior when calendar sync information is unavailable—system now fetches and updates correctly.
  * Enhanced connection cleanup to ensure proper websocket state management.

* **Tests**
  * Updated test coverage for debounced calendar updates and skip-delay behavior.
  * Added verification for calendar refresh fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->