### PR TITLE
[#748] fixed rrule until to follow RFC5545

### DIFF
--- a/__test__/features/Events/updateEventHelpers/makeVevent.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeVevent.test.ts
@@ -365,11 +365,11 @@ describe('RFC 5545 – RRULE (§3.8.5.3)', () => {
 
   it('maps endDate to UNTIL', () => {
     const event = baseEvent({
-      repetition: { freq: 'WEEKLY', endDate: '20241231T000000Z' }
+      repetition: { freq: 'WEEKLY', endDate: '2024-12-31' }
     })
     const vevent = makeVevent(event, TZID, OWNER)
     const rule = getProp(vevent, 'rrule')![3] as Record<string, unknown>
-    expect(rule.until).toBe('20241231T000000Z')
+    expect(rule.until).toBe('20241231T235959Z')
   })
 
   it('maps byday correctly', () => {

--- a/__test__/features/Events/updateEventHelpers/makeVevent.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeVevent.test.ts
@@ -369,7 +369,7 @@ describe('RFC 5545 – RRULE (§3.8.5.3)', () => {
     })
     const vevent = makeVevent(event, TZID, OWNER)
     const rule = getProp(vevent, 'rrule')![3] as Record<string, unknown>
-    expect(rule.until).toBe('20241231T235959Z')
+    expect(rule.until).toBe('20241231T225959Z')
   })
 
   it('maps byday correctly', () => {

--- a/src/features/Events/utils/makeVevent.ts
+++ b/src/features/Events/utils/makeVevent.ts
@@ -162,7 +162,7 @@ function formatUntilForRRule(
   tzid: string
 ): string {
   if (allday) {
-    return endDate
+    return endDate.replace(/-/g, '')
   }
 
   // Take the date part of endDate, add end of day, convert to UTC

--- a/src/features/Events/utils/makeVevent.ts
+++ b/src/features/Events/utils/makeVevent.ts
@@ -1,4 +1,5 @@
 import { extractEventBaseUuid } from '@/utils/extractEventBaseUuid'
+import moment from 'moment'
 import { RepetitionRule } from '../../Calendars/types/CalendarData'
 import { CalendarEvent } from '../EventsTypes'
 import { formatDateTimeToICal, formatDateToICal } from './formatDateToICal'
@@ -92,7 +93,11 @@ export function makeVevent(
       repetitionRule.count = event.repetition.occurrences
     }
     if (event.repetition.endDate) {
-      repetitionRule.until = event.repetition.endDate
+      repetitionRule.until = formatUntilForRRule(
+        event.repetition.endDate,
+        event.allday ?? false,
+        tzid
+      )
     }
     if (
       event.repetition.byday !== null &&
@@ -149,4 +154,23 @@ export function makeVevent(
   }
 
   return vevent
+}
+
+function formatUntilForRRule(
+  endDate: string,
+  allday: boolean,
+  tzid: string
+): string {
+  if (allday) {
+    return endDate
+  }
+
+  // Take the date part of endDate, add end of day, convert to UTC
+  const datePart = endDate
+  const timePart = '23:59:59'
+
+  return moment
+    .tz(`${datePart}T${timePart}`, tzid)
+    .utc()
+    .format('YYYYMMDDTHHmmss[Z]')
 }


### PR DESCRIPTION
resolves #748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recurring event end-dates now respect the event's local timezone and are set to the end of the day before conversion, ensuring accurate recurrence timing for both all-day and timed events.
* **Tests**
  * Updated recurrence rule tests to reflect the corrected end-date serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->