### PR TITLE
#920 add copy button next to the join in event preview

### DIFF
--- a/src/components/Event/components/VideoLink.tsx
+++ b/src/components/Event/components/VideoLink.tsx
@@ -1,0 +1,82 @@
+import { Box, Button, IconButton, Link } from '@linagora/twake-mui'
+import { useState } from 'react'
+import { useI18n } from 'twake-i18n'
+import { SnackbarAlert } from '@/components/Loading/SnackBarAlert'
+import { ContentCopy as CopyIcon } from '@mui/icons-material'
+import Tooltip from '@/components/Tooltip'
+
+const sanitizeMeetingLink = (raw: string | null): string | null => {
+  if (!raw) return null
+  try {
+    const parsed = new URL(raw)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+export const VideoLink: React.FC<{
+  meetingLink: string | null
+  icon?: React.ReactNode
+  label?: string
+}> = ({ meetingLink, icon, label }) => {
+  const { t } = useI18n()
+  const [openToast, setOpenToast] = useState(false)
+
+  const safeMeetingLink = sanitizeMeetingLink(meetingLink)
+
+  const handleCopyMeetingLink = async (): Promise<void> => {
+    if (!safeMeetingLink) return
+    try {
+      await navigator.clipboard.writeText(safeMeetingLink)
+      setOpenToast(true)
+    } catch (err) {
+      console.error('Failed to copy link:', err)
+    }
+  }
+
+  if (!safeMeetingLink) {
+    return null
+  }
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Link
+          href={safeMeetingLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{ textDecoration: 'none' }}
+        >
+          <Button
+            startIcon={icon}
+            variant="contained"
+            size="medium"
+            sx={{ borderRadius: '4px' }}
+          >
+            {label || t('eventPreview.joinVideo')}
+          </Button>
+        </Link>
+        <Tooltip title={t('event.form.copyMeetingLink')}>
+          <IconButton
+            onClick={() => void handleCopyMeetingLink()}
+            size="small"
+            sx={{ color: 'primary.main' }}
+            aria-label={t('event.form.copyMeetingLink')}
+            title={t('event.form.copyMeetingLink')}
+          >
+            <CopyIcon />
+          </IconButton>
+        </Tooltip>
+      </Box>
+
+      <SnackbarAlert
+        setOpen={setOpenToast}
+        open={openToast}
+        message={t('event.form.meetCopied')}
+      />
+    </>
+  )
+}

--- a/src/components/Event/fields/VideoConferenceField.tsx
+++ b/src/components/Event/fields/VideoConferenceField.tsx
@@ -4,17 +4,15 @@ import {
   generateMeetingLink,
   removeVideoConferenceFromDescription
 } from '@/utils/videoConferenceUtils'
-import { Box, Button, IconButton, Tooltip } from '@linagora/twake-mui'
-import {
-  Close as DeleteIcon,
-  ContentCopy as CopyIcon
-} from '@mui/icons-material'
+import { Box, Button, IconButton } from '@linagora/twake-mui'
+import { Close as DeleteIcon } from '@mui/icons-material'
 import React from 'react'
 import { useI18n } from 'twake-i18n'
-import { SnackbarAlert } from '../../Loading/SnackBarAlert'
 import { FieldWithLabel } from '../components/FieldWithLabel'
 import { SectionPreviewRow } from '../components/SectionPreviewRow'
 import { useScreenSizeDetection } from '@/useScreenSizeDetection'
+import { VideoLink } from '../components/VideoLink'
+import Tooltip from '@/components/Tooltip'
 
 export interface VideoConferenceFieldProps {
   hasVideoConference: boolean
@@ -32,14 +30,12 @@ const VideoConferenceFieldInShortMode: React.FC<{
   hasVideoConference: boolean
   meetingLink: string | null
   cameraIcon: React.ReactNode
-  handleCopyMeetingLink: () => Promise<void>
   handleDeleteVideoConference: () => void
   handleAddVideoConference: () => void
 }> = ({
   hasVideoConference,
   meetingLink,
   cameraIcon,
-  handleCopyMeetingLink,
   handleDeleteVideoConference,
   handleAddVideoConference
 }) => {
@@ -48,29 +44,11 @@ const VideoConferenceFieldInShortMode: React.FC<{
   if (hasVideoConference && meetingLink) {
     return (
       <Box display="flex" gap={1} alignItems="center">
-        <Button
-          startIcon={cameraIcon}
-          onClick={() =>
-            window.open(meetingLink, '_blank', 'noopener,noreferrer')
-          }
-          size="medium"
-          variant="contained"
-          color="primary"
-          sx={{ borderRadius: '4px', mr: 1 }}
-        >
-          {t('event.form.joinVisioConference')}
-        </Button>
-        <Tooltip title={t('event.form.copyMeetingLink')}>
-          <IconButton
-            onClick={() => void handleCopyMeetingLink()}
-            size="small"
-            sx={{ color: 'primary.main' }}
-            aria-label={t('event.form.copyMeetingLink')}
-            title={t('event.form.copyMeetingLink')}
-          >
-            <CopyIcon />
-          </IconButton>
-        </Tooltip>
+        <VideoLink
+          meetingLink={meetingLink}
+          icon={cameraIcon}
+          label={t('event.form.joinVisioConference')}
+        />
         <Tooltip title={t('event.form.removeVideoConference')}>
           <IconButton
             onClick={handleDeleteVideoConference}
@@ -97,14 +75,12 @@ const VideoConferenceFieldInExpandedMode: React.FC<{
   hasVideoConference: boolean
   meetingLink: string | null
   cameraIcon: React.ReactNode
-  handleCopyMeetingLink: () => Promise<void>
   handleDeleteVideoConference: () => void
   handleAddVideoConference: () => void
 }> = ({
   hasVideoConference,
   meetingLink,
   cameraIcon,
-  handleCopyMeetingLink,
   handleDeleteVideoConference,
   handleAddVideoConference
 }) => {
@@ -128,29 +104,11 @@ const VideoConferenceFieldInExpandedMode: React.FC<{
 
       {hasVideoConference && meetingLink && (
         <>
-          <Button
-            startIcon={cameraIcon}
-            onClick={() =>
-              window.open(meetingLink, '_blank', 'noopener,noreferrer')
-            }
-            size="medium"
-            variant="contained"
-            color="primary"
-            sx={{ borderRadius: '4px', mr: 1 }}
-          >
-            {t('event.form.joinVisioConference')}
-          </Button>
-          <Tooltip title={t('event.form.copyMeetingLink')}>
-            <IconButton
-              onClick={() => void handleCopyMeetingLink()}
-              size="small"
-              sx={{ color: 'primary.main' }}
-              aria-label={t('event.form.copyMeetingLink')}
-              title={t('event.form.copyMeetingLink')}
-            >
-              <CopyIcon />
-            </IconButton>
-          </Tooltip>
+          <VideoLink
+            meetingLink={meetingLink}
+            icon={cameraIcon}
+            label={t('event.form.joinVisioConference')}
+          />
           <Tooltip title={t('event.form.removeVideoConference')}>
             <IconButton
               onClick={handleDeleteVideoConference}
@@ -181,8 +139,6 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
-  const [openToast, setOpenToast] = React.useState(false)
-
   const handleAddVideoConference = (): void => {
     const newMeetingLink = generateMeetingLink()
     const updatedDescription = addVideoConferenceToDescription(
@@ -194,16 +150,6 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
     setMeetingLink(newMeetingLink)
     if (showMore) {
       setShowDescription?.(true)
-    }
-  }
-
-  const handleCopyMeetingLink = async (): Promise<void> => {
-    if (!meetingLink) return
-    try {
-      await navigator.clipboard.writeText(meetingLink)
-      setOpenToast(true)
-    } catch (err) {
-      console.error('Failed to copy link:', err)
     }
   }
 
@@ -228,7 +174,6 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
             hasVideoConference={hasVideoConference}
             meetingLink={meetingLink}
             cameraIcon={cameraIcon}
-            handleCopyMeetingLink={handleCopyMeetingLink}
             handleDeleteVideoConference={handleDeleteVideoConference}
             handleAddVideoConference={handleAddVideoConference}
           />
@@ -237,18 +182,11 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
             hasVideoConference={hasVideoConference}
             meetingLink={meetingLink}
             cameraIcon={cameraIcon}
-            handleCopyMeetingLink={handleCopyMeetingLink}
             handleDeleteVideoConference={handleDeleteVideoConference}
             handleAddVideoConference={handleAddVideoConference}
           />
         )}
       </FieldWithLabel>
-
-      <SnackbarAlert
-        setOpen={setOpenToast}
-        open={openToast}
-        message={t('event.form.meetCopied')}
-      />
     </>
   )
 }

--- a/src/components/Event/hooks/useFilterEventAttendees.ts
+++ b/src/components/Event/hooks/useFilterEventAttendees.ts
@@ -1,0 +1,71 @@
+import { CalendarEvent } from '@/features/Events/EventsTypes'
+import { userAttendee } from '@/features/User/models/attendee'
+import { useMemo } from 'react'
+
+const isResourceAttendee = (attendee: userAttendee): boolean =>
+  attendee.cutype === 'RESOURCE'
+
+const isEventOfResource = (
+  attendee: userAttendee,
+  calendarName?: string,
+  isResourceEventPreview?: boolean
+): boolean =>
+  (isResourceEventPreview && calendarName !== attendee.cn) ||
+  !isResourceEventPreview
+
+export const useFilterEventAttendees = ({
+  event,
+  isResourceEventPreview,
+  calendarName
+}: {
+  event: CalendarEvent
+  isResourceEventPreview?: boolean
+  calendarName?: string
+}): {
+  resources: userAttendee[]
+  eventAttendees: userAttendee[]
+  attendees: userAttendee[]
+  organizer: userAttendee
+} => {
+  const rawAttendees = useMemo(() => event.attendee ?? [], [event.attendee])
+
+  const resources = useMemo(
+    () =>
+      rawAttendees.filter(
+        attendee =>
+          isResourceAttendee(attendee) &&
+          isEventOfResource(attendee, calendarName, isResourceEventPreview)
+      ),
+    [calendarName, rawAttendees, isResourceEventPreview]
+  )
+
+  const eventAttendees = useMemo(
+    () => rawAttendees.filter(attendee => !isResourceAttendee(attendee)),
+    [rawAttendees]
+  )
+
+  const attendees = useMemo(
+    () =>
+      eventAttendees.filter(
+        a => a.cal_address !== event.organizer?.cal_address
+      ) || [],
+    [eventAttendees, event.organizer?.cal_address]
+  )
+
+  const organizer = useMemo(
+    () =>
+      eventAttendees.find(
+        a => a.cal_address === event.organizer?.cal_address
+      ) ||
+      ({
+        ...event.organizer,
+        partstat: 'ACCEPTED',
+        role: 'CHAIR',
+        cutype: 'INDIVIDUAL',
+        rsvp: 'FALSE'
+      } as userAttendee),
+    [eventAttendees, event.organizer]
+  )
+
+  return { resources, eventAttendees, attendees, organizer }
+}

--- a/src/features/Events/EventPreview/EventPreviewDetails.tsx
+++ b/src/features/Events/EventPreview/EventPreviewDetails.tsx
@@ -1,5 +1,5 @@
 import { InfoRow } from '@/components/Event/InfoRow'
-import { Box, Button, Link, Typography } from '@linagora/twake-mui'
+import { Box, Typography } from '@linagora/twake-mui'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined'
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined'
@@ -8,13 +8,13 @@ import RepeatIcon from '@mui/icons-material/Repeat'
 import SubjectIcon from '@mui/icons-material/Subject'
 import VideocamOutlinedIcon from '@mui/icons-material/VideocamOutlined'
 import { alpha, useTheme } from '@mui/material/styles'
-import { useMemo } from 'react'
 import { useI18n } from 'twake-i18n'
 import { CalendarEvent } from '../EventsTypes'
 import { EventPreviewAttendees } from './EventPreviewAttendees'
 import { makeRecurrenceString } from './utils/makeRecurrenceString'
 import { renderAttendeeBadge } from '@/components/Event/utils/eventUtils'
-import { userAttendee } from '@/features/User/models/attendee'
+import { VideoLink } from '@/components/Event/components/VideoLink'
+import { useFilterEventAttendees } from '@/components/Event/hooks/useFilterEventAttendees'
 
 interface EventPreviewDetailsProps {
   event: CalendarEvent
@@ -24,15 +24,16 @@ interface EventPreviewDetailsProps {
   calendarName?: string
 }
 
-export function EventPreviewDetails({
+export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
   event,
   isOwn,
   isNotPrivate,
   isResourceEventPreview,
   calendarName
-}: EventPreviewDetailsProps) {
+}) => {
   const { t } = useI18n()
   const theme = useTheme()
+
   const infoIconColor = alpha(theme.palette.grey[900], 0.9)
   const infoIconSx = {
     minWidth: '25px',
@@ -43,40 +44,17 @@ export function EventPreviewDetails({
     alignSelf: 'center'
   }
 
-  const resources = useMemo(
-    () =>
-      event?.attendee?.filter(
-        attendee =>
-          attendee.cutype === 'RESOURCE' &&
-          ((isResourceEventPreview && calendarName !== attendee.cn) ||
-            !isResourceEventPreview)
-      ),
-    [calendarName, event?.attendee, isResourceEventPreview]
-  )
-  const eventAttendees = useMemo(
-    () =>
-      event?.attendee?.filter(attendee => attendee.cutype !== 'RESOURCE') ?? [],
-    [event?.attendee]
-  )
-
-  const attendees =
-    eventAttendees?.filter(
-      a => a.cal_address !== event.organizer?.cal_address
-    ) || []
-  const organizer =
-    eventAttendees?.find(a => a.cal_address === event.organizer?.cal_address) ||
-    ({
-      ...event.organizer,
-      partstat: 'ACCEPTED',
-      role: 'CHAIR',
-      cutype: 'INDIVIDUAL',
-      rsvp: 'FALSE'
-    } as userAttendee)
+  const { resources, eventAttendees, attendees, organizer } =
+    useFilterEventAttendees({
+      event,
+      isResourceEventPreview,
+      calendarName
+    })
 
   const showDetails = isNotPrivate || isOwn
 
   const shouldShowAttendeesSection =
-    attendees.length > 0 || Boolean(organizer?.cal_address || organizer?.cn)
+    attendees.length > 0 || Boolean(organizer.cal_address || organizer?.cn)
 
   if (!showDetails) {
     return (
@@ -119,22 +97,7 @@ export function EventPreviewDetails({
               <VideocamOutlinedIcon />
             </Box>
           }
-          content={
-            <Link
-              href={event.x_openpass_videoconference}
-              target="_blank"
-              rel="noopener noreferrer"
-              sx={{ textDecoration: 'none' }}
-            >
-              <Button
-                variant="contained"
-                size="medium"
-                sx={{ borderRadius: '4px' }}
-              >
-                {t('eventPreview.joinVideo')}
-              </Button>
-            </Link>
-          }
+          content={<VideoLink meetingLink={event.x_openpass_videoconference} />}
         />
       )}
 


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/920

Add a copy button next to `Join the video conference` in event preview, like in create/update modal.

<img width="331" height="68" alt="image" src="https://github.com/user-attachments/assets/46ba3930-be97-46bc-a068-4ce2f4172332" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Join video" button with copy-to-clipboard functionality for meeting links, complete with confirmation feedback

* **Refactor**
  * Refactored video conference field UI and event details components for improved structure
  * Enhanced attendee and resource filtering logic for better data organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->