### PR TITLE
#914 unify style of tooltip

### DIFF
--- a/src/components/Calendar/MiniCalendar.tsx
+++ b/src/components/Calendar/MiniCalendar.tsx
@@ -7,29 +7,103 @@ import { DateCalendar } from '@mui/x-date-pickers'
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import moment from 'moment'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, forwardRef } from 'react'
 import { useI18n } from 'twake-i18n'
 import { CALENDAR_VIEWS } from './utils/constants'
+import { IconButton, SxProps } from '@linagora/twake-mui'
+import Tooltip from '../Tooltip'
+import {
+  PickerSelectionState,
+  PickerValue
+} from '@mui/x-date-pickers/internals'
 
-export function MiniCalendar({
-  calendarRef,
-  selectedDate,
-  setSelectedMiniDate
-}: {
+const NextIconButton = forwardRef<
+  HTMLButtonElement,
+  { sx?: SxProps; [key: string]: unknown }
+>((props, ref) => {
+  const { t } = useI18n()
+  const { sx: propSx, ...rest } = props
+  return (
+    <Tooltip title={t('tooltip.nextMonth')}>
+      <IconButton
+        {...rest}
+        ref={ref}
+        title=""
+        sx={{
+          ...(propSx as SxProps),
+          '&::after': {
+            display: 'none !important',
+            content: '"none !important"'
+          },
+          '&::before': {
+            display: 'none !important',
+            content: '"none !important"'
+          }
+        }}
+      />
+    </Tooltip>
+  )
+})
+NextIconButton.displayName = 'NextIconButton'
+
+const PreviousIconButton = forwardRef<
+  HTMLButtonElement,
+  { sx?: SxProps; [key: string]: unknown }
+>((props, ref) => {
+  const { t } = useI18n()
+  const { sx: propSx, ...rest } = props
+  return (
+    <Tooltip title={t('tooltip.previousMonth')}>
+      <IconButton
+        {...rest}
+        ref={ref}
+        title=""
+        sx={{
+          ...(propSx as SxProps),
+          '&::after': {
+            display: 'none !important',
+            content: '"none !important"'
+          },
+          '&::before': {
+            display: 'none !important',
+            content: '"none !important"'
+          }
+        }}
+      />
+    </Tooltip>
+  )
+})
+PreviousIconButton.displayName = 'PreviousIconButton'
+
+export const MiniCalendar: React.FC<{
   calendarRef: React.MutableRefObject<CalendarApi | null>
   selectedDate: Date
   setSelectedMiniDate: (d: Date) => void
-}) {
+}> = ({ calendarRef, selectedDate, setSelectedMiniDate }) => {
   const dispatch = useAppDispatch()
   const [visibleDate, setVisibleDate] = useState(selectedDate)
   const { t } = useI18n()
 
   useEffect(() => {
-    const handleVisibleDateChange = () => {
+    const handleVisibleDateChange = (): void => {
       setVisibleDate(selectedDate)
     }
     handleVisibleDateChange()
   }, [selectedDate])
+
+  const handleChange = (
+    dateMoment: PickerValue,
+    selectionState?: PickerSelectionState
+  ): void => {
+    if (!dateMoment) return
+    const date = dateMoment.toDate()
+    if (selectionState === 'finish') {
+      dispatch(setView('calendar'))
+      setSelectedMiniDate(date)
+      calendarRef.current?.gotoDate(date)
+    }
+  }
+
   return (
     <LocalizationProvider
       dateAdapter={AdapterMoment}
@@ -37,22 +111,16 @@ export function MiniCalendar({
     >
       <DateCalendar
         value={moment(visibleDate)}
-        onChange={async (dateMoment, selectionState) => {
-          if (!dateMoment) return
-          const date = dateMoment.toDate()
-          if (selectionState === 'finish') {
-            await dispatch(setView('calendar'))
-            setSelectedMiniDate(date)
-            calendarRef.current?.gotoDate(date)
-          }
-        }}
+        onChange={handleChange}
         showDaysOutsideCurrentMonth
         onMonthChange={month => {
           setVisibleDate(month.toDate())
         }}
         views={['month', 'day']}
         slots={{
-          switchViewIcon: KeyboardArrowDownIcon
+          switchViewIcon: KeyboardArrowDownIcon,
+          nextIconButton: NextIconButton,
+          previousIconButton: PreviousIconButton
         }}
         sx={{
           width: '100%',
@@ -77,7 +145,7 @@ export function MiniCalendar({
             const isInSelectedWeek =
               calendarRef.current?.view.type === CALENDAR_VIEWS.timeGridWeek ||
               calendarRef.current?.view.type === undefined
-                ? (() => {
+                ? ((): boolean => {
                     const startOfWeek = computeStartOfTheWeek(selected)
                     const endOfWeek = new Date(startOfWeek)
                     endOfWeek.setDate(startOfWeek.getDate() + 6)

--- a/src/components/Calendar/Sidebar/UtilButtons.tsx
+++ b/src/components/Calendar/Sidebar/UtilButtons.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Box } from '@linagora/twake-mui'
+import { IconButton, Box, Tooltip } from '@linagora/twake-mui'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { useI18n } from 'twake-i18n'
 import { AppListMenu } from '@/components/Menubar/AppListMenu'
@@ -25,17 +25,19 @@ export const UtilButtons: React.FC<{ isIframe?: boolean }> = ({ isIframe }) => {
   return (
     <Box display="flex" alignItems="center">
       {supportLink && (
-        <IconButton
-          component="a"
-          href={supportLink}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ marginRight: 4 }}
-          aria-label={t('menubar.help')}
-          title={t('menubar.help')}
-        >
-          <HelpOutlineIcon fontSize="small" />
-        </IconButton>
+        <Tooltip title={t('menubar.help')}>
+          <IconButton
+            component="a"
+            href={supportLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ marginRight: 4 }}
+            aria-label={t('menubar.help')}
+            title={t('menubar.help')}
+          >
+            <HelpOutlineIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
       )}
 
       <AppListMenu

--- a/src/components/Event/fields/VideoConferenceField.tsx
+++ b/src/components/Event/fields/VideoConferenceField.tsx
@@ -4,7 +4,7 @@ import {
   generateMeetingLink,
   removeVideoConferenceFromDescription
 } from '@/utils/videoConferenceUtils'
-import { Box, Button, IconButton } from '@linagora/twake-mui'
+import { Box, Button, IconButton, Tooltip } from '@linagora/twake-mui'
 import {
   Close as DeleteIcon,
   ContentCopy as CopyIcon
@@ -60,24 +60,28 @@ const VideoConferenceFieldInShortMode: React.FC<{
         >
           {t('event.form.joinVisioConference')}
         </Button>
-        <IconButton
-          onClick={() => void handleCopyMeetingLink()}
-          size="small"
-          sx={{ color: 'primary.main' }}
-          aria-label={t('event.form.copyMeetingLink')}
-          title={t('event.form.copyMeetingLink')}
-        >
-          <CopyIcon />
-        </IconButton>
-        <IconButton
-          onClick={handleDeleteVideoConference}
-          size="small"
-          sx={{ color: 'error.main' }}
-          aria-label={t('event.form.removeVideoConference')}
-          title={t('event.form.removeVideoConference')}
-        >
-          <DeleteIcon />
-        </IconButton>
+        <Tooltip title={t('event.form.copyMeetingLink')}>
+          <IconButton
+            onClick={() => void handleCopyMeetingLink()}
+            size="small"
+            sx={{ color: 'primary.main' }}
+            aria-label={t('event.form.copyMeetingLink')}
+            title={t('event.form.copyMeetingLink')}
+          >
+            <CopyIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={t('event.form.removeVideoConference')}>
+          <IconButton
+            onClick={handleDeleteVideoConference}
+            size="small"
+            sx={{ color: 'error.main' }}
+            aria-label={t('event.form.removeVideoConference')}
+            title={t('event.form.removeVideoConference')}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Tooltip>
       </Box>
     )
   }
@@ -136,24 +140,28 @@ const VideoConferenceFieldInExpandedMode: React.FC<{
           >
             {t('event.form.joinVisioConference')}
           </Button>
-          <IconButton
-            onClick={() => void handleCopyMeetingLink()}
-            size="small"
-            sx={{ color: 'primary.main' }}
-            aria-label={t('event.form.copyMeetingLink')}
-            title={t('event.form.copyMeetingLink')}
-          >
-            <CopyIcon />
-          </IconButton>
-          <IconButton
-            onClick={handleDeleteVideoConference}
-            size="small"
-            sx={{ color: 'error.main' }}
-            aria-label={t('event.form.removeVideoConference')}
-            title={t('event.form.removeVideoConference')}
-          >
-            <DeleteIcon />
-          </IconButton>
+          <Tooltip title={t('event.form.copyMeetingLink')}>
+            <IconButton
+              onClick={() => void handleCopyMeetingLink()}
+              size="small"
+              sx={{ color: 'primary.main' }}
+              aria-label={t('event.form.copyMeetingLink')}
+              title={t('event.form.copyMeetingLink')}
+            >
+              <CopyIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={t('event.form.removeVideoConference')}>
+            <IconButton
+              onClick={handleDeleteVideoConference}
+              size="small"
+              sx={{ color: 'error.main' }}
+              aria-label={t('event.form.removeVideoConference')}
+              title={t('event.form.removeVideoConference')}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Tooltip>
         </>
       )}
     </Box>

--- a/src/components/Menubar/AppListMenu.tsx
+++ b/src/components/Menubar/AppListMenu.tsx
@@ -3,6 +3,7 @@ import { Dialog, IconButton, Popover } from '@linagora/twake-mui'
 import WidgetsOutlinedIcon from '@mui/icons-material/WidgetsOutlined'
 import { useI18n } from 'twake-i18n'
 import { AppIcon, AppIconProps } from './AppIcon'
+import Tooltip from '../Tooltip'
 
 const sharedPaperSx = {
   minWidth: 230,
@@ -65,14 +66,16 @@ export const AppListMenu: React.FC<{
 
   return (
     <>
-      <IconButton
-        onClick={onAppMenuOpen}
-        style={{ marginRight: 8 }}
-        aria-label={t('menubar.apps')}
-        title={t('menubar.apps')}
-      >
-        <WidgetsOutlinedIcon fontSize={iconSize} />
-      </IconButton>
+      <Tooltip title={t('menubar.apps')}>
+        <IconButton
+          onClick={onAppMenuOpen}
+          style={{ marginRight: 8 }}
+          aria-label={t('menubar.apps')}
+          title={t('menubar.apps')}
+        >
+          <WidgetsOutlinedIcon fontSize={iconSize} />
+        </IconButton>
+      </Tooltip>
       <AppListPopup
         anchorEl={anchorEl}
         onAppMenuClose={onAppMenuClose}

--- a/src/components/Menubar/DesktopMenubar.tsx
+++ b/src/components/Menubar/DesktopMenubar.tsx
@@ -98,17 +98,19 @@ export const DesktopMenubar: React.FC<SharedMenubarProps> = ({
           <>
             {supportLink && (
               <div className="menu-items">
-                <IconButton
-                  component="a"
-                  href={supportLink}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ marginRight: 8 }}
-                  aria-label={t('menubar.help')}
-                  title={t('menubar.help')}
-                >
-                  <HelpOutlineIcon />
-                </IconButton>
+                <Tooltip title={t('menubar.help')}>
+                  <IconButton
+                    component="a"
+                    href={supportLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ marginRight: 8 }}
+                    aria-label={t('menubar.help')}
+                    title={t('menubar.help')}
+                  >
+                    <HelpOutlineIcon />
+                  </IconButton>
+                </Tooltip>
               </div>
             )}
 

--- a/src/components/Menubar/MobileMenuBar.tsx
+++ b/src/components/Menubar/MobileMenuBar.tsx
@@ -15,6 +15,7 @@ import { DatePickerMobile } from './components/DatePickerMobile'
 import { SmallNavigationControls } from './components/SmallNavigationControls'
 import './Menubar.styl'
 import MobileSearchBar from './MobileEventSearchBar'
+import { Tooltip } from '../Tooltip'
 
 export interface MobileMenubarProps {
   calendarRef: React.RefObject<CalendarApi | null>
@@ -82,6 +83,10 @@ export const MobileMenubar: React.FC<MobileMenubarProps> = ({
     )
   }
 
+  const toggleDatePickerTitle = openDatePicker
+    ? t('menubar.hideDatePicker')
+    : t('menubar.showDatePicker')
+
   return (
     <>
       <header className="menubar menubar--mobile">
@@ -120,27 +125,21 @@ export const MobileMenubar: React.FC<MobileMenubarProps> = ({
                   >
                     {dateLabel}
                   </Typography>
-                  <IconButton
-                    size="small"
-                    onClick={onToggleDatePicker}
-                    aria-label={
-                      openDatePicker
-                        ? t('menubar.hideDatePicker')
-                        : t('menubar.showDatePicker')
-                    }
-                    title={
-                      openDatePicker
-                        ? t('menubar.hideDatePicker')
-                        : t('menubar.showDatePicker')
-                    }
-                    aria-expanded={openDatePicker}
-                  >
-                    {openDatePicker ? (
-                      <ArrowDropUpIcon />
-                    ) : (
-                      <ArrowDropDownIcon />
-                    )}
-                  </IconButton>
+                  <Tooltip title={toggleDatePickerTitle}>
+                    <IconButton
+                      size="small"
+                      onClick={onToggleDatePicker}
+                      aria-label={toggleDatePickerTitle}
+                      title={toggleDatePickerTitle}
+                      aria-expanded={openDatePicker}
+                    >
+                      {openDatePicker ? (
+                        <ArrowDropUpIcon />
+                      ) : (
+                        <ArrowDropDownIcon />
+                      )}
+                    </IconButton>
+                  </Tooltip>
                 </Stack>
               </div>
             </div>

--- a/src/components/Menubar/TabletMenubar.tsx
+++ b/src/components/Menubar/TabletMenubar.tsx
@@ -13,6 +13,7 @@ import { MainTitle } from './MainTitle'
 import { SharedMenubarProps } from './Menubar'
 import MobileSearchBar from './MobileEventSearchBar'
 import { UserMenu } from './UserMenu'
+import Tooltip from '../Tooltip'
 
 export const TabletMenubar: React.FC<SharedMenubarProps> = ({
   calendarRef,
@@ -63,13 +64,15 @@ export const TabletMenubar: React.FC<SharedMenubarProps> = ({
   return (
     <header className="menubar">
       <div className="left-menu">
-        <IconButton
-          onClick={onToggleSidebar}
-          aria-label={t('menubar.toggleSidebar')}
-          title={t('menubar.toggleSidebar')}
-        >
-          <MenuIcon />
-        </IconButton>
+        <Tooltip title={t('menubar.toggleSidebar')}>
+          <IconButton
+            onClick={onToggleSidebar}
+            aria-label={t('menubar.toggleSidebar')}
+            title={t('menubar.toggleSidebar')}
+          >
+            <MenuIcon />
+          </IconButton>
+        </Tooltip>
 
         {!isIframe && (
           <div className="menu-items">

--- a/src/components/Menubar/UserMenu.tsx
+++ b/src/components/Menubar/UserMenu.tsx
@@ -18,6 +18,7 @@ import LogoutIcon from '@mui/icons-material/Logout'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import { MouseEvent } from 'react'
 import { useI18n } from 'twake-i18n'
+import { Tooltip } from '../Tooltip'
 
 export type UserMenuProps = {
   anchorEl: HTMLElement | null
@@ -168,19 +169,26 @@ export function UserMenu({
 
   return (
     <>
-      <IconButton
-        onClick={!isIframe ? onUserMenuOpen : onSettingsClick}
-        aria-label={isIframe ? t('menubar.settings') : t('menubar.userProfile')}
+      <Tooltip
         title={isIframe ? t('menubar.settings') : t('menubar.userProfile')}
       >
-        {!isIframe ? (
-          <Avatar color={stringToGradient(displayName)} size={size}>
-            {getInitials(displayName)}
-          </Avatar>
-        ) : (
-          <SettingsOutlinedIcon />
-        )}
-      </IconButton>
+        <IconButton
+          onClick={!isIframe ? onUserMenuOpen : onSettingsClick}
+          aria-label={
+            isIframe ? t('menubar.settings') : t('menubar.userProfile')
+          }
+          title={isIframe ? t('menubar.settings') : t('menubar.userProfile')}
+        >
+          {!isIframe ? (
+            <Avatar color={stringToGradient(displayName)} size={size}>
+              {getInitials(displayName)}
+            </Avatar>
+          ) : (
+            <SettingsOutlinedIcon />
+          )}
+        </IconButton>
+      </Tooltip>
+
       <UserMenuPopup
         anchorEl={anchorEl}
         onClose={onClose}

--- a/src/components/Menubar/components/NavigationControls.tsx
+++ b/src/components/Menubar/components/NavigationControls.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@/components/Tooltip'
 import { Button, ButtonGroup } from '@linagora/twake-mui'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
@@ -17,25 +18,31 @@ export const NavigationControls: React.FC<{
           '& button:last-of-type': { borderRadius: '0 12px 12px 0' }
         }}
       >
-        <Button
-          sx={{ width: 20 }}
-          onClick={() => onNavigate('prev')}
-          aria-label={t('menubar.prev')}
-          title={t('menubar.prev')}
-        >
-          <ChevronLeftIcon sx={{ height: 20 }} />
-        </Button>
-        <Button onClick={() => onNavigate('today')}>
-          {t('menubar.today')}
-        </Button>
-        <Button
-          sx={{ width: 20 }}
-          onClick={() => onNavigate('next')}
-          aria-label={t('menubar.next')}
-          title={t('menubar.next')}
-        >
-          <ChevronRightIcon sx={{ height: 20 }} />
-        </Button>
+        <Tooltip title={t('menubar.prev')}>
+          <Button
+            sx={{ width: 20 }}
+            onClick={() => onNavigate('prev')}
+            aria-label={t('menubar.prev')}
+            title={t('menubar.prev')}
+          >
+            <ChevronLeftIcon sx={{ height: 20 }} />
+          </Button>
+        </Tooltip>
+        <Tooltip title={t('menubar.today')}>
+          <Button onClick={() => onNavigate('today')}>
+            {t('menubar.today')}
+          </Button>
+        </Tooltip>
+        <Tooltip title={t('menubar.next')}>
+          <Button
+            sx={{ width: 20 }}
+            onClick={() => onNavigate('next')}
+            aria-label={t('menubar.next')}
+            title={t('menubar.next')}
+          >
+            <ChevronRightIcon sx={{ height: 20 }} />
+          </Button>
+        </Tooltip>
       </ButtonGroup>
     </div>
   )

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -449,6 +449,8 @@
     "registerOtherCalendars": "Register calendars",
     "registerResources": "Register resources",
     "collapse": "Collapse",
-    "expand": "Expand"
+    "expand": "Expand",
+    "nextMonth": "Next month",
+    "previousMonth": "Previous month"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -450,6 +450,8 @@
     "registerOtherCalendars": "Enregistrer des calendriers",
     "registerResources": "Enregistrer des ressources",
     "collapse": "Réduire",
-    "expand": "Développer"
+    "expand": "Développer",
+    "nextMonth": "Mois suivant",
+    "previousMonth": "Mois précédent"
   }
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -450,6 +450,8 @@
     "registerOtherCalendars": "Зарегистрировать календари",
     "registerResources": "Зарегистрировать ресурсы",
     "collapse": "Свернуть",
-    "expand": "Развернуть"
+    "expand": "Развернуть",
+    "nextMonth": "Следующий месяц",
+    "previousMonth": "Предыдущий месяц"
   }
 }

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -448,6 +448,8 @@
     "registerOtherCalendars": "Đăng ký lịch",
     "registerResources": "Đăng ký tài nguyên",
     "collapse": "Thu gọn",
-    "expand": "Mở rộng"
+    "expand": "Mở rộng",
+    "nextMonth": "Tháng sau",
+    "previousMonth": "Tháng trước"
   }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added localized tooltips to many icon buttons (navigation, video conference actions, help, apps, user/settings, sidebar toggle, date-picker toggle) to improve discoverability and accessibility.
  * Improved mini-calendar navigation with custom prev/next controls and streamlined date selection behavior.
* **Documentation**
  * Added locale entries for previous/next month tooltip text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->