### PR TITLE
#921 elipse description in event chip

### DIFF
--- a/src/components/Event/EventChip/EventChip.tsx
+++ b/src/components/Event/EventChip/EventChip.tsx
@@ -223,7 +223,7 @@ export const EventChip: React.FC<EventChipProps> = ({
                     fontFamily: 'Roboto',
                     fontWeight: '500',
                     fontStyle: 'Medium',
-                    fontSize: '12px',
+                    fontSize: '10px',
                     lineHeight: '16px',
                     letterSpacing: '0%',
                     verticalAlign: 'middle',
@@ -236,7 +236,7 @@ export const EventChip: React.FC<EventChipProps> = ({
                   {event._def.extendedProps.location}
                 </Typography>
               )}
-              <Box sx={{ display: 'flex', alignItems: 'flex-start', mt: 0.5 }}>
+              <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
                 {event._def.extendedProps.description && (
                   <Typography
                     sx={{
@@ -249,11 +249,10 @@ export const EventChip: React.FC<EventChipProps> = ({
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',
                       display: '-webkit-box',
-                      WebkitLineClamp: 2,
                       WebkitBoxOrient: 'vertical',
-                      whiteSpace: 'normal',
+                      whiteSpace: 'nowrap',
                       flex: 1,
-                      maxWidth: '75%',
+                      maxWidth: '100%',
                       color: titleStyle.color
                     }}
                   >


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/921

In event chip, the description only displays in 1 line and will be elipsed if too long.

<img width="168" height="90" alt="image" src="https://github.com/user-attachments/assets/e4fd2638-6fdb-4a33-b914-e89846379f04" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined styling of event information display within the EventChip component.
  * Adjusted location text font sizing for improved visual balance.
  * Enhanced description section layout with improved text wrapping and width constraints for better readability and content presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->