### PR TITLE
#200 unify font family

### DIFF
--- a/src/App.styl
+++ b/src/App.styl
@@ -1,6 +1,5 @@
 .App
   text-align center
-  font-family "Roboto"
   height 100vh
 
   &--mobile

--- a/src/components/Calendar/Calendar.styl
+++ b/src/components/Calendar/Calendar.styl
@@ -85,7 +85,6 @@
   flex-direction column
   align-items center
   padding 0.5rem 0
-  font-family "Inter", sans-serif
   gap 6px
   &--mobile
     flex-direction column-reverse !important
@@ -100,7 +99,6 @@
   display flex
   flex-direction column
   gap 30px
-  font-family "Segoe UI", Tahoma, Geneva, Verdana, sans-serif
 
 /* sidebar header */
 .sidebar-calendar h2

--- a/src/components/Calendar/CalendarName.tsx
+++ b/src/components/Calendar/CalendarName.tsx
@@ -9,7 +9,9 @@ import { useI18n } from 'twake-i18n'
 import { OwnerCaption } from './OwnerCaption'
 import { ResourceIcon } from '../Attendees/ResourceIcon'
 
-export function CalendarName({ calendar }: { calendar: Calendar }) {
+export const CalendarName: React.FC<{ calendar: Calendar }> = ({
+  calendar
+}) => {
   const userData = useAppSelector(state => state.user.userData)
   const { t } = useI18n()
 
@@ -45,7 +47,7 @@ export function CalendarName({ calendar }: { calendar: Calendar }) {
         />
       )}
       <Box style={{ display: 'flex', flexDirection: 'column' }}>
-        <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+        <Typography variant="body2" sx={{ overflowWrap: 'break-word' }}>
           {renameDefault(calendar.name, ownerDisplayName, t, isOwnCalendar)}
         </Typography>
         <OwnerCaption

--- a/src/components/Calendar/CalendarSelection.tsx
+++ b/src/components/Calendar/CalendarSelection.tsx
@@ -17,7 +17,8 @@ import {
   AccordionSummary,
   Checkbox,
   IconButton,
-  ListItem
+  ListItem,
+  Typography
 } from '@linagora/twake-mui'
 import AddIcon from '@mui/icons-material/Add'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -105,7 +106,7 @@ const CalendarAccordion: React.FC<{
           }
         }}
       >
-        <span>{title}</span>
+        <Typography variant="body2">{title}</Typography>
         {showAddButton && (
           <Tooltip title={addBtnTooltip}>
             <IconButton
@@ -441,7 +442,7 @@ const CalendarSelector: React.FC<{
               style={{
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
-                wordBreak: 'break-word'
+                overflowWrap: 'break-word'
               }}
             >
               {displayName}

--- a/src/components/Calendar/CustomCalendar.styl
+++ b/src/components/Calendar/CustomCalendar.styl
@@ -9,7 +9,6 @@ th.fc-col-header-cell.fc-day
 a.fc-timegrid-axis-cushion
   color #243b55
   text-align center
-  font-family Roboto
   font-size 12.507px
   font-style normal
   font-weight 400
@@ -27,12 +26,10 @@ a.fc-timegrid-axis-cushion
   font-weight 500
   line-height 20px
   letter-spacing 0.25px
-  font-family "Inter", sans-serif
 
 .fc-daygrid-day-top .fc-daygrid-day-number,
 span.fc-daygrid-day-number
   color #243b55
-  font-family Roboto
   font-size 28px
   font-style normal
   font-weight 400
@@ -42,7 +39,6 @@ span.fc-daygrid-day-number
   line-height 39px
 
 .fc-daygrid-day-frame .fc-daygrid-day-top .fc-daygrid-day-number
-  font-family Inter
   font-size 12px
   font-weight 500
   line-height 16px
@@ -96,7 +92,6 @@ th.fc-timegrid-axis.fc-scrollgrid-shrink
   max-width 80px
   padding 0
   text-align left
-  font-family Roboto
   font-size 12.507px
   font-style normal
   font-weight 400
@@ -109,7 +104,6 @@ th.fc-timegrid-axis.fc-scrollgrid-shrink
 
 .fc-timegrid-slot-label-cushion
   color #aea9b1
-  font-family Roboto
   font-size 14px
   font-style normal
   font-weight 400
@@ -180,7 +174,6 @@ th.fc-col-header-cell.fc-day
   content attr(data-time)
   color #f67e35
   white-space nowrap
-  font-family Roboto, sans-serif
   font-weight 600
   position absolute
   top -2px
@@ -260,7 +253,6 @@ tbody > tr.fc-scrollgrid-section:first-of-type .fc-scroller
   border-radius 8px
   background #fff
   overflow hidden
-  font-family Inter, sans-serif
   width 244px
   box-shadow 0 4px 16px rgba(0,0,0,0.1)
 
@@ -309,7 +301,6 @@ tbody > tr.fc-scrollgrid-section:first-of-type .fc-scroller
           white-space nowrap
           overflow hidden
           text-overflow ellipsis
-          font-family: Inter !important
           font-weight: 400 !important
           font-style: Regular !important
           font-size: 14px !important

--- a/src/components/Calendar/OwnerCaption.tsx
+++ b/src/components/Calendar/OwnerCaption.tsx
@@ -14,7 +14,7 @@ export function OwnerCaption({
       style={{
         overflow: 'hidden',
         textOverflow: 'ellipsis',
-        wordBreak: 'break-word'
+        overflowWrap: 'break-word'
       }}
     >
       {showCaption && ownerDisplayName}

--- a/src/components/Calendar/SettingsTab.tsx
+++ b/src/components/Calendar/SettingsTab.tsx
@@ -58,7 +58,7 @@ export function SettingsTab({
   )
 
   useEffect(() => {
-    const handleToggleDesc = () => {
+    const handleToggleDesc = (): void => {
       if (description) setToggleDesc(true)
     }
     handleToggleDesc()
@@ -89,8 +89,7 @@ export function SettingsTab({
               }
               text={name}
               style={{
-                fontSize: '16px',
-                fontFamily: "'Inter', sans-serif"
+                fontSize: '16px'
               }}
             />
           ) : (

--- a/src/components/Event/EventChip/EventChip.tsx
+++ b/src/components/Event/EventChip/EventChip.tsx
@@ -200,7 +200,6 @@ export const EventChip: React.FC<EventChipProps> = ({
                 style={{
                   color: titleStyle.color,
                   opacity: '70%',
-                  fontFamily: 'Inter',
                   fontWeight: '500',
                   fontSize: '10px',
                   lineHeight: '16px',
@@ -229,7 +228,6 @@ export const EventChip: React.FC<EventChipProps> = ({
                 <Typography
                   style={{
                     marginRight: 2,
-                    fontFamily: 'Roboto',
                     fontWeight: '500',
                     fontStyle: 'Medium',
                     fontSize: '10px',
@@ -249,7 +247,6 @@ export const EventChip: React.FC<EventChipProps> = ({
                 {event._def.extendedProps.description && (
                   <Typography
                     sx={{
-                      fontFamily: 'Roboto',
                       fontWeight: 500,
                       fontSize: '10px',
                       lineHeight: '16px',

--- a/src/components/Event/EventChip/EventChipUtils.tsx
+++ b/src/components/Event/EventChip/EventChipUtils.tsx
@@ -61,7 +61,6 @@ export function getTitleStyle(
   isPrivate?: boolean
 ): React.CSSProperties {
   const baseStyle: React.CSSProperties = {
-    fontFamily: 'Roboto',
     fontWeight: '500',
     fontStyle: 'Medium',
     fontSize: '12px',
@@ -70,7 +69,6 @@ export function getTitleStyle(
     verticalAlign: 'middle',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    font: 'Roboto',
     whiteSpace: 'nowrap',
     color: bestColor
   }
@@ -196,7 +194,6 @@ export function DisplayedIcons(
         color: iconColor || 'inherit',
         margin: 0,
         marginRight: '4px',
-        fontFamily: 'inherit',
         fontWeight: 'inherit',
         lineHeight: 'inherit',
         letterSpacing: 'inherit'

--- a/src/components/Event/EventChip/MobileEventChipSchedule.tsx
+++ b/src/components/Event/EventChip/MobileEventChipSchedule.tsx
@@ -114,7 +114,6 @@ export const MobileEventChipSchedule: React.FC<
             styles={{
               color: titleStyle.color,
               opacity: '70%',
-              fontFamily: 'Inter',
               fontWeight: '500',
               fontSize: '10px',
               lineHeight: '16px',

--- a/src/components/Event/InfoRow.tsx
+++ b/src/components/Event/InfoRow.tsx
@@ -49,11 +49,11 @@ export function InfoRow({
           variant="body2"
           color={error ? 'error' : 'textPrimary'}
           sx={{
-            wordBreak: 'break-word',
             whiteSpace: 'pre-line',
             maxHeight: isMobile ? 'none' : '33vh',
             overflowY: isMobile ? undefined : 'auto',
             width: '100%',
+            overflowWrap: 'break-word',
             ...style
           }}
         >

--- a/src/components/Event/fields/CalendarSelectField.tsx
+++ b/src/components/Event/fields/CalendarSelectField.tsx
@@ -65,7 +65,7 @@ const CalendarSelectFieldCollapsed: React.FC<{
     >
       {selectedCalendar?.name ? (
         <Box style={{ display: 'flex', flexDirection: 'column' }}>
-          <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+          <Typography variant="body2" sx={{ overflowWrap: 'break-word' }}>
             {renameDefault(
               selectedCalendar.name,
               selectedOwnerDisplayName,

--- a/src/components/Menubar/Menubar.styl
+++ b/src/components/Menubar/Menubar.styl
@@ -107,7 +107,6 @@
 
 
 .current-date-time
-  font-family Roboto
   font-size 22px
   font-style normal
   font-weight 400

--- a/src/components/Menubar/UserMenu.tsx
+++ b/src/components/Menubar/UserMenu.tsx
@@ -67,7 +67,6 @@ const UserMenuContent: React.FC<{
         <Typography
           sx={{
             color: theme.palette.grey[900],
-            fontFamily: 'Inter',
             fontSize: 22,
             fontWeight: 600
           }}

--- a/src/features/Events/AttendanceValidation/EventCounterModal.tsx
+++ b/src/features/Events/AttendanceValidation/EventCounterModal.tsx
@@ -186,7 +186,7 @@ export function EventCounterModal({
           <Typography
             variant="h3"
             sx={{
-              wordBreak: 'break-word'
+              overflowWrap: 'break-word'
             }}
           >
             {formatEventChipTitle(contextualizedEvent.event, t)}

--- a/src/features/Events/EventPreview/EventPreviewDetails.tsx
+++ b/src/features/Events/EventPreview/EventPreviewDetails.tsx
@@ -150,11 +150,11 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
                 variant="body2"
                 color="textPrimary"
                 sx={{
-                  wordBreak: 'break-word',
                   whiteSpace: 'pre-line',
                   maxHeight: '33vh',
                   overflowY: 'auto',
-                  width: '100%'
+                  width: '100%',
+                  overflowWrap: 'break-word'
                 }}
               >
                 {resource.cn}
@@ -162,7 +162,7 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
               </Typography>
               <Typography
                 sx={{
-                  wordBreak: 'break-word',
+                  overflowWrap: 'break-word',
                   whiteSpace: 'pre-line',
                   overflowY: 'auto',
                   width: '100%',
@@ -175,8 +175,7 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
             </Box>
           ))}
           style={{
-            fontSize: '16px',
-            fontFamily: "'Inter', sans-serif"
+            fontSize: '16px'
           }}
         />
       )}

--- a/src/features/Events/EventPreview/EventPreviewModal.tsx
+++ b/src/features/Events/EventPreview/EventPreviewModal.tsx
@@ -53,12 +53,9 @@ const EventPreviewTitleRow: React.FC<EventPreviewTitleRowProps> = ({
             <LockOutlineIcon />
           ))}
         <Typography
-          variant="h5"
+          variant="h3"
           sx={{
-            fontSize: '24px',
-            fontWeight: 600,
-            wordBreak: 'break-word',
-            fontFamily: 'Inter, sans-serif'
+            overflowWrap: 'break-word'
           }}
         >
           {formatEventChipTitle(event, t)}

--- a/src/features/Search/mobileSearchResultsComponents.tsx
+++ b/src/features/Search/mobileSearchResultsComponents.tsx
@@ -61,7 +61,6 @@ const headerSx = {
 const getSubheaderStyle = (color?: string): React.CSSProperties => ({
   color,
   opacity: '70%',
-  fontFamily: 'Inter',
   fontWeight: '500',
   fontSize: '10px',
   lineHeight: '16px',

--- a/src/index.styl
+++ b/src/index.styl
@@ -1,6 +1,5 @@
 body
   margin 0
-  font-family -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif
   -webkit-font-smoothing antialiased
   -moz-osx-font-smoothing grayscale
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import * as Sentry from '@sentry/react'
+import './index.styl'
 import App from './App'
 import { store } from './app/store'
 


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/200#issuecomment-4517287404

Now all the elements have the same font family `Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated typography rendering across calendar, event, and navigation components for consistent appearance throughout the application.
  * Improved text wrapping behavior for long titles, calendar names, and user information to enhance readability.
  * Adjusted event preview heading sizes for improved visual hierarchy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->