### PR TITLE
#950 add missing icon in event chip

### DIFF
--- a/src/components/Event/EventChip/EventChip.tsx
+++ b/src/components/Event/EventChip/EventChip.tsx
@@ -142,9 +142,18 @@ export const EventChip: React.FC<EventChipProps> = ({
           }}
           title={
             showCompact ? (
-              <Typography variant="body2" style={titleStyle}>
-                {event.title}
-              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  width: '100%'
+                }}
+              >
+                {DisplayedIcons(IconDisplayed, titleStyle.color)}
+                <Typography variant="body2" style={titleStyle}>
+                  {event.title}
+                </Typography>
+              </Box>
             ) : (
               <Box
                 sx={{


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/950

<img width="233" height="62" alt="image" src="https://github.com/user-attachments/assets/b9efb656-9fc8-408e-864c-db4a4f96f50e" />
