### PR TITLE
#890 resolve blinking after import calendar

### DIFF
--- a/src/components/Dialog/ResponsiveDialog.tsx
+++ b/src/components/Dialog/ResponsiveDialog.tsx
@@ -188,10 +188,15 @@ function ResponsiveDialog({
       open={open}
       onClose={handleClose}
       maxWidth={false}
-      fullScreen={isMobile && open}
+      fullScreen={isMobile}
       fullWidth
       transitionDuration={isExpanded ? 0 : 300}
-      sx={[baseSx, ...(Array.isArray(sx) ? sx : [sx])]}
+      sx={
+        [
+          ...(baseSx ? [baseSx] : []),
+          ...(Array.isArray(sx) ? (sx as SxProps<Theme>[]) : sx ? [sx] : [])
+        ] as SxProps<Theme>
+      }
       style={isExpanded ? { zIndex: 1200 } : undefined}
       {...otherDialogProps}
     >
@@ -236,10 +241,16 @@ function ResponsiveDialog({
       </DialogTitle>
       <DialogContent
         dividers={dividers}
-        sx={[
-          baseContentSx,
-          ...(Array.isArray(contentSx) ? contentSx : [contentSx])
-        ]}
+        sx={
+          [
+            baseContentSx,
+            ...(Array.isArray(contentSx)
+              ? (contentSx as SxProps<Theme>[])
+              : contentSx
+                ? [contentSx]
+                : [])
+          ] as SxProps<Theme>
+        }
         {...dialogContentProps}
       >
         {isExpanded ? (


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/890

This error occurs because the `ResponsiveDialog` set prop is `fullScreen={isMobile && open}`, so when hitting close, the dialog changes to smaller variant before closing. That's why we saw a blinking dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `ResponsiveDialog` to properly determine fullscreen mode on mobile devices.

* **Refactor**
  * Improved styling prop handling in `ResponsiveDialog` to correctly process custom styles without unnecessary wrapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->