### PR TITLE
[#947] added missing data for sabre strict to work on testing

### DIFF
--- a/__test__/features/Events/EventRepetition.test.tsx
+++ b/__test__/features/Events/EventRepetition.test.tsx
@@ -10,6 +10,7 @@ import EventPreviewModal from '@/features/Events/EventPreview'
 import EventUpdateModal from '@/features/Events/EventUpdateModal'
 import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../../utils/Renderwithproviders'
+import { VcalendarProperties } from '@/features/Calendars/types/VcalendarProperties'
 
 jest.mock('@/components/Event/utils/eventUtils', () => {
   const actual = jest.requireActual('@/components/Event/utils/eventUtils')
@@ -593,7 +594,7 @@ describe('RSVP to Recurring Event', () => {
 
     expect(callArgs[1]).toStrictEqual([
       'vcalendar',
-      [],
+      VcalendarProperties,
       [
         [
           'vevent',

--- a/src/features/Calendars/types/VcalendarProperties.ts
+++ b/src/features/Calendars/types/VcalendarProperties.ts
@@ -1,6 +1,6 @@
 import { VObjectProperty } from './CalendarData'
 
-export const VcalendarProperties: VObjectProperty = [
+export const VcalendarProperties: VObjectProperty[] = [
   ['prodid', {}, 'text', '-//Linagora//Twake-Calendar//EN'],
   ['version', {}, 'text', '2.0']
-] as unknown as VObjectProperty
+] as VObjectProperty[]

--- a/src/features/Calendars/types/VcalendarProperties.ts
+++ b/src/features/Calendars/types/VcalendarProperties.ts
@@ -1,0 +1,6 @@
+import { VObjectProperty } from './CalendarData'
+
+export const VcalendarProperties: VObjectProperty = [
+  ['prodid', {}, 'text', '-//Linagora//Twake-Calendar//EN'],
+  ['version', {}, 'text', '2.0']
+] as unknown as VObjectProperty

--- a/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
+++ b/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
@@ -7,6 +7,7 @@ import {
 } from '../../Calendars/types/CalendarData'
 import { CalendarEvent } from '../EventsTypes'
 import { makeTimezone, parseCalendarEvent } from '../utils'
+import { VcalendarProperties } from '@/features/Calendars/types/VcalendarProperties'
 
 export function makeDeleteEventInstanceJCal(
   vevents: VCalComponent[],
@@ -67,7 +68,11 @@ export function makeDeleteEventInstanceJCal(
   const timezoneData = TIMEZONES.zones[seriesEvent.timezone]
   const vtimezone = makeTimezone(timezoneData, seriesEvent)
 
-  return ['vcalendar', [], [...filteredVevents, vtimezone.component.jCal]]
+  return [
+    'vcalendar',
+    VcalendarProperties,
+    [...filteredVevents, vtimezone.component.jCal]
+  ]
 }
 
 const normalizeRecurrenceId = (id: VObjectValue): string =>

--- a/src/features/Events/transformers/makeEventWithOverrides.ts
+++ b/src/features/Events/transformers/makeEventWithOverrides.ts
@@ -5,6 +5,7 @@ import {
 } from '../../Calendars/types/CalendarData'
 import { CalendarEvent } from '../EventsTypes'
 import { makeTimezone, makeVevent } from '../utils'
+import { VcalendarProperties } from '@/features/Calendars/types/VcalendarProperties'
 
 export function makeEventWithOverrides(
   updatedEvent: CalendarEvent,
@@ -42,7 +43,7 @@ export function makeEventWithOverrides(
 
   return [
     'vcalendar',
-    [],
+    VcalendarProperties,
     [...nextVevents, vtimezone.component.jCal as VCalComponent]
   ]
 }

--- a/src/features/Events/transformers/makeSeriesJCal.ts
+++ b/src/features/Events/transformers/makeSeriesJCal.ts
@@ -6,6 +6,7 @@ import {
 } from '../../Calendars/types/CalendarData'
 import { CalendarEvent } from '../EventsTypes'
 import { makeTimezone, makeVevent } from '../utils'
+import { VcalendarProperties } from '@/features/Calendars/types/VcalendarProperties'
 
 const METADATA_FIELDS = [
   'summary',
@@ -301,7 +302,7 @@ export const makeSeriesJCal = (
 
   return [
     'vcalendar',
-    [],
+    VcalendarProperties,
     [...finalVevents, vtimezone.component.jCal as VCalComponent]
   ] as VCalComponent
 }

--- a/src/features/Events/transformers/updateSeriesPartstatJCal.ts
+++ b/src/features/Events/transformers/updateSeriesPartstatJCal.ts
@@ -5,6 +5,7 @@ import {
 } from '../../Calendars/types/CalendarData'
 import { CalendarEvent } from '../EventsTypes'
 import { makeTimezone } from '../utils'
+import { VcalendarProperties } from '@/features/Calendars/types/VcalendarProperties'
 
 export function updateSeriesPartstatJCal(
   vevents: VCalComponent[],
@@ -36,7 +37,11 @@ export function updateSeriesPartstatJCal(
   const timezoneData = TIMEZONES.zones[event.timezone]
   const vtimezone = makeTimezone(timezoneData, event)
 
-  return ['vcalendar', [], [...updatedVevents, vtimezone.component.jCal]]
+  return [
+    'vcalendar',
+    VcalendarProperties,
+    [...updatedVevents, vtimezone.component.jCal]
+  ]
 }
 
 const normalizeEmail = (addr: string): string =>

--- a/src/features/Events/utils/calendarEventToJCal.ts
+++ b/src/features/Events/utils/calendarEventToJCal.ts
@@ -2,6 +2,7 @@ import { TIMEZONES } from '@/utils/timezone-data'
 import { CalendarEvent } from '../EventsTypes'
 import { makeVevent } from './makeVevent'
 import { makeTimezone } from './makeTimezone'
+import { VcalendarProperties } from '@/features/Calendars/types/VcalendarProperties'
 
 export function calendarEventToJCal(
   event: CalendarEvent,
@@ -14,5 +15,5 @@ export function calendarEventToJCal(
   const timezoneData = TIMEZONES.zones[event.timezone]
   const vtimezone = makeTimezone(timezoneData, event)
 
-  return ['vcalendar', [], [vevent, vtimezone.component.jCal]]
+  return ['vcalendar', VcalendarProperties, [vevent, vtimezone.component.jCal]]
 }

--- a/src/features/Events/utils/makeVevent.ts
+++ b/src/features/Events/utils/makeVevent.ts
@@ -30,7 +30,8 @@ export function makeVevent(
         'unknown',
         event.x_openpass_videoconference ?? null
       ],
-      ['summary', {}, 'text', event.title ?? '']
+      ['summary', {}, 'text', event.title ?? ''],
+      ['dtstamp', {}, 'date-time', formatDateTimeToICal(new Date())]
     ]
   ]
   if (event.alarm?.trigger) {


### PR DESCRIPTION
resolves #947 

to support sabre strict mode, all was needed was a dtstamp in the vevent data and the proid and version in the vcalendar data. 

@chibenwa should the vcal properties be stored in the .env.js, I'm not sure if it's something that would change depending on the env. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar events now include standardized vCalendar properties (product ID and version) for improved compatibility.
  * Events now properly include timestamp information.

* **Improvements**
  * Enhanced consistency in calendar data structure across event operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->