### PR TITLE
#952 prevent show alert if new timezone has same offset

### DIFF
--- a/__test__/components/Timezone/TimezoneChangeAlert.test.tsx
+++ b/__test__/components/Timezone/TimezoneChangeAlert.test.tsx
@@ -33,12 +33,24 @@ describe('TimezoneChangeAlert', () => {
   })
 
   const mockBrowserTZ = (tz: string) => {
-    jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(
-      () =>
-        ({
-          resolvedOptions: () => ({ timeZone: tz })
-        }) as any
-    )
+    jest
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation((locales, options) => {
+        const timeZone = options?.timeZone || tz
+        let offset = 'UTC'
+        if (timeZone === 'Asia/Ho_Chi_Minh') {
+          offset = 'GMT+7'
+        } else if (
+          timeZone === 'Europe/Paris' ||
+          timeZone === 'Europe/Brussels'
+        ) {
+          offset = 'GMT+2'
+        }
+        return {
+          resolvedOptions: () => ({ timeZone }),
+          formatToParts: () => [{ type: 'timeZoneName', value: offset }]
+        } as any
+      })
   }
 
   const baseState = {
@@ -64,6 +76,15 @@ describe('TimezoneChangeAlert', () => {
     renderWithProviders(<TimezoneChangeAlert />, state)
 
     expect(screen.queryByText(/We detected you are in/)).not.toBeInTheDocument()
+  })
+
+  it('does not show snackbar when browser TZ has different name but same offset as configured TZ', () => {
+    mockBrowserTZ('Europe/Brussels')
+    const state = baseState
+    renderWithProviders(<TimezoneChangeAlert />, state)
+    expect(
+      screen.queryByText(/settings\.tzPrompt\.detected/)
+    ).not.toBeInTheDocument()
   })
 
   it('does not show snackbar when ASK_FOR_TZ_UPDATE is false', () => {

--- a/src/components/Timezone/TimezoneChangeAlert.tsx
+++ b/src/components/Timezone/TimezoneChangeAlert.tsx
@@ -7,6 +7,7 @@ import {
 import { Alert, Box, Button, Snackbar, Typography } from '@linagora/twake-mui'
 import React, { useEffect, useState } from 'react'
 import { useI18n } from 'twake-i18n'
+import { getTimezoneOffset } from '@/utils/timezone'
 
 export const TimezoneChangeAlert: React.FC = () => {
   const dispatch = useAppDispatch()
@@ -30,8 +31,21 @@ export const TimezoneChangeAlert: React.FC = () => {
 
       const lastCheckedTZ = localStorage.getItem('lastCheckedTZ')
 
-      const hasTimezoneChanged = currentBrowserTZ !== lastCheckedTZ
-      const shouldPrompt = currentBrowserTZ !== configuredTZ
+      const getSafeTimezoneOffset = (tz: string | null | undefined): string => {
+        if (!tz) return ''
+        try {
+          return getTimezoneOffset(tz)
+        } catch {
+          return ''
+        }
+      }
+
+      const browserOffset = getSafeTimezoneOffset(currentBrowserTZ)
+      const lastCheckedOffset = getSafeTimezoneOffset(lastCheckedTZ)
+      const configuredOffset = getSafeTimezoneOffset(configuredTZ)
+
+      const hasTimezoneChanged = browserOffset !== lastCheckedOffset
+      const shouldPrompt = browserOffset !== configuredOffset
 
       if (hasTimezoneChanged && shouldPrompt) {
         setOpen(true)


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/952

By checking timezone offset instead of timezone name, the alert of changing timezone will not show in case of the same offset but different name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone change detection to compare offsets rather than timezone names, preventing false alerts when switching between different timezones that share the same UTC offset (e.g., Europe/Paris and Europe/Brussels).

* **Tests**
  * Added test coverage to verify the alert behavior remains silent when browser timezone differs in name but matches in offset with the configured timezone.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->