### PR TITLE
[#961] added check to prevent float in number textfield

### DIFF
--- a/src/components/Event/EventRepeat.tsx
+++ b/src/components/Event/EventRepeat.tsx
@@ -25,6 +25,7 @@ import { ReadOnlyDateField } from './components/ReadOnlyPickerField'
 import { LONG_DATE_FORMAT } from './utils/dateTimeFormatters'
 import { FC_DAYS, WeekDaySelector } from './WeekDaySelector'
 import { useScreenSizeDetection } from '@/useScreenSizeDetection'
+import { preventFloatNumber, toPositiveInt } from '@/utils/preventFloatNumber'
 
 const numericSlotProps = {
   htmlInput: {
@@ -70,11 +71,12 @@ export const RepeatEvent: React.FC<{
           <TextField
             type="number"
             value={repetition.interval ?? 1}
+            onKeyDown={preventFloatNumber}
             disabled={!isOwn}
             onChange={e =>
               setRepetition({
                 ...repetition,
-                interval: Number(e.target.value)
+                interval: toPositiveInt(e.target.value)
               })
             }
             size={isMobile ? 'medium' : 'small'}
@@ -83,6 +85,7 @@ export const RepeatEvent: React.FC<{
               htmlInput: {
                 ...numericSlotProps.htmlInput,
                 min: 1,
+                step: 1,
                 'data-testid': 'repeat-interval',
                 style: {
                   textAlign: 'center',
@@ -277,7 +280,7 @@ export const RepeatEvent: React.FC<{
                     size={isMobile ? 'medium' : 'small'}
                     value={repetition.occurrences || 1}
                     onChange={e => {
-                      const value = Number(e.target.value)
+                      const value = toPositiveInt(e.target.value)
                       setRepetition({
                         ...repetition,
                         endDate: null,
@@ -285,11 +288,13 @@ export const RepeatEvent: React.FC<{
                       })
                     }}
                     sx={{ width: 100 }}
+                    onKeyDown={preventFloatNumber}
                     disabled={!isOwn}
                     slotProps={{
                       htmlInput: {
                         ...numericSlotProps.htmlInput,
                         min: 1,
+                        step: 1,
                         'data-testid': 'occurrences-input'
                       }
                     }}

--- a/src/utils/preventFloatNumber.ts
+++ b/src/utils/preventFloatNumber.ts
@@ -1,0 +1,12 @@
+export const preventFloatNumber = (
+  event: React.KeyboardEvent<HTMLInputElement>
+) => {
+  if (/^[-+,.]$/.test(event?.key)) {
+    event.preventDefault()
+  }
+}
+
+export const toPositiveInt = (raw: string, fallback = 1): number => {
+  const n = Math.trunc(Number(raw))
+  return n > 0 ? n : fallback
+}


### PR DESCRIPTION
resolves #961 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric input handling for event repeat settings: keyboard entry now blocks minus, plus, and comma characters to prevent floats; inputs are constrained to integer steps and parsing now ensures values become positive integers with a sensible fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-calendar-frontend/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->