### PR TITLE
#623 resolve fail to load resource

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,16 +79,26 @@
         document.body.innerHTML = errorUI
       }
 
-      window.addEventListener('error', function (e) {
-        var isUnexpectedToken =
-          e.message &&
-          (e.message.includes("Unexpected token '<'") ||
-            e.message.includes("expected expression, got '<'"))
-        var isScriptError = e.filename && e.filename.indexOf('.js') > -1
-        if (isUnexpectedToken && isScriptError) {
-          showFallbackUI()
-        }
-      })
+      window.addEventListener(
+        'error',
+        function (e) {
+          // Catch syntax errors (Unexpected token '<')
+          var isUnexpectedToken =
+            e.message &&
+            (e.message.includes("Unexpected token '<'") ||
+              e.message.includes("expected expression, got '<'"))
+          var isScriptError = e.filename && e.filename.indexOf('.js') > -1
+
+          // Catch asset loading network failures (404s)
+          var isNetworkError =
+            e.target &&
+            (e.target.tagName === 'SCRIPT' || e.target.tagName === 'LINK')
+          if ((isUnexpectedToken && isScriptError) || isNetworkError) {
+            showFallbackUI()
+          }
+        },
+        true
+      )
 
       window.addEventListener('unhandledrejection', function (e) {
         // AbortErrors are intentional (SSO redirect in progress, cancelled fetches)


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/623

The previous fix did not handle the case network error so the script to notice user reloads the page did not trigger. I've added a condition to handle for this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to gracefully recover from script and resource loading failures with a user-friendly refresh message instead of a broken page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->