### PR TITLE
#954 push source map in sentry

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
     distPath: {
       root: 'dist'
     },
-    minify: true
+    minify: true,
+    sourceMap: {
+      js: process.env.NODE_ENV === 'production' ? 'hidden-source-map' : 'source-map'
+    }
   },
   performance: {
     chunkSplit: {

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
     minify: true,
     sourceMap: {
-      js: process.env.NODE_ENV === 'production' ? 'hidden-source-map' : 'source-map'
+      js:   'source-map'
     }
   },
   performance: {

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     },
     minify: true,
     sourceMap: {
-      js:   'source-map'
+      js: 'source-map'
     }
   },
   performance: {


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to retain JavaScript minification while explicitly enabling source-map generation for JavaScript outputs, improving debuggability of production builds without changing public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->