### PR TITLE
Sync issue when untick calendar

### DIFF
--- a/__test__/components/EventModifications.test.tsx
+++ b/__test__/components/EventModifications.test.tsx
@@ -112,7 +112,9 @@ describe('CalendarApp integration', () => {
     expect(eventEl).toBeInTheDocument()
     act(() => {
       if (calendarApi) {
-        const fcEvent = calendarApi.getEventById('event1')
+        const fcEvent = calendarApi.getEventById(
+          '667037022b752d0026472254/cal1/event1'
+        )
         expect(fcEvent?.title).toBe('Test Event')
         const oldEnd = new Date(new Date().getTime() + 3600000) // +1 hour
         const newEnd = new Date(oldEnd.getTime() + 1800000) // +30 min

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -469,11 +469,18 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     if (!isWebKit) return
 
     const api = calendarRef.current
-    if (!api) return
+    const wrapper = calendarWrapperRef.current
+    if (!api || !wrapper) return
 
-    const raf = requestAnimationFrame(() => api.updateSize())
+    const raf = requestAnimationFrame(() => {
+      api.updateSize()
+      wrapper.style.transform = 'translateZ(0)'
+      requestAnimationFrame(() => {
+        wrapper.style.transform = ''
+      })
+    })
     return (): void => cancelAnimationFrame(raf)
-  }, [sortedSelectedCalendars, calendarRef])
+  }, [sortedSelectedCalendars, fullCalendarEvents, calendarRef])
 
   useTouchListener(
     eventHandlers.handleDateSelect,

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -456,6 +456,25 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
     }
   }, [calendarRef])
 
+  // Safari (WebKit) sometimes leaves orphaned, absolutely-positioned event
+  // chips on the grid when the event set shrinks — e.g. when a shared calendar
+  // is deselected. The chips' DOM nodes are not repainted away until a reflow
+  // is forced. updateSize() re-runs FullCalendar's layout, forcing the reflow
+  // that clears the stale chips. Scoped to WebKit so other browsers don't pay
+  // for the extra layout pass.
+  useEffect(() => {
+    const isWebKit =
+      typeof navigator !== 'undefined' &&
+      /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+    if (!isWebKit) return
+
+    const api = calendarRef.current
+    if (!api) return
+
+    const raf = requestAnimationFrame(() => api.updateSize())
+    return (): void => cancelAnimationFrame(raf)
+  }, [sortedSelectedCalendars, calendarRef])
+
   useTouchListener(
     eventHandlers.handleDateSelect,
     isTablet || isMobile,

--- a/src/components/Calendar/utils/calendarUtils.ts
+++ b/src/components/Calendar/utils/calendarUtils.ts
@@ -70,6 +70,7 @@ export function formatEventChipTitle(
 }
 
 type ConvertedEvent = CalendarEvent & {
+  id: string
   colors: Record<string, string> | undefined
   editable: boolean
   priority: number
@@ -167,6 +168,14 @@ function buildConvertedEvent({
 
   const convertedEvent: ConvertedEvent = {
     ...event,
+    // FullCalendar reconciles events by `id`, not by our `uid`. Without a
+    // stable, grid-unique id it can't reliably drop chips when the event set
+    // shrinks (e.g. deselecting a shared calendar) — most visibly for a
+    // recurring series, whose occurrences are many sibling chips removed at
+    // once. The uid already embeds the recurrenceId for occurrences (see
+    // processEventUid), so it is unique within a calendar; the calId prefix
+    // keeps it unique when the same uid is shared across displayed calendars.
+    id: `${event.calId}/${event.uid}`,
     title: formatEventChipTitle(event, t),
     colors: event.color,
     editable: isEventEditable(


### PR DESCRIPTION
GIVEN some calendar are un-selected some calendar
THEN some ships of the calendar remain visible 


https://github.com/user-attachments/assets/45c62889-fe79-460e-9675-5cffe21f9bd6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Safari/WebKit rendering issue so event chips are reliably removed when calendars or events change.
  * Ensured event instances reconcile correctly so stale event chips no longer persist after updates.

* **Tests**
  * Updated calendar event tests to validate reconciliation using fully-qualified event identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->