### PR TITLE
#962 remove fallback to get resource detail

### DIFF
--- a/__test__/features/Calendars/services/getCalendarsListAsync.test.tsx
+++ b/__test__/features/Calendars/services/getCalendarsListAsync.test.tsx
@@ -1,12 +1,21 @@
 import { fetchCalendars } from '@/features/Calendars/CalendarDAO'
 import { getCalendarsListAsync } from '@/features/Calendars/services/getCalendarsListAsync'
-import { fetchOwnerData } from '@/features/Calendars/services/helpers'
+import { getOwnerOrResourceData } from '@/features/Calendars/services/helpers'
 import { normalizeCalendar } from '@/features/Calendars/utils/normalizeCalendar'
 import { fetchCurrentUser } from '@/features/User/UserDao'
 import { formatReduxError } from '@/utils/errorUtils'
 
 jest.mock('@/features/User/UserDao')
-jest.mock('@/features/Calendars/services/helpers')
+jest.mock('@/features/Calendars/services/helpers', () => {
+  const originalModule = jest.requireActual(
+    '@/features/Calendars/services/helpers'
+  )
+  return {
+    __esModule: true,
+    ...originalModule,
+    getOwnerOrResourceData: jest.fn()
+  }
+})
 jest.mock('@/features/Calendars/CalendarDAO')
 jest.mock('@/utils/errorUtils')
 jest.mock('@/features/Calendars/utils/normalizeCalendar')
@@ -19,7 +28,7 @@ jest.mock('@mui/material/styles', () => ({
 }))
 
 const mockedFetchCurrentUser = fetchCurrentUser as jest.Mock
-const mockedFetchOwnerData = fetchOwnerData as jest.Mock
+const mockedGetOwnerOrResourceData = getOwnerOrResourceData as jest.Mock
 const mockedFetchCalendars = fetchCalendars as jest.Mock
 const mockedFormatReduxError = formatReduxError as jest.Mock
 const mockedNormalizeCalendar = normalizeCalendar as jest.Mock
@@ -86,7 +95,7 @@ describe('getCalendarsListAsync', () => {
         invite: [{ href: '', principal: '', access: 3, inviteStatus: 1 }]
       })
 
-    mockedFetchOwnerData
+    mockedGetOwnerOrResourceData
       .mockResolvedValueOnce({
         firstname: 'John',
         lastname: 'Doe',
@@ -150,9 +159,7 @@ describe('getCalendarsListAsync', () => {
     })
 
     // toRejectedError is imported from a mocked module; provide the expected return
-    const { toRejectedError } = jest.requireMock('@/utils/errorUtils') as {
-      toRejectedError: jest.Mock
-    }
+    const { toRejectedError } = jest.requireMock('@/utils/errorUtils')
     toRejectedError.mockReturnValueOnce({
       status: 500,
       message: 'Server Error'
@@ -182,14 +189,19 @@ describe('getCalendarsListAsync', () => {
       ownerId: 'error-123'
     })
 
-    // fetchOwnerData fails
-    mockedFetchOwnerData.mockRejectedValueOnce(new Error('Network Error'))
+    // getOwnerOrResourceData fails
+    mockedGetOwnerOrResourceData.mockRejectedValueOnce(
+      new Error('Network Error')
+    )
 
     const thunk = getCalendarsListAsync()
     const result = await thunk(dispatch, getState, undefined)
 
     const payload = result.payload as any
-    expect(mockedFetchOwnerData).toHaveBeenCalledWith('error-123')
+    expect(mockedGetOwnerOrResourceData).toHaveBeenCalledWith(
+      'error-123',
+      false
+    )
     expect(payload.importedCalendars['cal-1'].owner).toEqual({
       firstname: '',
       lastname: 'Unknown User',
@@ -208,13 +220,16 @@ describe('getCalendarsListAsync', () => {
       _embedded: { 'dav:calendar': [{ id: 'cal-1' }] }
     })
     mockedNormalizeCalendar.mockReturnValue({
-      cal: { 'dav:name': 'Resource Cal' },
+      cal: {
+        'dav:name': 'Resource Cal',
+        invite: [{ href: 'principals/resources/resource-123', access: 1 }]
+      },
       id: 'cal-1',
       ownerId: 'resource-123'
     })
 
-    // fetchOwnerData succeeds and returns a resource config structure
-    mockedFetchOwnerData.mockResolvedValueOnce({
+    // getOwnerOrResourceData succeeds and returns a resource config structure
+    mockedGetOwnerOrResourceData.mockResolvedValueOnce({
       firstname: 'Creator',
       lastname: 'User',
       emails: [],
@@ -225,7 +240,10 @@ describe('getCalendarsListAsync', () => {
     const result = await thunk(dispatch, getState, undefined)
 
     const payload = result.payload as any
-    expect(mockedFetchOwnerData).toHaveBeenCalledWith('resource-123')
+    expect(mockedGetOwnerOrResourceData).toHaveBeenCalledWith(
+      'resource-123',
+      true
+    )
     expect(payload.importedCalendars['cal-1'].owner).toEqual({
       firstname: 'Creator',
       lastname: 'User',

--- a/__test__/features/Calendars/services/helpers.test.tsx
+++ b/__test__/features/Calendars/services/helpers.test.tsx
@@ -1,4 +1,8 @@
-import { fetchOwnerData } from '@/features/Calendars/services/helpers'
+import {
+  fetchOwnerData,
+  fetchOwnerOfResource,
+  extractResourceOwnerIds
+} from '@/features/Calendars/services/helpers'
 import { fetchUserById } from '@/features/User/UserDao'
 import { fetchResourceById } from '@/features/User/ResourceDAO'
 
@@ -33,31 +37,6 @@ describe('helpers', () => {
       expect(result).toEqual(mockUser)
     })
 
-    it('should fetch resource details and its creator when user is not found', async () => {
-      const mockResource = { creator: 'creator-456' } as any
-      const mockCreator = {
-        firstname: 'Creator',
-        lastname: 'User',
-        emails: ['creator@example.com']
-      } as any
-
-      mockedFetchUserById.mockRejectedValueOnce({ response: { status: 404 } })
-      mockedFetchResourceById.mockResolvedValueOnce(mockResource)
-      mockedFetchUserById.mockResolvedValueOnce(mockCreator)
-
-      const result = await fetchOwnerData('resource-123')
-
-      expect(fetchUserById).toHaveBeenNthCalledWith(1, 'resource-123')
-      expect(fetchResourceById).toHaveBeenCalledWith('resource-123')
-      expect(fetchUserById).toHaveBeenNthCalledWith(2, 'creator-456')
-      expect(result).toEqual({
-        ...mockCreator,
-        resource: true,
-        administrators: undefined,
-        resourceIcon: undefined
-      })
-    })
-
     it('should throw error when fetchUserById fails with non-404 error', async () => {
       const mockError = { response: { status: 500 } }
       mockedFetchUserById.mockRejectedValueOnce(mockError)
@@ -68,16 +47,103 @@ describe('helpers', () => {
       expect(fetchResourceById).not.toHaveBeenCalled()
     })
 
+    it('should throw error when fetchUserById fails with 404 error', async () => {
+      const mockError = { response: { status: 404 } }
+      mockedFetchUserById.mockRejectedValueOnce(mockError)
+
+      await expect(fetchOwnerData('user-123')).rejects.toEqual(mockError)
+
+      expect(fetchUserById).toHaveBeenCalledWith('user-123')
+      expect(fetchResourceById).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fetchOwnerOfResource', () => {
+    it('should fetch resource details and its creator successfully', async () => {
+      const mockResource = { creator: 'creator-456' } as any
+      const mockCreator = {
+        firstname: 'Creator',
+        lastname: 'User',
+        emails: ['creator@example.com']
+      } as any
+
+      mockedFetchResourceById.mockResolvedValueOnce(mockResource)
+      mockedFetchUserById.mockResolvedValueOnce(mockCreator)
+
+      const result = await fetchOwnerOfResource('resource-123')
+
+      expect(fetchResourceById).toHaveBeenCalledWith('resource-123')
+      expect(fetchUserById).toHaveBeenCalledWith('creator-456')
+      expect(result).toEqual({
+        ...mockCreator,
+        administrators: undefined,
+        resourceIcon: undefined
+      })
+    })
+
     it('should throw error when fetchResourceById fails', async () => {
       const mockError = new Error('Resource not found')
-      mockedFetchUserById.mockRejectedValueOnce({ response: { status: 404 } })
       mockedFetchResourceById.mockRejectedValueOnce(mockError)
 
-      await expect(fetchOwnerData('resource-123')).rejects.toEqual(mockError)
+      await expect(fetchOwnerOfResource('resource-123')).rejects.toEqual(
+        mockError
+      )
 
-      expect(fetchUserById).toHaveBeenCalledWith('resource-123')
       expect(fetchResourceById).toHaveBeenCalledWith('resource-123')
-      expect(fetchUserById).toHaveBeenCalledTimes(1)
+      expect(fetchUserById).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('extractResourceOwnerIds', () => {
+    it('should return resource owner IDs from cal.invite', () => {
+      const mockCalendars = [
+        {
+          cal: {
+            invite: [
+              { href: 'principals/resources/res1', access: 1 },
+              { href: 'principals/users/user1', access: 2 }
+            ]
+          },
+          ownerId: 'owner-res1'
+        },
+        {
+          cal: {
+            invite: [{ href: 'principals/users/user2', access: 1 }]
+          },
+          ownerId: 'owner-user2'
+        }
+      ] as any
+
+      const result = extractResourceOwnerIds(mockCalendars)
+      expect(result).toEqual(new Set(['owner-res1']))
+    })
+
+    it('should return resource owner IDs from calendarserver:source invite', () => {
+      const mockCalendars = [
+        {
+          cal: {
+            'calendarserver:source': {
+              invite: [{ href: 'principals/resources/res2', access: 1 }]
+            }
+          },
+          ownerId: 'owner-res2'
+        }
+      ] as any
+
+      const result = extractResourceOwnerIds(mockCalendars)
+      expect(result).toEqual(new Set(['owner-res2']))
+    })
+
+    it('should return empty set if no resource owner IDs are found', () => {
+      const mockCalendars = [
+        {
+          cal: {},
+          ownerId: 'owner-none'
+        }
+      ] as any
+
+      const result = extractResourceOwnerIds(mockCalendars)
+      expect(result).toEqual(new Set())
     })
   })
 })

--- a/src/features/Calendars/services/getCalendarsListAsync.ts
+++ b/src/features/Calendars/services/getCalendarsListAsync.ts
@@ -5,11 +5,11 @@ import { defaultColors } from '@/utils/defaultColors'
 import { formatReduxError, toRejectedError } from '@/utils/errorUtils'
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { fetchCalendars } from '../CalendarDAO'
-import { Calendar, CalendarInvite } from '../CalendarTypes'
+import { Calendar, CalendarInvite, DelegationAccess } from '../CalendarTypes'
 import { CalendarData } from '../types/CalendarData'
 import { RejectedError } from '../types/RejectedError'
 import { normalizeCalendar } from '../utils/normalizeCalendar'
-import { fetchOwnerData } from './helpers'
+import { getOwnerOrResourceData, extractResourceOwnerIds } from './helpers'
 import { createTheme } from '@mui/material/styles'
 import { getAccessiblePair } from '@/utils/getAccessiblePair'
 
@@ -24,119 +24,30 @@ export const getCalendarsListAsync = createAsyncThunk<
   const existingCalendars = state.calendars.list || {}
   const existingUser = { id: state.user?.userData?.openpaasId || undefined }
   try {
-    const fetchedCalendars: Record<string, Calendar> = {}
     const user = existingUser.id ? existingUser : await getOpenPaasUser()
-    const calendars = await fetchCalendars(user.id)
+    const calendars = await fetchCalendars(user.id as string)
     const rawCalendars = calendars._embedded['dav:calendar']
 
     const errors: string[] = []
 
     const normalizedCalendars = rawCalendars.map((cal: CalendarData) =>
-      normalizeCalendar(cal, user.id)
+      normalizeCalendar(cal, user.id as string)
     )
 
-    const uniqueOwnerIds = Array.from(
-      new Set(normalizedCalendars.map(({ ownerId }) => ownerId).filter(Boolean))
+    const ownerDataMap = await fetchCalendarsOwnerData(
+      normalizedCalendars,
+      errors
     )
 
-    const ownerDataMap = new Map<string, OpenPaasUserData>()
-    const OWNER_BATCH_SIZE = 20
-
-    const mapOwnerData = async (ownerId: string): Promise<void> => {
-      try {
-        const data = await fetchOwnerData(ownerId)
-        ownerDataMap.set(ownerId, data)
-      } catch (error) {
-        console.error(`Failed to fetch user details for ${ownerId}:`, error)
-        ownerDataMap.set(ownerId, {
-          firstname: '',
-          lastname: 'Unknown User',
-          emails: []
-        })
-        errors.push(formatReduxError(error))
-      }
-    }
-
-    for (let i = 0; i < uniqueOwnerIds.length; i += OWNER_BATCH_SIZE) {
-      const chunk = uniqueOwnerIds.slice(i, i + OWNER_BATCH_SIZE)
-      await Promise.all(chunk.map(ownerId => mapOwnerData(ownerId)))
-    }
-
-    normalizedCalendars.forEach(
-      ({
-        cal,
-        description,
-        delegated,
-        link,
-        id,
-        ownerId,
-        visibility,
-        access
-      }) => {
-        const ownerData = ownerDataMap.get(ownerId) || {
-          firstname: '',
-          lastname: 'Unknown User',
-          emails: []
-        }
-
-        const rawColor = cal['apple:color']
-        const color = rawColor
-          ? {
-              light: rawColor,
-              dark: getAccessiblePair(rawColor, theme)
-            }
-          : defaultColors[0]
-
-        const invite: CalendarInvite[] = (
-          (cal.invite ?? []) as Array<{
-            href: string
-            principal: string
-            access: number
-            inviteStatus: number
-          }>
-        ).filter((inv): inv is CalendarInvite => [2, 3, 5].includes(inv.access))
-
-        fetchedCalendars[id] = {
-          id,
-          name: cal['dav:name'] ?? '',
-          link,
-          owner: ownerData,
-          description,
-          delegated,
-          color,
-          visibility,
-          access,
-          events: {},
-          invite
-        }
-      }
+    const fetchedCalendars = buildFetchedCalendars(
+      normalizedCalendars,
+      ownerDataMap
     )
 
-    const importedCalendars: Record<string, Calendar> = {}
-
-    const fetchedIds = new Set(Object.keys(fetchedCalendars))
-    const existingIds = new Set(Object.keys(existingCalendars))
-
-    const added = [...fetchedIds].filter(id => !existingIds.has(id))
-
-    existingIds.forEach(id => {
-      if (fetchedIds.has(id)) {
-        const existingCal = existingCalendars[id]
-        const fetchedCal = fetchedCalendars[id]
-
-        if (fetchedCal) {
-          importedCalendars[id] = {
-            ...fetchedCal,
-            events: existingCal.events || {}
-          }
-        }
-      }
-    })
-
-    // Add new calendars
-    added.forEach(id => {
-      importedCalendars[id] = fetchedCalendars[id]
-    })
+    const importedCalendars = mergeCalendars(
+      fetchedCalendars,
+      existingCalendars
+    )
 
     return {
       importedCalendars,
@@ -146,3 +57,145 @@ export const getCalendarsListAsync = createAsyncThunk<
     return rejectWithValue(toRejectedError(err))
   }
 })
+
+async function fetchCalendarsOwnerData(
+  normalizedCalendars: Array<{ cal: CalendarData; ownerId: string }>,
+  errors: string[]
+): Promise<Map<string, OpenPaasUserData>> {
+  const resourceOwnerIds = extractResourceOwnerIds(normalizedCalendars)
+  const uniqueOwnerIds = Array.from(
+    new Set(normalizedCalendars.map(({ ownerId }) => ownerId).filter(Boolean))
+  )
+
+  const ownerDataMap = new Map<string, OpenPaasUserData>()
+  const OWNER_BATCH_SIZE = 20
+
+  const mapOwnerData = async (ownerId: string): Promise<void> => {
+    const isResource = resourceOwnerIds.has(ownerId)
+    try {
+      const data = await getOwnerOrResourceData(ownerId, isResource)
+      ownerDataMap.set(ownerId, data)
+    } catch (error) {
+      console.error(
+        `Failed to fetch ${
+          isResource ? 'resource' : 'user'
+        } details for ${ownerId}:`,
+        error
+      )
+      ownerDataMap.set(ownerId, {
+        firstname: '',
+        lastname: 'Unknown User',
+        emails: []
+      })
+      errors.push(formatReduxError(error))
+    }
+  }
+
+  for (let i = 0; i < uniqueOwnerIds.length; i += OWNER_BATCH_SIZE) {
+    const chunk = uniqueOwnerIds.slice(i, i + OWNER_BATCH_SIZE)
+    await Promise.all(chunk.map(ownerId => mapOwnerData(ownerId)))
+  }
+
+  return ownerDataMap
+}
+
+function buildFetchedCalendars(
+  normalizedCalendars: Array<{
+    cal: CalendarData
+    description?: string
+    delegated: boolean
+    link?: string
+    id: string
+    ownerId: string
+    visibility: 'private' | 'public'
+    access?: DelegationAccess
+  }>,
+  ownerDataMap: Map<string, OpenPaasUserData>
+): Record<string, Calendar> {
+  const fetchedCalendars: Record<string, Calendar> = {}
+
+  normalizedCalendars.forEach(
+    ({
+      cal,
+      description,
+      delegated,
+      link,
+      id,
+      ownerId,
+      visibility,
+      access
+    }) => {
+      const ownerData = ownerDataMap.get(ownerId) || {
+        firstname: '',
+        lastname: 'Unknown User',
+        emails: []
+      }
+
+      const rawColor = cal['apple:color']
+      const color = rawColor
+        ? {
+            light: rawColor,
+            dark: getAccessiblePair(rawColor, theme)
+          }
+        : defaultColors[0]
+
+      const invite: CalendarInvite[] = (
+        (cal.invite ?? []) as Array<{
+          href: string
+          principal: string
+          access: number
+          inviteStatus: number
+        }>
+      ).filter((inv): inv is CalendarInvite => [2, 3, 5].includes(inv.access))
+
+      fetchedCalendars[id] = {
+        id,
+        name: cal['dav:name'] ?? '',
+        link: link ?? '',
+        owner: ownerData,
+        description,
+        delegated,
+        color,
+        visibility,
+        access,
+        events: {},
+        invite
+      }
+    }
+  )
+
+  return fetchedCalendars
+}
+
+function mergeCalendars(
+  fetchedCalendars: Record<string, Calendar>,
+  existingCalendars: Record<string, Calendar>
+): Record<string, Calendar> {
+  const importedCalendars: Record<string, Calendar> = {}
+
+  const fetchedIds = new Set(Object.keys(fetchedCalendars))
+  const existingIds = new Set(Object.keys(existingCalendars))
+
+  const added = [...fetchedIds].filter(id => !existingIds.has(id))
+
+  existingIds.forEach(id => {
+    if (fetchedIds.has(id)) {
+      const existingCal = existingCalendars[id]
+      const fetchedCal = fetchedCalendars[id]
+
+      if (fetchedCal) {
+        importedCalendars[id] = {
+          ...fetchedCal,
+          events: existingCal.events || {}
+        }
+      }
+    }
+  })
+
+  // Add new calendars
+  added.forEach(id => {
+    importedCalendars[id] = fetchedCalendars[id]
+  })
+
+  return importedCalendars
+}

--- a/src/features/Calendars/services/getTempCalendarsListAsync.ts
+++ b/src/features/Calendars/services/getTempCalendarsListAsync.ts
@@ -5,7 +5,8 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import { fetchCalendars } from '../CalendarDAO'
 import { Calendar } from '../CalendarTypes'
 import { RejectedError } from '../types/RejectedError'
-import { fetchOwnerData } from './helpers'
+import { CalendarData, CalendarList } from '../types/CalendarData'
+import { getOwnerOrResourceData } from './helpers'
 
 export const getTempCalendarsListAsync = createAsyncThunk<
   Record<string, Calendar>,
@@ -13,58 +14,14 @@ export const getTempCalendarsListAsync = createAsyncThunk<
   { rejectValue: RejectedError }
 >('calendars/getTempCalendars', async (tempUser, { rejectWithValue }) => {
   try {
+    const openpaasId = getValidOpenPaasId(tempUser)
+    const calendars = await fetchCalendars(openpaasId, 'sharedPublic=true&')
+    const rawCalendars = getRawCalendars(calendars, tempUser)
+
     const importedCalendars: Record<string, Calendar> = {}
-    if (!tempUser.openpaasId) {
-      const username = tempUser.displayName || tempUser.email || 'User'
-      throw new Error(
-        `TRANSLATION:calendar.userDoesNotHaveValidId|name=${encodeURIComponent(username)}`
-      )
-    }
-    const calendars = await fetchCalendars(
-      tempUser.openpaasId,
-      'sharedPublic=true&'
-    )
-
-    const rawCalendars = calendars._embedded?.['dav:calendar']
-    if (!rawCalendars || rawCalendars.length === 0) {
-      const userName = tempUser.displayName || tempUser.email || 'User'
-      // Format: TRANSLATION:key|param1=value1
-      const encodedName = encodeURIComponent(userName)
-      throw new Error(
-        `TRANSLATION:calendar.userDoesNotHavePublicCalendars|name=${encodedName}`
-      )
-    }
-
     for (const cal of rawCalendars) {
-      const name = cal['dav:name'] ?? ''
-      const description = cal['caldav:description'] ?? ''
-      const delegated = cal['calendarserver:delegatedsource'] ? true : false
-      const source = cal['calendarserver:source']
-        ? cal['calendarserver:source']._links.self?.href
-        : cal._links.self?.href
-      if (!source) {
-        throw new Error('No source for calendar')
-      }
-      const link = cal._links.self?.href ?? ''
-
-      const id = source.replace('/calendars/', '').replace('.json', '')
-      const visibility = getCalendarVisibility(cal['acl'] ?? [])
-      const ownerData = await fetchOwnerData(id.split('/')[0])
-
-      importedCalendars[id] = {
-        id,
-        name,
-        link,
-        owner: ownerData,
-        description,
-        delegated,
-        color: {
-          light: tempUser.color?.light ?? '#a8a8a8ff',
-          dark: tempUser.color?.dark ?? '#a8a8a8ff'
-        },
-        visibility,
-        events: {}
-      }
+      const tempCal = await processTempCalendar(cal, tempUser)
+      importedCalendars[tempCal.id] = tempCal
     }
 
     return importedCalendars
@@ -76,3 +33,67 @@ export const getTempCalendarsListAsync = createAsyncThunk<
     })
   }
 })
+
+function getValidOpenPaasId(tempUser: User): string {
+  if (!tempUser.openpaasId) {
+    const username = tempUser.displayName || tempUser.email || 'User'
+    throw new Error(
+      `TRANSLATION:calendar.userDoesNotHaveValidId|name=${encodeURIComponent(username)}`
+    )
+  }
+  return tempUser.openpaasId
+}
+
+function getRawCalendars(
+  calendars: CalendarList,
+  tempUser: User
+): CalendarData[] {
+  const rawCalendars = calendars._embedded?.['dav:calendar']
+  if (!rawCalendars || rawCalendars.length === 0) {
+    const userName = tempUser.displayName || tempUser.email || 'User'
+    const encodedName = encodeURIComponent(userName)
+    throw new Error(
+      `TRANSLATION:calendar.userDoesNotHavePublicCalendars|name=${encodedName}`
+    )
+  }
+  return rawCalendars
+}
+
+function getCalendarSource(cal: CalendarData): string {
+  const source = cal['calendarserver:source']
+    ? cal['calendarserver:source']._links.self?.href
+    : cal._links.self?.href
+  if (!source) {
+    throw new Error('No source for calendar')
+  }
+  return source
+}
+
+function getCalendarColor(tempUser: User): { light: string; dark: string } {
+  return {
+    light: tempUser.color?.light ?? '#a8a8a8ff',
+    dark: tempUser.color?.dark ?? '#a8a8a8ff'
+  }
+}
+
+async function processTempCalendar(
+  cal: CalendarData,
+  tempUser: User
+): Promise<Calendar> {
+  const source = getCalendarSource(cal)
+  const id = source.replace('/calendars/', '').replace('.json', '')
+  const isResource = tempUser.objectType === 'resource'
+  const ownerData = await getOwnerOrResourceData(id.split('/')[0], isResource)
+
+  return {
+    id,
+    name: cal['dav:name'] ?? '',
+    link: cal._links.self?.href ?? '',
+    owner: ownerData,
+    description: cal['caldav:description'] ?? '',
+    delegated: !!cal['calendarserver:delegatedsource'],
+    color: getCalendarColor(tempUser),
+    visibility: getCalendarVisibility(cal['acl'] ?? []),
+    events: {}
+  }
+}

--- a/src/features/Calendars/services/helpers.ts
+++ b/src/features/Calendars/services/helpers.ts
@@ -1,6 +1,8 @@
 import { fetchResourceById } from '@/features/User/ResourceDAO'
 import { OpenPaasUserData } from '@/features/User/type/OpenPaasUserData'
 import { getUserDetails } from '@/features/User/userAPI'
+import { CalendarData } from '../types/CalendarData'
+import { CalendarInvite } from '../CalendarTypes'
 
 export const fetchOwnerOfResource = async (
   resourceId: string
@@ -30,18 +32,48 @@ export const fetchOwnerData = async (
     const owner = await getUserDetails(ownerId)
     return owner
   } catch (error) {
-    const status = (error as { response?: { status?: number } }).response
-      ?.status
-
-    if (status === 404) {
-      const owner = await fetchOwnerOfResource(ownerId)
-      return {
-        ...owner,
-        resource: true
-      }
-    }
-
     console.error(`Failed to fetch user details for ${ownerId}:`, error)
     throw error
   }
+}
+
+export function isResourceCalendar(cal: CalendarData): boolean {
+  return (
+    (cal.invite ??
+      (
+        cal['calendarserver:source'] as unknown as {
+          invite: CalendarInvite[]
+        }
+      )?.invite ??
+      []) as Array<{
+      href: string
+      access: number
+    }>
+  ).some(inv => inv.access === 1 && inv.href?.includes('principals/resources'))
+}
+
+export function extractResourceOwnerIds(
+  normalizedCalendars: Array<{ cal: CalendarData; ownerId?: string }>
+): Set<string> {
+  const resourceOwnerIds = new Set<string>()
+  normalizedCalendars.forEach(({ cal, ownerId }) => {
+    if (isResourceCalendar(cal) && ownerId) {
+      resourceOwnerIds.add(ownerId)
+    }
+  })
+  return resourceOwnerIds
+}
+
+export async function getOwnerOrResourceData(
+  ownerId: string,
+  isResource?: boolean
+): Promise<OpenPaasUserData> {
+  if (isResource) {
+    const owner = await fetchOwnerOfResource(ownerId)
+    return {
+      ...owner,
+      resource: true
+    }
+  }
+  return fetchOwnerData(ownerId)
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/962

Remove the fallback when getting the owner of resources in getCalendarListAsync and getTempCalendarListAsync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for calendar owner and resource data fetching, with better fallback behavior and error messages when lookups fail.

* **Refactor**
  * Restructured calendar data processing logic to better distinguish between resource and regular calendars, centralizing color derivation and field mapping.

* **Tests**
  * Expanded test coverage for owner/resource data fetching scenarios and error propagation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->