### PR TITLE
[#988] fix delegated calendar are properly parsed at first read

### DIFF
--- a/common/src/features/Calendars/CalendarDAO.ts
+++ b/common/src/features/Calendars/CalendarDAO.ts
@@ -1,7 +1,7 @@
+import { Calendar } from '@common/types/CalendarTypes'
 import { api } from '@common/utils/apiUtils'
-import { CalendarList } from './types/CalendarData'
-import { Calendar } from './CalendarTypes'
 import { DavSyncResponse } from './types/CalendarApiTypes'
+import { CalendarList } from './types/CalendarData'
 
 export async function fetchCalendars(
   userId: string,

--- a/common/src/features/Calendars/services/addSharedCalendarAsync.ts
+++ b/common/src/features/Calendars/services/addSharedCalendarAsync.ts
@@ -1,4 +1,7 @@
-import { calendarAction } from '@common/features/Calendars/CalendarDAO'
+import {
+  calendarAction,
+  fetchCalendars
+} from '@common/features/Calendars/CalendarDAO'
 import { makeAddSharedCalendarBody } from '@common/features/Calendars/transformers'
 import { CalendarInput } from '@common/features/Calendars/types/CalendarData'
 import { RejectedError } from '@common/features/Calendars/types/RejectedError'
@@ -19,6 +22,7 @@ export const addSharedCalendarThunk = (
       link: string
       name: string
       desc: string
+      delegated: boolean
       owner: OpenPaasUserData
     },
     { userId: string; calId: string; cal: CalendarInput },
@@ -43,14 +47,22 @@ export const addSharedCalendarThunk = (
         } catch (e) {
           console.error('Error while fetching owner of shared calendar: ', e)
         }
+        const calendars = await fetchCalendars(userId)
+        const delegated = calendars._embedded['dav:calendar'].find(
+          c => c['calendarserver:delegatedsource'] === cal.cal._links.self?.href
+        )
+
         return {
           calId: cal.cal._links.self?.href
             ?.replace('/calendars/', '')
             .replace('.json', ''),
           color: cal.color,
-          link: `/calendars/${userId}/${calId}.json`,
+          link:
+            delegated?._links.self?.href ??
+            `/calendars/${userId}/${calId}.json`,
           desc: cal.cal['caldav:description'] ?? '',
           name: cal.cal['dav:name'] ?? '',
+          delegated: !!delegated,
           owner: ownerData
         }
       } catch (err) {
@@ -68,6 +80,7 @@ export const addSharedCalendarThunk = (
           id: action.payload.calId,
           link: action.payload.link,
           description: action.payload.desc,
+          delegated: action.payload.delegated,
           name: action.payload.name,
           events: {},
           owner: action.payload.owner

--- a/common/src/features/Calendars/services/getCalendarsListAsync.ts
+++ b/common/src/features/Calendars/services/getCalendarsListAsync.ts
@@ -189,19 +189,20 @@ function buildFetchedCalendars(
           inviteStatus: number
         }>
       ).filter((inv): inv is CalendarInvite => [2, 3, 5].includes(inv.access))
-
-      fetchedCalendars[id] = {
-        id,
-        name: cal['dav:name'] ?? '',
-        link: link ?? '',
-        owner: ownerData,
-        description,
-        delegated,
-        color,
-        visibility,
-        access,
-        events: {},
-        invite
+      if (!fetchedCalendars[id] || delegated) {
+        fetchedCalendars[id] = {
+          id,
+          name: cal['dav:name'] ?? '',
+          link: link ?? '',
+          owner: ownerData,
+          description,
+          delegated,
+          color,
+          visibility,
+          access,
+          events: {},
+          invite
+        }
       }
     }
   )


### PR DESCRIPTION
resolves #988 

For now we fetch the whole calendar list to get the calendar delegated source. I tried getting the calendar data via a simple get with the same scope as the list (that returns me the delegated source in the calendar data) but it didn't provide me the delegated source needed to register properly as a delegated calendar.