### PR TITLE
[#990] added chips for attachements

### DIFF
--- a/common/src/components/Event/InfoRow.tsx
+++ b/common/src/components/Event/InfoRow.tsx
@@ -42,35 +42,36 @@ export function InfoRow({
       }}
     >
       {icon}
-      {content ? (
-        content
-      ) : (
-        <Typography
-          variant="body2"
-          color={error ? 'error' : 'textPrimary'}
-          sx={{
-            whiteSpace: 'pre-line',
-            maxHeight: isMobile ? 'none' : '33vh',
-            overflowY: isMobile ? undefined : 'auto',
-            width: '100%',
-            overflowWrap: 'break-word',
-            ...style
-          }}
-        >
-          {data ? (
-            <Link
-              href={data}
-              target="_blank"
-              rel="noopener noreferrer"
-              underline="always"
-            >
-              {text}
-            </Link>
-          ) : text ? (
-            detectUrls(text)
-          ) : null}
-        </Typography>
-      )}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        {text && (
+          <Typography
+            variant="body2"
+            color={error ? 'error' : 'textPrimary'}
+            sx={{
+              whiteSpace: 'pre-line',
+              maxHeight: isMobile ? 'none' : '33vh',
+              overflowY: isMobile ? undefined : 'auto',
+              width: '100%',
+              overflowWrap: 'break-word',
+              ...style
+            }}
+          >
+            {data ? (
+              <Link
+                href={data}
+                target="_blank"
+                rel="noopener noreferrer"
+                underline="always"
+              >
+                {text}
+              </Link>
+            ) : text ? (
+              detectUrls(text)
+            ) : null}
+          </Typography>
+        )}
+        {content && content}
+      </Box>
     </Box>
   )
 }

--- a/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
@@ -2,7 +2,6 @@ import { Attachment } from '@common/types/EventsTypes'
 import { Link, radius } from '@linagora/twake-mui'
 import { Box, Typography } from '@linagora/twake-mui'
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
-import { useI18n } from 'twake-i18n'
 
 const chipStyle = {
   display: 'inline-flex',
@@ -44,21 +43,5 @@ export const AttachementChip: React.FC<{
         </Typography>
       </Box>
     </Link>
-  )
-}
-
-export const MoreAttachementChip: React.FC<{
-  count: number
-  onClick: () => void
-  showMore: boolean
-}> = ({ count, onClick, showMore }) => {
-  const { t } = useI18n()
-  return (
-    <Box sx={{ ...chipStyle }} onClick={onClick}>
-      <Typography noWrap variant="body1" sx={{ maxWidth: 160 }}>
-        {!showMore && t('eventPreview.attachment.more', { count: count })}
-        {showMore && '-'}
-      </Typography>
-    </Box>
   )
 }

--- a/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
@@ -1,0 +1,64 @@
+import { Attachment } from '@common/types/EventsTypes'
+import { Link, radius } from '@linagora/twake-mui'
+import { Box, Typography } from '@linagora/twake-mui'
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile'
+import { useI18n } from 'twake-i18n'
+
+const chipStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 1,
+  border: '1px solid',
+  borderColor: 'divider',
+  borderRadius: radius.sm,
+  px: 1,
+  py: 0.5,
+  cursor: 'pointer',
+  '&:hover': {
+    backgroundColor: 'action.hover'
+  },
+  height: '44px'
+}
+
+export const AttachementChip: React.FC<{
+  attachment: Attachment
+}> = ({ attachment }) => {
+  return (
+    <Link
+      key={`${attachment.uri}`}
+      href={attachment.uri}
+      target="_blank"
+      rel="noopener noreferrer"
+      underline="none"
+      sx={{
+        textDecoration: 'none',
+        '&:hover': {
+          textDecoration: 'none'
+        }
+      }}
+    >
+      <Box sx={{ ...chipStyle, width: '150px' }}>
+        <InsertDriveFileIcon fontSize="small" />
+        <Typography noWrap variant="body1" sx={{ maxWidth: 160 }}>
+          {attachment.x_filename ?? ''}
+        </Typography>
+      </Box>
+    </Link>
+  )
+}
+
+export const MoreAttachementChip: React.FC<{
+  count: number
+  onClick: () => void
+  showMore: boolean
+}> = ({ count, onClick, showMore }) => {
+  const { t } = useI18n()
+  return (
+    <Box sx={{ ...chipStyle }} onClick={onClick}>
+      <Typography noWrap variant="body1" sx={{ maxWidth: 160 }}>
+        {!showMore && t('eventPreview.attachment.more', { count: count })}
+        {showMore && '-'}
+      </Typography>
+    </Box>
+  )
+}

--- a/common/src/components/EventPreview/AttachementPreview/index.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/index.tsx
@@ -1,6 +1,6 @@
 import { Attachment } from '@common/types/EventsTypes'
 import { Box, Button } from '@linagora/twake-mui'
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { AttachementChip } from './AttachementChip'
 
@@ -16,7 +16,7 @@ export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
   const { t } = useI18n()
   const [showAllAttachments, setShowAllAttachments] = useState(false)
 
-  if (!attachments || attachments.length === 0) {
+  if (!attachments?.length) {
     return null
   }
 
@@ -24,19 +24,12 @@ export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
     <Box
       sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, alignItems: 'center' }}
     >
-      {attachments
-        .slice(0, ATTACHMENT_DISPLAY_LIMIT)
-        .map((attachment, index) => (
-          <AttachementChip
-            key={`${attachment.uri}-${index}`}
-            attachment={attachment}
-          />
-        ))}
+      {renderAttachments({ attachments, slice: 'first' })}
       {attachments.length > ATTACHMENT_DISPLAY_LIMIT && (
         <Button
           variant="text"
           size="small"
-          sx={{ fontSize: '14px', color: 'text.secondary' }}
+          sx={{ color: 'text.secondary' }}
           onClick={() => setShowAllAttachments(!showAllAttachments)}
         >
           {showAllAttachments
@@ -44,15 +37,24 @@ export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
             : t('eventPreview.showMore')}
         </Button>
       )}
-      {showAllAttachments &&
-        attachments
-          .slice(ATTACHMENT_DISPLAY_LIMIT)
-          .map((attachment, index) => (
-            <AttachementChip
-              key={`${attachment.uri}-${ATTACHMENT_DISPLAY_LIMIT + index}`}
-              attachment={attachment}
-            />
-          ))}
+      {showAllAttachments && renderAttachments({ attachments, slice: 'rest' })}
     </Box>
   )
+}
+
+const renderAttachments: React.FC<{
+  attachments: Attachment[]
+  slice: 'first' | 'rest'
+}> = ({ attachments, slice }) => {
+  const sliced =
+    slice === 'first'
+      ? attachments.slice(0, ATTACHMENT_DISPLAY_LIMIT)
+      : attachments.slice(ATTACHMENT_DISPLAY_LIMIT)
+
+  return sliced.map((attachment, index) => (
+    <AttachementChip
+      key={`${attachment.uri}-${slice === 'rest' ? ATTACHMENT_DISPLAY_LIMIT + index : index}`}
+      attachment={attachment}
+    />
+  ))
 }

--- a/common/src/components/EventPreview/AttachementPreview/index.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/index.tsx
@@ -1,7 +1,10 @@
 import { Attachment } from '@common/types/EventsTypes'
-import { Box } from '@linagora/twake-mui'
+import { Box, Button } from '@linagora/twake-mui'
 import { useState } from 'react'
-import { AttachementChip, MoreAttachementChip } from './AttachementChip'
+import { useI18n } from 'twake-i18n'
+import { AttachementChip } from './AttachementChip'
+
+const ATTACHMENT_DISPLAY_LIMIT = 2
 
 interface AttachementPreviewProps {
   attachments: Attachment[]
@@ -10,38 +13,46 @@ interface AttachementPreviewProps {
 export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
   attachments
 }) => {
+  const { t } = useI18n()
   const [showAllAttachments, setShowAllAttachments] = useState(false)
+
   if (!attachments || attachments.length === 0) {
     return null
   }
+
   return (
     <Box
-      sx={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 1
-      }}
+      sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, alignItems: 'center' }}
     >
-      {!showAllAttachments && (
-        <>
-          <AttachementChip attachment={attachments[0]} />
-          <AttachementChip attachment={attachments[1]} />
-        </>
+      {attachments
+        .slice(0, ATTACHMENT_DISPLAY_LIMIT)
+        .map((attachment, index) => (
+          <AttachementChip
+            key={`${attachment.uri}-${index}`}
+            attachment={attachment}
+          />
+        ))}
+      {attachments.length > ATTACHMENT_DISPLAY_LIMIT && (
+        <Button
+          variant="text"
+          size="small"
+          sx={{ fontSize: '14px', color: 'text.secondary' }}
+          onClick={() => setShowAllAttachments(!showAllAttachments)}
+        >
+          {showAllAttachments
+            ? t('eventPreview.showLess')
+            : t('eventPreview.showMore')}
+        </Button>
       )}
       {showAllAttachments &&
-        attachments.map((attachment, index) => {
-          return (
+        attachments
+          .slice(ATTACHMENT_DISPLAY_LIMIT)
+          .map((attachment, index) => (
             <AttachementChip
-              key={`${attachment.uri}-${index}`}
+              key={`${attachment.uri}-${ATTACHMENT_DISPLAY_LIMIT + index}`}
               attachment={attachment}
             />
-          )
-        })}
-      <MoreAttachementChip
-        count={attachments.length - 2}
-        showMore={showAllAttachments}
-        onClick={() => setShowAllAttachments(!showAllAttachments)}
-      />
+          ))}
     </Box>
   )
 }

--- a/common/src/components/EventPreview/AttachementPreview/index.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/index.tsx
@@ -1,0 +1,47 @@
+import { Attachment } from '@common/types/EventsTypes'
+import { Box } from '@linagora/twake-mui'
+import { useState } from 'react'
+import { AttachementChip, MoreAttachementChip } from './AttachementChip'
+
+interface AttachementPreviewProps {
+  attachments: Attachment[]
+}
+
+export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
+  attachments
+}) => {
+  const [showAllAttachments, setShowAllAttachments] = useState(false)
+  if (!attachments || attachments.length === 0) {
+    return null
+  }
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1
+      }}
+    >
+      {!showAllAttachments && (
+        <>
+          <AttachementChip attachment={attachments[0]} />
+          <AttachementChip attachment={attachments[1]} />
+        </>
+      )}
+      {showAllAttachments &&
+        attachments.map((attachment, index) => {
+          return (
+            <AttachementChip
+              key={`${attachment.uri}-${index}`}
+              attachment={attachment}
+            />
+          )
+        })}
+      <MoreAttachementChip
+        count={attachments.length - 2}
+        showMore={showAllAttachments}
+        onClick={() => setShowAllAttachments(!showAllAttachments)}
+      />
+    </Box>
+  )
+}

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -1,4 +1,7 @@
+import { VideoLink } from '@common/components/Event/components/VideoLink'
 import { InfoRow } from '@common/components/Event/InfoRow'
+import { userAttendee } from '@common/features/User/models/attendee'
+import { Attachment, RepetitionObject } from '@common/types/EventsTypes'
 import { Box, Typography, useTheme } from '@linagora/twake-mui'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined'
@@ -9,12 +12,10 @@ import SubjectIcon from '@mui/icons-material/Subject'
 import VideocamOutlinedIcon from '@mui/icons-material/VideocamOutlined'
 import React from 'react'
 import { useI18n } from 'twake-i18n'
-import { VideoLink } from '@common/components/Event/components/VideoLink'
-import { makeRecurrenceString } from './utils/makeRecurrenceString'
-import { translateDuration, translateAlarmAction } from './utils/parseDuration'
-import { userAttendee } from '@common/features/User/models/attendee'
+import { AttachementPreview } from './AttachementPreview'
 import { infoIconSx } from './EventPreviewDetails'
-import { RepetitionObject } from '@common/types/EventsTypes'
+import { makeRecurrenceString } from './utils/makeRecurrenceString'
+import { translateAlarmAction, translateDuration } from './utils/parseDuration'
 
 interface BaseEventRowProps {
   icon: React.ReactNode
@@ -135,14 +136,19 @@ export const EventResourceRow: React.FC<{
 
 export const EventDescriptionRow: React.FC<{
   description?: string
-}> = ({ description }) => {
-  if (!description) return null
+  attach?: Attachment[]
+}> = ({ description, attach }) => {
+  if (!(description || attach)) return null
   return (
     <BaseEventRow
       alignItems="flex-start"
       alignSelf="flex-start"
       icon={<SubjectIcon />}
       text={description}
+      content={
+        attach &&
+        attach.length > 0 && <AttachementPreview attachments={attach} />
+      }
     />
   )
 }

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -138,7 +138,7 @@ export const EventDescriptionRow: React.FC<{
   description?: string
   attach?: Attachment[]
 }> = ({ description, attach }) => {
-  if (!(description || attach)) return null
+  if (!(description || !!attach?.length)) return null
   return (
     <BaseEventRow
       alignItems="flex-start"

--- a/common/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/common/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -147,7 +147,6 @@ export function EventPreviewAttendees({
                 size="small"
                 sx={{
                   marginLeft: 2,
-                  fontSize: '14px',
                   color: 'text.secondary',
                   alignSelf: 'center'
                 }}
@@ -164,7 +163,6 @@ export function EventPreviewAttendees({
               size="small"
               sx={{
                 marginLeft: 2,
-                fontSize: '14px',
                 color: 'text.secondary',
                 alignSelf: 'center'
               }}

--- a/common/src/components/EventPreview/EventPreviewDetails.tsx
+++ b/common/src/components/EventPreview/EventPreviewDetails.tsx
@@ -90,7 +90,10 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
 
       <EventResourceRow resources={resources} />
 
-      <EventDescriptionRow description={event.description} />
+      <EventDescriptionRow
+        description={event.description}
+        attach={event.attach}
+      />
 
       <EventAlarmRow alarm={event.alarm} />
 

--- a/common/src/features/Events/utils/parseCalendarEvent.ts
+++ b/common/src/features/Events/utils/parseCalendarEvent.ts
@@ -208,6 +208,14 @@ const PROPERTY_PARSERS: Record<
   },
   rrule: (params, value, event) => {
     parseRruleProperty(value, event)
+  },
+  attach: (params, value, event) => {
+    if (!event.attach) event.attach = []
+    event.attach.push({
+      uri: safeString(value),
+      fmttype: params.fmttype,
+      x_filename: params['x-filename']
+    })
   }
 }
 

--- a/common/src/features/Events/utils/parseCalendarEvent.ts
+++ b/common/src/features/Events/utils/parseCalendarEvent.ts
@@ -210,11 +210,12 @@ const PROPERTY_PARSERS: Record<
     parseRruleProperty(value, event)
   },
   attach: (params, value, event) => {
+    const paramsObj = (params ?? {}) as Record<string, string | undefined>
     if (!event.attach) event.attach = []
     event.attach.push({
       uri: safeString(value),
-      fmttype: params.fmttype,
-      x_filename: params['x-filename']
+      fmttype: paramsObj.fmttype,
+      x_filename: paramsObj['x-filename']
     })
   }
 }

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -308,6 +308,9 @@
       "tooltipOwn": "Only you and attendees can see the details of this event.",
       "hiddenDetails": "This is a private event. Details are hidden."
     },
+    "attachment": {
+      "more": "+ %{count} more"
+    },
     "free": {
       "label": "Free",
       "tooltip": "Others see you as available during the time range of this event."

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -308,9 +308,6 @@
       "tooltipOwn": "Only you and attendees can see the details of this event.",
       "hiddenDetails": "This is a private event. Details are hidden."
     },
-    "attachment": {
-      "more": "+ %{count} more"
-    },
     "free": {
       "label": "Free",
       "tooltip": "Others see you as available during the time range of this event."

--- a/common/src/types/EventsTypes.ts
+++ b/common/src/types/EventsTypes.ts
@@ -31,6 +31,13 @@ export interface CalendarEvent {
   exdates?: string[]
   passthroughProps?: VObjectProperty[]
   selectedResources?: Resource[]
+  attach?: Attachment[]
+}
+
+export interface Attachment {
+  uri: string
+  fmttype?: string
+  x_filename?: string
 }
 
 export interface RepetitionObject {


### PR DESCRIPTION
resolves #990

<img width="582" height="421" alt="image" src="https://github.com/user-attachments/assets/ff0d7f59-1418-445d-8797-8478872d0191" />

<img width="585" height="477" alt="image" src="https://github.com/user-attachments/assets/29926576-a773-4152-901c-ce6aa7328188" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events now display attached files in event previews with clickable links and file icons
  * Attachment list includes truncated filenames for readability
  * Expandable "show more/less" toggle for events with multiple attachments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->