### PR TITLE
[#1008] improved input field behavior for people search

### DIFF
--- a/__test__/components/PeopleSearch.test.tsx
+++ b/__test__/components/PeopleSearch.test.tsx
@@ -376,6 +376,89 @@ describe('PeopleSearch', () => {
       // Single email should NOT trigger multi-paste handler
       expect(onChange).not.toHaveBeenCalled()
     })
+
+    it('adds a single valid email on paste when enableEmailAutocompleteAndCommit is true', async () => {
+      const { onChange } = setup([], {
+        freeSolo: true,
+        enableEmailAutocompleteAndCommit: true
+      })
+      const input = screen.getByRole('combobox')
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => 'pasted@example.com'
+        }
+      })
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: 'pasted@example.com' })
+          ])
+        )
+      })
+    })
+
+    it('clears input after pasting a single email with enableEmailAutocompleteAndCommit', async () => {
+      const { onChange } = setup([], {
+        freeSolo: true,
+        enableEmailAutocompleteAndCommit: true
+      })
+      const input = screen.getByRole('combobox')
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => 'pasted@example.com'
+        }
+      })
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled()
+      })
+
+      expect(input).toHaveValue('')
+    })
+
+    it('does not add duplicate email on paste with enableEmailAutocompleteAndCommit', async () => {
+      const existing: User = {
+        email: 'already@example.com',
+        displayName: 'Already Present'
+      }
+      const { onChange } = setup([existing], {
+        freeSolo: true,
+        enableEmailAutocompleteAndCommit: true
+      })
+      const input = screen.getByRole('combobox')
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => 'already@example.com'
+        }
+      })
+
+      // onChange should not be called because email is already present
+      expect(onChange).not.toHaveBeenCalled()
+      // Input should be cleared
+      expect(input).toHaveValue('')
+    })
+
+    it('does not add invalid single email on paste even with enableEmailAutocompleteAndCommit', async () => {
+      const { onChange } = setup([], {
+        freeSolo: true,
+        enableEmailAutocompleteAndCommit: true
+      })
+      const input = screen.getByRole('combobox')
+
+      fireEvent.paste(input, {
+        clipboardData: {
+          getData: () => 'not-an-email'
+        }
+      })
+
+      // onChange should not be called for invalid email
+      expect(onChange).not.toHaveBeenCalled()
+    })
   })
 
   it('retains input value when field loses focus (blur)', async () => {
@@ -453,6 +536,57 @@ describe('PeopleSearch', () => {
 
       expect(onChange).not.toHaveBeenCalled()
       expect(input).toHaveValue('space@example.com')
+    })
+
+    it('selects highlighted option on Enter key press', async () => {
+      mockedSearchUsers.mockResolvedValueOnce([baseUser])
+      const { onChange } = setup([], { enableEmailAutocompleteAndCommit: true })
+
+      const input = screen.getByRole('combobox')
+      await userEvent.type(input, 'Test')
+      await act(async () => {
+        jest.advanceTimersByTime(300)
+      })
+
+      // Wait for options to appear
+      await waitFor(() => {
+        expect(screen.getByText('Test User')).toBeInTheDocument()
+      })
+
+      // Press Enter to select the highlighted option
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.arrayContaining([
+            expect.objectContaining({ email: 'test@example.com' })
+          ])
+        )
+      })
+    })
+
+    it('clears input after selecting with Enter key', async () => {
+      mockedSearchUsers.mockResolvedValueOnce([baseUser])
+      const { onChange } = setup([], { enableEmailAutocompleteAndCommit: true })
+
+      const input = screen.getByRole('combobox')
+      await userEvent.type(input, 'Test')
+      await act(async () => {
+        jest.advanceTimersByTime(300)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Test User')).toBeInTheDocument()
+      })
+
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled()
+      })
+
+      expect(input).toHaveValue('')
     })
   })
 })

--- a/common/src/components/Attendees/PeopleSearch.tsx
+++ b/common/src/components/Attendees/PeopleSearch.tsx
@@ -1,36 +1,37 @@
+import { SearchState } from '@common/components/Calendar/utils/tempSearchUtil'
 import { SnackbarAlert } from '@common/components/Loading/SnackBarAlert'
 import {
   Autocomplete,
+  AutocompleteProps,
+  Box,
   PaperProps,
   PopperProps,
-  Box,
   SxProps,
-  type AutocompleteRenderInputParams,
-  AutocompleteProps
+  type AutocompleteRenderInputParams
 } from '@linagora/twake-mui'
-import { AttendeeOptionsList } from './AttendeeOptionsList'
 import {
   HTMLAttributes,
   ReactElement,
   SyntheticEvent,
+  useRef,
   type ReactNode
 } from 'react'
 import { useI18n } from 'twake-i18n'
-import { User } from './types'
 import { AttendeeChip, type AttendeeChipProps } from './AttendeeChip'
-import { SearchState } from '@common/components/Calendar/utils/tempSearchUtil'
-import {
-  usePeopleSearchState,
-  normaliseUser,
-  dedupeByEmail
-} from './usePeopleSearchState'
+import { AttendeeOptionsList } from './AttendeeOptionsList'
 import {
   PeopleSearchInput,
   type ExtendedAutocompleteRenderInputParams
 } from './PeopleSearchInput'
+import { User } from './types'
+import {
+  dedupeByEmail,
+  normaliseUser,
+  usePeopleSearchState
+} from './usePeopleSearchState'
 
+export { dedupeByEmail, normaliseUser }
 export type { ExtendedAutocompleteRenderInputParams }
-export { normaliseUser, dedupeByEmail }
 
 export interface PeopleSearchProps {
   selectedUsers: User[]
@@ -148,6 +149,7 @@ interface RenderInputParams {
   searchPlaceholder: string
   inputSlot: PeopleSearchProps['inputSlot']
   enableEmailAutocompleteAndCommit?: boolean
+  onEnterKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 const renderPeopleSearchInput = ({
@@ -157,7 +159,8 @@ const renderPeopleSearchInput = ({
   onToggleEventPreview,
   searchPlaceholder,
   inputSlot,
-  enableEmailAutocompleteAndCommit
+  enableEmailAutocompleteAndCommit,
+  onEnterKeyDown
 }: RenderInputParams): ReactNode => {
   if (customRenderInput) {
     return customRenderInput(params, searchState.query, searchState.setQuery)
@@ -175,6 +178,7 @@ const renderPeopleSearchInput = ({
       onKeyDown={
         enableEmailAutocompleteAndCommit ? searchState.handleKeyDown : undefined
       }
+      onEnterKeyDown={onEnterKeyDown}
     />
   )
 }
@@ -213,6 +217,8 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
     enableEmailAutocompleteAndCommit
   })
 
+  const highlightedOptionRef = useRef<User | null>(null)
+
   const isOpenOptions = resolveIsOpen({
     hideOptions,
     isOpen: searchState.isOpen,
@@ -223,6 +229,31 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
     hasCustomRenderInput: !!customRenderInput
   })
 
+  const handleHighlightChange = (
+    _event: SyntheticEvent,
+    option: User | null
+  ): void => {
+    highlightedOptionRef.current = option
+  }
+
+  const handleEnterKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ): void => {
+    if (event.key !== 'Enter') return
+    const hasHighlightedOption =
+      highlightedOptionRef.current && searchState.options.length > 0
+    // If dropdown is open and there's a highlighted option, select it
+    if (isOpenOptions && hasHighlightedOption) {
+      event.preventDefault()
+      searchState.handleAutocompleteChange(event, [
+        ...selectedUsers,
+        highlightedOptionRef.current
+      ])
+      searchState.setQuery('')
+      highlightedOptionRef.current = null
+    }
+  }
+
   return (
     <>
       <Autocomplete
@@ -231,6 +262,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
         multiple
         options={searchState.options}
         autoComplete={false}
+        autoHighlight
         clearOnBlur={false}
         onBlur={freeSolo ? searchState.handleBlurCommit : undefined}
         open={isOpenOptions}
@@ -249,6 +281,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
         inputValue={searchState.query}
         onInputChange={searchState.handleInputChange}
         onChange={searchState.handleAutocompleteChange}
+        onHighlightChange={handleHighlightChange}
         slotProps={getAutocompleteSlotProps(customSlotProps)}
         forcePopupIcon={false}
         disableClearable
@@ -260,7 +293,8 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
             onToggleEventPreview,
             searchPlaceholder,
             inputSlot,
-            enableEmailAutocompleteAndCommit
+            enableEmailAutocompleteAndCommit,
+            onEnterKeyDown: handleEnterKeyDown
           })
         }
         renderOption={(props, option) => (

--- a/common/src/components/Attendees/PeopleSearchInput.tsx
+++ b/common/src/components/Attendees/PeopleSearchInput.tsx
@@ -26,6 +26,7 @@ export interface PeopleSearchInputProps {
   searchPlaceholder: string
   inputSlot?: (params: ExtendedAutocompleteRenderInputParams) => ReactNode
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
+  onEnterKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 export const PeopleSearchInput: React.FC<PeopleSearchInputProps> = ({
@@ -37,7 +38,8 @@ export const PeopleSearchInput: React.FC<PeopleSearchInputProps> = ({
   inputError,
   searchPlaceholder,
   inputSlot,
-  onKeyDown
+  onKeyDown,
+  onEnterKeyDown
 }) => {
   const { t } = useI18n()
 
@@ -71,6 +73,11 @@ export const PeopleSearchInput: React.FC<PeopleSearchInputProps> = ({
         if (e.defaultPrevented) return
         params.inputProps.onKeyDown?.(e)
         if (e.key === 'Enter') {
+          // First, try the autocomplete selection handler
+          onEnterKeyDown?.(e)
+          // If event was already handled, don't trigger event preview
+          if (e.defaultPrevented) return
+
           if (onToggleEventPreview && !isOpen) {
             e.preventDefault()
             ;(

--- a/common/src/components/Attendees/usePasteHandler.ts
+++ b/common/src/components/Attendees/usePasteHandler.ts
@@ -9,7 +9,8 @@ export function usePasteHandler({
   onChange,
   setQuery,
   setInputError,
-  t
+  t,
+  enableEmailAutocompleteAndCommit
 }: {
   freeSolo?: boolean
   selectedUsers: User[]
@@ -17,7 +18,8 @@ export function usePasteHandler({
   setQuery: (value: string) => void
   setInputError: (error: string | null) => void
   t: (key: string) => string
-}) {
+  enableEmailAutocompleteAndCommit?: boolean
+}): (event: React.ClipboardEvent<HTMLInputElement>) => void {
   return useCallback(
     (event: React.ClipboardEvent<HTMLInputElement>) => {
       if (!freeSolo) return
@@ -31,8 +33,10 @@ export function usePasteHandler({
         .map(s => s.trim())
         .filter(Boolean)
 
-      // If there is only one chunk, let the default Autocomplete behaviour handle it
-      if (chunks.length <= 1) return
+      if (chunks.length === 0) return
+
+      // Single chunk without enableEmailAutocompleteAndCommit: let the input handle it normally
+      if (chunks.length === 1 && !enableEmailAutocompleteAndCommit) return
 
       event.preventDefault()
 
@@ -65,6 +69,14 @@ export function usePasteHandler({
         setInputError(null)
       }
     },
-    [freeSolo, selectedUsers, onChange, setQuery, setInputError, t]
+    [
+      freeSolo,
+      selectedUsers,
+      onChange,
+      setQuery,
+      setInputError,
+      t,
+      enableEmailAutocompleteAndCommit
+    ]
   )
 }

--- a/common/src/components/Attendees/usePeopleSearchState.ts
+++ b/common/src/components/Attendees/usePeopleSearchState.ts
@@ -344,7 +344,8 @@ const usePeopleSearchHandlers = ({
     onChange,
     setQuery,
     setInputError,
-    t
+    t,
+    enableEmailAutocompleteAndCommit
   })
 
   return {


### PR DESCRIPTION
resolves #1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pressing Enter commits the highlighted autocomplete option and clears the input.
  * Pasting a single valid email into the field auto-commits it as an attendee and clears the input.
  * Duplicate pasted emails are ignored and do not re-add attendees; invalid pasted text is not committed.

* **Tests**
  * Added comprehensive tests for Enter-key commits and single-email paste behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->