### PR TITLE
#1009 display content in schedule view as much as posible

### DIFF
--- a/common/src/components/Calendar/CustomCalendar.styl
+++ b/common/src/components/Calendar/CustomCalendar.styl
@@ -392,6 +392,11 @@ hr.MuiDivider-root.MuiDivider-fullWidth
 .fc-list-table
   border-width 0
   border-collapse collapse
+  display block
+
+  tbody
+    display block
+    width 100%
 
 .fc-list-day
   display none !important
@@ -399,6 +404,8 @@ hr.MuiDivider-root.MuiDivider-fullWidth
 .fc-list-event
   cursor pointer
   transition background-color 0.2s ease
+  width 100%
+  display block
   
   &:hover
     background-color #F8FAFC !important
@@ -423,3 +430,4 @@ hr.MuiDivider-root.MuiDivider-fullWidth
 .fc-list-event-title
   width 100% !important
   padding 0 !important
+  display block

--- a/common/src/components/Event/EventChip/DesktopEventChipSchedule.tsx
+++ b/common/src/components/Event/EventChip/DesktopEventChipSchedule.tsx
@@ -10,7 +10,8 @@ import {
   RenderOrganizer,
   RenderVideoJoin,
   RenderTitle,
-  RenderText
+  RenderLocation,
+  RenderDescription
 } from '@common/features/Search/searchResultsComponents'
 import {
   RenderDayIndicator,
@@ -85,8 +86,8 @@ export const DesktopEventChipSchedule: React.FC<
       />
       <RenderTitle summary={arg.event.title} isRecurrent={isRecurrent} t={t} />
       <RenderOrganizer organizer={ext.organizer} />
-      <RenderText text={ext.location} />
-      <RenderText text={ext.description} />
+      <RenderLocation text={ext.location} />
+      <RenderDescription text={ext.description} />
       <Box sx={{ ml: 'auto', flexShrink: 0 }}>
         <RenderVideoJoin t={t} url={videoUrl} />
       </Box>

--- a/common/src/features/Search/DesktopResultItem.tsx
+++ b/common/src/features/Search/DesktopResultItem.tsx
@@ -8,7 +8,8 @@ import { SearchEventResult } from './types/SearchEventResult'
 import { useEventPreview } from './useEventPreview'
 import {
   RenderDate,
-  RenderText,
+  RenderLocation,
+  RenderDescription,
   RenderOrganizer,
   RenderTime,
   RenderTitle,
@@ -64,19 +65,21 @@ export default function DesktopResultItem({
           }
         }}
       >
-        <RenderDate
-          startDate={startDate}
-          endDate={endDate}
-          t={t}
-          timeZone={timeZone}
-        />
-        <RenderTime
-          startDate={startDate}
-          endDate={endDate}
-          allDay={!!eventData.data.allDay}
-          t={t}
-          timeZone={timeZone}
-        />
+        <Box display="flex" alignItems="center" sx={{ minWidth: '225px' }}>
+          <RenderDate
+            startDate={startDate}
+            endDate={endDate}
+            t={t}
+            timeZone={timeZone}
+          />
+          <RenderTime
+            startDate={startDate}
+            endDate={endDate}
+            allDay={!!eventData.data.allDay}
+            t={t}
+            timeZone={timeZone}
+          />
+        </Box>
         <SquareRoundedIcon
           style={{
             color: calendarColor ?? defaultColors[0].light,
@@ -92,8 +95,8 @@ export default function DesktopResultItem({
           t={t}
         />
         <RenderOrganizer organizer={eventData.data.organizer} />
-        <RenderText text={eventData.data.location} />
-        <RenderText text={eventData.data.description} />
+        <RenderLocation text={eventData.data.location} />
+        <RenderDescription text={eventData.data.description} />
         <RenderVideoJoin
           t={t}
           url={eventData.data['x-openpaas-videoconference']}

--- a/common/src/features/Search/searchResultsComponents.tsx
+++ b/common/src/features/Search/searchResultsComponents.tsx
@@ -127,7 +127,7 @@ export const RenderTitle: React.FC<TitleProps> = ({
         display="flex"
         flexDirection="row"
         gap={1}
-        sx={{ minWidth: 0, width: '150px', alignItems: 'center' }}
+        sx={{ minWidth: 0, flex: '0 0 12%', alignItems: 'center' }}
       >
         <Typography
           sx={{
@@ -135,7 +135,9 @@ export const RenderTitle: React.FC<TitleProps> = ({
             fontSize: '17px',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap'
+            whiteSpace: 'nowrap',
+            flex: 1,
+            minWidth: 0
           }}
         >
           {summary || t('event.untitled')}
@@ -151,7 +153,9 @@ export const RenderTitle: React.FC<TitleProps> = ({
 }
 
 export const RenderOrganizer: React.FC<OrganizerProps> = ({ organizer }) => {
-  if (!organizer?.cn && !organizer?.email) return null
+  if (!organizer?.cn && !organizer?.email) {
+    return <Box sx={{ minWidth: 0, flex: '0 0 20%' }} />
+  }
 
   const organizerName = organizer.cn || organizer.email
 
@@ -162,13 +166,14 @@ export const RenderOrganizer: React.FC<OrganizerProps> = ({ organizer }) => {
           display: 'flex',
           alignItems: 'center',
           gap: 1,
-          minWidth: '150px',
-          maxWidth: '150px'
+          minWidth: 0,
+          maxWidth: '15%',
+          marginRight: 3
         }}
       >
         <Avatar
           alt={organizerName}
-          sx={{ width: 24, height: 24, fontSize: '0.75rem' }}
+          sx={{ width: 24, height: 24, fontSize: '0.75rem', flexShrink: 0 }}
           {...stringAvatar(organizerName || '')}
         />
         <Typography
@@ -177,7 +182,8 @@ export const RenderOrganizer: React.FC<OrganizerProps> = ({ organizer }) => {
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            flex: 1
+            flex: 1,
+            minWidth: 0
           }}
         >
           {organizerName}
@@ -187,7 +193,12 @@ export const RenderOrganizer: React.FC<OrganizerProps> = ({ organizer }) => {
   )
 }
 
-export const RenderText: React.FC<{ text?: string }> = ({ text }) => {
+interface RenderTextProps {
+  text?: string
+  sx?: React.ComponentProps<typeof Typography>['sx']
+}
+
+export const RenderText: React.FC<RenderTextProps> = ({ text, sx }) => {
   if (!text) return null
   return (
     <Typography
@@ -198,12 +209,20 @@ export const RenderText: React.FC<{ text?: string }> = ({ text }) => {
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         minWidth: 0,
-        maxWidth: '200px'
+        ...sx
       }}
     >
       {text.replace(/\n/g, ' ')}
     </Typography>
   )
+}
+
+export const RenderLocation: React.FC<{ text?: string }> = ({ text }) => {
+  return <RenderText text={text} sx={{ flex: '0 1 auto', maxWidth: '20%' }} />
+}
+
+export const RenderDescription: React.FC<{ text?: string }> = ({ text }) => {
+  return <RenderText text={text} sx={{ flex: '1 1 0%' }} />
 }
 
 export const RenderVideoJoin: React.FC<VideoJoinProps> = ({ url, t }) => {


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1009

#### Schedule view

<img width="1919" height="962" alt="image" src="https://github.com/user-attachments/assets/e13afd5d-3bc9-477e-8f34-f4c53f106abc" />

#### Search results

<img width="1919" height="963" alt="image" src="https://github.com/user-attachments/assets/01463a44-1efc-4120-a34e-cde761b2b366" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced FullCalendar List View styling with explicit display rules for improved layout consistency.
  * Refined search result and event chip column layouts to better handle text truncation and alignment across date, time, location, and description fields.

* **Refactor**
  * Updated event rendering to use dedicated components for location and description fields, improving consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->