### PR TITLE
#1016 implement public calendar localization

### DIFF
--- a/__test__/features/excal/PublicLanguageContext.test.tsx
+++ b/__test__/features/excal/PublicLanguageContext.test.tsx
@@ -1,0 +1,101 @@
+import {
+  isValidLanguage,
+  getBrowserLanguage,
+  getDefaultLanguage
+} from '@public/context/PublicLanguageContext'
+
+describe('PublicLanguageContext Localization helpers', () => {
+  let languageSpy: jest.SpyInstance
+  let languagesSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    languageSpy = jest.spyOn(window.navigator, 'language', 'get')
+    languagesSpy = jest.spyOn(window.navigator, 'languages', 'get')
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    ;(window as unknown as { LANG: string | undefined }).LANG = undefined
+  })
+
+  describe('isValidLanguage', () => {
+    it('should return true for supported languages', () => {
+      expect(isValidLanguage('en')).toBe(true)
+      expect(isValidLanguage('fr')).toBe(true)
+      expect(isValidLanguage('ru')).toBe(true)
+      expect(isValidLanguage('vi')).toBe(true)
+    })
+
+    it('should return false for unsupported languages or empty values', () => {
+      expect(isValidLanguage('es')).toBe(false)
+      expect(isValidLanguage('')).toBe(false)
+      expect(isValidLanguage(null)).toBe(false)
+      expect(isValidLanguage(undefined)).toBe(false)
+    })
+  })
+
+  describe('getBrowserLanguage', () => {
+    it('should return primary language code from navigator.language', () => {
+      languageSpy.mockReturnValue('fr-FR')
+      languagesSpy.mockReturnValue(['fr-FR', 'en-US'])
+      expect(getBrowserLanguage()).toBe('fr')
+    })
+
+    it('should fallback to navigator.languages[0] if language is missing', () => {
+      languageSpy.mockReturnValue('')
+      languagesSpy.mockReturnValue(['ru-RU', 'en-US'])
+      expect(getBrowserLanguage()).toBe('ru')
+    })
+
+    it('should return undefined if language info is missing', () => {
+      languageSpy.mockReturnValue(undefined)
+      languagesSpy.mockReturnValue(undefined)
+      expect(getBrowserLanguage()).toBeUndefined()
+    })
+  })
+
+  describe('getDefaultLanguage', () => {
+    beforeEach(() => {
+      ;(window as unknown as { LANG: string | undefined }).LANG = undefined
+      languageSpy.mockReturnValue('en-US')
+    })
+
+    it('should prioritize saved language in localStorage', () => {
+      localStorage.setItem('lang', 'fr')
+      ;(window as unknown as { LANG: string | undefined }).LANG = 'ru'
+      languageSpy.mockReturnValue('vi-VN')
+
+      expect(getDefaultLanguage()).toBe('fr')
+    })
+
+    it('should fallback to browser language if localStorage is not set or invalid', () => {
+      localStorage.removeItem('lang')
+      ;(window as unknown as { LANG: string | undefined }).LANG = 'ru'
+      languageSpy.mockReturnValue('vi-VN')
+
+      expect(getDefaultLanguage()).toBe('vi')
+
+      // Invalid localStorage key
+      localStorage.setItem('lang', 'invalid')
+      expect(getDefaultLanguage()).toBe('vi')
+    })
+
+    it('should fallback to window.LANG if localStorage and browser language are missing or invalid', () => {
+      localStorage.removeItem('lang')
+      ;(window as unknown as { LANG: string | undefined }).LANG = 'ru'
+      languageSpy.mockReturnValue('es-ES') // unsupported
+
+      expect(getDefaultLanguage()).toBe('ru')
+    })
+
+    it('should default to en if everything else is missing or invalid', () => {
+      localStorage.removeItem('lang')
+      ;(window as unknown as { LANG: string | undefined }).LANG = undefined
+      languageSpy.mockReturnValue('es-ES') // unsupported
+
+      expect(getDefaultLanguage()).toBe('en')
+    })
+  })
+})

--- a/apps/public/src/App.tsx
+++ b/apps/public/src/App.tsx
@@ -1,13 +1,12 @@
 import * as Sentry from '@sentry/react'
 import { TwakeMuiThemeProvider } from '@linagora/twake-mui'
-import { Suspense } from 'react'
+import { Suspense, useState } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { HistoryRouter as Router } from 'redux-first-history/rr6'
 import { history } from '@common/app/store'
 import { Error as ErrorPage } from '@common/components/Error/Error'
 import { ErrorBoundary } from 'react-error-boundary'
 import { Loading } from '@common/components/Loading/Loading'
-import { AVAILABLE_LANGUAGES } from '@common/features/Settings/constants'
 import { PublicLayout } from './components/PublicLayout'
 import { EventPreviewPage } from './features/EventPreview/EventPreviewPage'
 
@@ -23,25 +22,22 @@ import en from '@common/locales/en.json'
 import fr from '@common/locales/fr.json'
 import ru from '@common/locales/ru.json'
 import vi from '@common/locales/vi.json'
+import {
+  PublicLanguageContext,
+  getDefaultLanguage,
+  SupportedLanguage
+} from './context/PublicLanguageContext'
 
 const locale = { en, fr, ru, vi }
 const dateLocales = { en: enGB, fr: frLocale, ru: ruLocale, vi: viLocale }
 
-const SUPPORTED_LANGUAGES = AVAILABLE_LANGUAGES.map(lang => lang.code)
-type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number]
-
-const isValidLanguage = (
-  lang: string | null | undefined
-): lang is SupportedLanguage => {
-  return !!lang && SUPPORTED_LANGUAGES.includes(lang as SupportedLanguage)
-}
-
 export default function App(): JSX.Element {
-  const savedLang = localStorage.getItem('lang')
-  const defaultLang = window.LANG
+  const [lang, setLang] = useState<SupportedLanguage>(getDefaultLanguage)
 
-  const lang =
-    [savedLang, defaultLang].find(l => !!l && isValidLanguage(l)) || 'en'
+  const handleLanguageChange = (newLang: SupportedLanguage): void => {
+    localStorage.setItem('lang', newLang)
+    setLang(newLang)
+  }
 
   return (
     <TwakeMuiThemeProvider>
@@ -50,35 +46,45 @@ export default function App(): JSX.Element {
         lang={lang}
         locales={dateLocales}
       >
-        <ErrorBoundary
-          FallbackComponent={({ error }) => (
-            <ErrorPage isCrashFallback errorBoundaryMessage={error as Error} />
-          )}
-          onError={(error, errorInfo) => {
-            Sentry.captureException(error, {
-              contexts: {
-                react: {
-                  componentStack: errorInfo.componentStack
-                }
-              }
-            })
+        <PublicLanguageContext.Provider
+          value={{
+            currentLanguage: lang,
+            setCurrentLanguage: handleLanguageChange
           }}
         >
-          <Suspense fallback={<Loading />}>
-            <Router history={history}>
-              <Routes>
-                <Route
-                  path="/excal"
-                  element={
-                    <PublicLayout>
-                      <EventPreviewPage />
-                    </PublicLayout>
+          <ErrorBoundary
+            FallbackComponent={({ error }) => (
+              <ErrorPage
+                isCrashFallback
+                errorBoundaryMessage={error as Error}
+              />
+            )}
+            onError={(error, errorInfo) => {
+              Sentry.captureException(error, {
+                contexts: {
+                  react: {
+                    componentStack: errorInfo.componentStack
                   }
-                />
-              </Routes>
-            </Router>
-          </Suspense>
-        </ErrorBoundary>
+                }
+              })
+            }}
+          >
+            <Suspense fallback={<Loading />}>
+              <Router history={history}>
+                <Routes>
+                  <Route
+                    path="/excal"
+                    element={
+                      <PublicLayout>
+                        <EventPreviewPage />
+                      </PublicLayout>
+                    }
+                  />
+                </Routes>
+              </Router>
+            </Suspense>
+          </ErrorBoundary>
+        </PublicLanguageContext.Provider>
       </I18n>
     </TwakeMuiThemeProvider>
   )

--- a/apps/public/src/components/PublicLanguageSelector.tsx
+++ b/apps/public/src/components/PublicLanguageSelector.tsx
@@ -1,0 +1,53 @@
+import { useTheme, MenuItem, Select } from '@linagora/twake-mui'
+import LanguageIcon from '@mui/icons-material/Language'
+import { AVAILABLE_LANGUAGES } from '@common/features/Settings/constants'
+import {
+  isValidLanguage,
+  usePublicLanguage
+} from '../context/PublicLanguageContext'
+
+export const PublicLanguageSelector = (): JSX.Element => {
+  const theme = useTheme()
+  const { currentLanguage, setCurrentLanguage } = usePublicLanguage()
+
+  return (
+    <Select
+      value={currentLanguage}
+      onChange={e => {
+        const nextLang = String(e.target.value)
+        if (isValidLanguage(nextLang)) {
+          setCurrentLanguage(nextLang)
+        }
+      }}
+      variant="standard"
+      disableUnderline
+      startAdornment={
+        <LanguageIcon
+          sx={{
+            mr: 1,
+            fontSize: 20,
+            color: theme.palette.text.secondary
+          }}
+        />
+      }
+      sx={{
+        color: theme.palette.text.secondary,
+        fontSize: '0.875rem',
+        fontWeight: 500,
+        cursor: 'pointer',
+        '& .MuiSelect-select': {
+          py: '6px',
+          pr: '24px !important',
+          display: 'flex',
+          alignItems: 'center'
+        }
+      }}
+    >
+      {AVAILABLE_LANGUAGES.map(({ code, label }) => (
+        <MenuItem key={code} value={code}>
+          {label}
+        </MenuItem>
+      ))}
+    </Select>
+  )
+}

--- a/apps/public/src/components/PublicLayout.tsx
+++ b/apps/public/src/components/PublicLayout.tsx
@@ -10,6 +10,7 @@ import {
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import React from 'react'
 import { useI18n } from 'twake-i18n'
+import { PublicLanguageSelector } from './PublicLanguageSelector'
 
 interface PublicLayoutProps {
   children?: React.ReactNode
@@ -38,9 +39,14 @@ export const PublicLayout: React.FC<PublicLayoutProps> = ({ children }) => {
         sx={{
           position: 'absolute',
           top: { xs: 16, sm: 24 },
-          right: { xs: 16, sm: 24 }
+          right: { xs: 16, sm: 24 },
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2
         }}
       >
+        <PublicLanguageSelector />
+
         <Button
           onClick={handleHelpClick}
           sx={{

--- a/apps/public/src/context/PublicLanguageContext.tsx
+++ b/apps/public/src/context/PublicLanguageContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext } from 'react'
+import { AVAILABLE_LANGUAGES } from '@common/features/Settings/constants'
+
+export const SUPPORTED_LANGUAGES = AVAILABLE_LANGUAGES.map(lang => lang.code)
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number]
+
+export const isValidLanguage = (
+  lang: string | null | undefined
+): lang is SupportedLanguage => {
+  return !!lang && SUPPORTED_LANGUAGES.includes(lang as SupportedLanguage)
+}
+
+export const getBrowserLanguage = (): string | undefined => {
+  if (typeof navigator === 'undefined') {
+    return undefined
+  }
+  const navLang =
+    navigator.language || (navigator.languages && navigator.languages[0])
+  if (!navLang) {
+    return undefined
+  }
+  return navLang.split('-')[0].toLowerCase()
+}
+
+const safeLocalStorageGet = (key: string): string | undefined => {
+  try {
+    return window.localStorage.getItem(key) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+export const getDefaultLanguage = (): SupportedLanguage => {
+  if (typeof window === 'undefined') {
+    return 'en'
+  }
+  const savedLang = safeLocalStorageGet('lang')
+  const defaultLang = window.LANG
+  const browserLang = getBrowserLanguage()
+
+  return (
+    [savedLang, browserLang, defaultLang].find(
+      l => !!l && isValidLanguage(l)
+    ) || 'en'
+  )
+}
+
+export interface PublicLanguageContextType {
+  currentLanguage: SupportedLanguage
+  setCurrentLanguage: (lang: SupportedLanguage) => void
+}
+
+export const PublicLanguageContext = createContext<PublicLanguageContextType>({
+  currentLanguage: 'en',
+  setCurrentLanguage: () => {}
+})
+
+export const usePublicLanguage = (): PublicLanguageContextType =>
+  useContext(PublicLanguageContext)

--- a/common/src/declarations.d.ts
+++ b/common/src/declarations.d.ts
@@ -40,6 +40,10 @@ declare module '@linagora/twake-mui' {
   export const Avatar: import('react').FC<AvatarProps>
 
   export const radius: Record<string, string | number>
+
+  export const TwakeMuiThemeProvider: import('react').FC<
+    import('@mui/material/styles').ThemeProviderProps
+  >
 }
 
 declare const process: {
@@ -56,5 +60,6 @@ declare module 'twake-i18n' {
   }
   export const I18nContext: import('react').Context<any>
   export const DEFAULT_LANG: string
-  export default class I18n extends import('react').Component<any, any, any> {}
+  const I18n: import('react').ComponentType<any>
+  export default I18n
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1016

This PR implements:
- Auto-detect language from the browser in this order: stored language in local storage, browser language, then the default language.
- Language selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a public language selector to the app header.
  * The selected language is persisted for future visits.
  * Initial language now derives from local settings, then browser preferences, with a sensible fallback.

* **Tests**
  * Added coverage for public language detection and defaulting logic, including edge cases and invalid inputs.

* **Chores**
  * Updated shared TypeScript typings to better reflect the UI provider and i18n component exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->