### PR TITLE
#1023 add the divider between header and main layout

### DIFF
--- a/common/src/components/Calendar/Calendar.styl
+++ b/common/src/components/Calendar/Calendar.styl
@@ -15,6 +15,9 @@
 .main-layout.calendar-layout
   background-color #fff
   flex-direction row
+  
+  &--desktop
+    margin-top 8px
 
 .calendar
   flex-grow 1

--- a/common/src/components/Calendar/Calendar.tsx
+++ b/common/src/components/Calendar/Calendar.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import { useAppDispatch, useAppSelector } from '@common/app/hooks'
 import { setIsMobileSearchOpen } from '@common/features/Calendars/CalendarSlice'
 import EventPopover from '@common/features/Events/EventModal'
@@ -492,7 +493,10 @@ const CalendarApp: React.FC<CalendarAppProps> = ({
 
   return (
     <main
-      className={`main-layout calendar-layout ${menubarProps?.isIframe ? ' isInIframe' : ''}`}
+      className={cx('main-layout calendar-layout', {
+        isInIframe: Boolean(menubarProps?.isIframe),
+        'calendar-layout--desktop': !isMobile
+      })}
     >
       <TimezoneChangeAlert />
       <Sidebar

--- a/common/src/components/Calendar/Sidebar/DesktopSidebar.tsx
+++ b/common/src/components/Calendar/Sidebar/DesktopSidebar.tsx
@@ -31,8 +31,8 @@ export const DesktopSidebar: React.FC<CalendarSidebarProps> = ({
           paddingLeft: 3,
           paddingRight: 2,
           width: '270px',
-          marginTop: isIframe ? 1 : '70px',
-          height: isIframe ? 'calc(100% - 8px)' : 'calc(100% - 70px)'
+          marginTop: isIframe ? 1 : '68px',
+          height: isIframe ? 'calc(100% - 8px)' : 'calc(100% - 68px)'
         },
         zIndex: 5
       }}


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1023

Add the divider between header and main layout

<img width="3024" height="252" alt="image" src="https://github.com/user-attachments/assets/275dec0b-9876-442d-93b0-7a731ed58e96" />
