### PR TITLE
[#1031] preserve DTSTART timezone when updating partstat

### DIFF
--- a/__test__/features/Events/EventDisplay.test.tsx
+++ b/__test__/features/Events/EventDisplay.test.tsx
@@ -7,9 +7,50 @@ import {
 } from '@common/components/Event/utils/eventUtils'
 import EventPreviewModal from '@common/components/EventPreview'
 import * as eventThunks from '@common/features/Calendars/CalendarSlice'
+import * as EventDao from '@common/features/Events/EventDao'
 import { DelegationAccess } from '@common/types/CalendarTypes'
+import { VCalComponent } from '@common/features/Calendars/types/CalendarData'
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '../../utils/Renderwithproviders'
+
+// Stored event jCal returned by the server (Europe/Paris). A PARTSTAT update
+// must patch this in place, so it is what fetchEventJCal resolves to in the
+// RSVP tests below.
+const storedEventJCal = (): VCalComponent =>
+  [
+    'vcalendar',
+    [],
+    [
+      [
+        'vevent',
+        [
+          ['uid', {}, 'text', 'event1'],
+          [
+            'dtstart',
+            { tzid: 'Europe/Paris' },
+            'date-time',
+            '2025-01-15T11:00:00'
+          ],
+          [
+            'attendee',
+            { partstat: 'NEEDS-ACTION', cutype: 'INDIVIDUAL' },
+            'cal-address',
+            'mailto:test@test.com'
+          ]
+        ],
+        []
+      ]
+    ]
+  ] as unknown as VCalComponent
+
+const sentPartstat = (jCal: VCalComponent): string | undefined => {
+  const vevent = (jCal[2] as VCalComponent[]).find(c => c[0] === 'vevent')
+  const props = (vevent?.[1] ?? []) as Array<
+    [string, Record<string, string>, string, string]
+  >
+  const attendee = props.find(p => p[0] === 'attendee')
+  return attendee?.[1]?.partstat
+}
 
 describe('Event Preview Display', () => {
   const mockOnClose = jest.fn()
@@ -366,13 +407,10 @@ describe('Event Preview Display', () => {
   })
 
   it('handles RSVP Accept click', async () => {
+    jest.spyOn(EventDao, 'fetchEventJCal').mockResolvedValue(storedEventJCal())
     const spy = jest
-      .spyOn(eventThunks, 'putEvent')
-      .mockImplementation(payload => {
-        const promise = Promise.resolve(payload)
-        ;(promise as any).unwrap = () => promise
-        return () => promise as any
-      })
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({} as Response)
 
     const rsvpState = {
       ...preloadedState,
@@ -422,18 +460,14 @@ describe('Event Preview Display', () => {
       expect(spy).toHaveBeenCalled()
     })
 
-    const updatedEvent = spy.mock.calls[0][0].newEvent
-    expect(updatedEvent.attendee[0].partstat).toBe('ACCEPTED')
+    expect(sentPartstat(spy.mock.calls[0][1] as VCalComponent)).toBe('ACCEPTED')
   })
 
   it('handles RSVP Maybe click', async () => {
+    jest.spyOn(EventDao, 'fetchEventJCal').mockResolvedValue(storedEventJCal())
     const spy = jest
-      .spyOn(eventThunks, 'putEvent')
-      .mockImplementation(payload => {
-        const promise = Promise.resolve(payload)
-        ;(promise as any).unwrap = () => promise
-        return () => promise as any
-      })
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({} as Response)
 
     const rsvpState = {
       ...preloadedState,
@@ -483,18 +517,16 @@ describe('Event Preview Display', () => {
       expect(spy).toHaveBeenCalled()
     })
 
-    const updatedEvent = spy.mock.calls[0][0].newEvent
-    expect(updatedEvent.attendee[0].partstat).toBe('TENTATIVE')
+    expect(sentPartstat(spy.mock.calls[0][1] as VCalComponent)).toBe(
+      'TENTATIVE'
+    )
   })
 
   it('handles RSVP Decline click', async () => {
+    jest.spyOn(EventDao, 'fetchEventJCal').mockResolvedValue(storedEventJCal())
     const spy = jest
-      .spyOn(eventThunks, 'putEvent')
-      .mockImplementation(payload => {
-        const promise = Promise.resolve(payload)
-        ;(promise as any).unwrap = () => promise
-        return () => promise as any
-      })
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({} as Response)
 
     const rsvpState = {
       ...preloadedState,
@@ -544,8 +576,7 @@ describe('Event Preview Display', () => {
       expect(spy).toHaveBeenCalled()
     })
 
-    const updatedEvent = spy.mock.calls[0][0].newEvent
-    expect(updatedEvent.attendee[0].partstat).toBe('DECLINED')
+    expect(sentPartstat(spy.mock.calls[0][1] as VCalComponent)).toBe('DECLINED')
   })
   it('handles Edit click when is own but with no organizer', async () => {
     renderWithProviders(

--- a/__test__/features/Events/EventRepetition.test.tsx
+++ b/__test__/features/Events/EventRepetition.test.tsx
@@ -262,8 +262,8 @@ describe('EventPreviewModal - Recurring Event Interactions', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -284,8 +284,8 @@ describe('EventPreviewModal - Recurring Event Interactions', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -306,8 +306,8 @@ describe('EventPreviewModal - Recurring Event Interactions', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -362,8 +362,8 @@ describe('EventPreviewModal - Recurring Event Interactions', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'single-event'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="single-event"
         />,
         nonRecurringState
       )
@@ -404,8 +404,8 @@ describe('Delete Recurring Event Instance', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -454,8 +454,8 @@ describe('Delete Recurring Event Instance', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -505,8 +505,8 @@ describe('RSVP to Recurring Event', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -566,8 +566,8 @@ describe('RSVP to Recurring Event', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -656,8 +656,8 @@ describe('Edit Recurring Event in Full Display', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -699,8 +699,8 @@ describe('Edit Recurring Event in Full Display', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
           typeOfAction="solo"
         />,
         basePreloadedState
@@ -753,8 +753,8 @@ describe('Edit Recurring Event in Full Display', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
           typeOfAction="all"
         />,
         basePreloadedState
@@ -786,8 +786,8 @@ describe('Edit Recurring Event in Full Display', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
           typeOfAction="solo"
           eventData={
             basePreloadedState.calendars.list['667037022b752d0026472254/cal1']
@@ -833,8 +833,8 @@ describe('Edit Recurring Event in Full Display', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
           typeOfAction="all"
         />,
         basePreloadedState
@@ -969,8 +969,8 @@ describe('RepeatEvent Component - Recurrence Editing', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'otherCal/cal'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="otherCal/cal"
+          eventId="recurring-base/20250315T100000"
         />,
         {
           ...basePreloadedState,
@@ -1045,13 +1045,14 @@ describe('handleRSVP function', () => {
       ]
     }
 
-    await handleRSVP(
-      mockDispatch,
-      basePreloadedState.calendars.list['667037022b752d0026472254/cal1'],
-      basePreloadedState.user,
-      nonRecurringEvent,
-      'ACCEPTED'
-    )
+    await handleRSVP({
+      dispatch: mockDispatch,
+      calendar:
+        basePreloadedState.calendars.list['667037022b752d0026472254/cal1'],
+      user: basePreloadedState.user,
+      event: nonRecurringEvent,
+      rsvp: 'ACCEPTED'
+    })
 
     expect(mockDispatch).toHaveBeenCalled()
   })
@@ -1178,8 +1179,8 @@ describe('Calendar Integration - EditModeDialog Flow', () => {
         <EventPreviewModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         basePreloadedState
       )
@@ -1324,8 +1325,8 @@ describe('Event URL handling for recurring events', () => {
         <EventUpdateModal
           open={true}
           onClose={mockOnClose}
-          calId={'667037022b752d0026472254/cal1'}
-          eventId={'recurring-base/20250315T100000'}
+          calId="667037022b752d0026472254/cal1"
+          eventId="recurring-base/20250315T100000"
         />,
         twoCalState
       )

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -105,7 +105,13 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
       .mockResolvedValue({} as Response)
     const dispatch = jest.fn()
 
-    await handleRSVP(dispatch, CALENDAR, USER, STALE_EVENT, 'TENTATIVE')
+    await handleRSVP({
+      dispatch,
+      calendar: CALENDAR,
+      user: USER,
+      event: STALE_EVENT,
+      rsvp: 'TENTATIVE'
+    })
 
     expect(putSpy).toHaveBeenCalledTimes(1)
     const putJCal = putSpy.mock.calls[0][1] as VCalComponent
@@ -152,7 +158,13 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
       .mockResolvedValue({} as Response)
     const dispatch = jest.fn()
 
-    await handleRSVP(dispatch, CALENDAR, USER, STALE_EVENT, 'TENTATIVE')
+    await handleRSVP({
+      dispatch,
+      calendar: CALENDAR,
+      user: USER,
+      event: STALE_EVENT,
+      rsvp: 'TENTATIVE'
+    })
 
     expect(putSpy).not.toHaveBeenCalled()
     expect(dispatch).toHaveBeenCalledTimes(1)
@@ -165,13 +177,13 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
       .mockResolvedValue({} as Response)
     const dispatch = jest.fn()
 
-    await handleRSVP(
+    await handleRSVP({
       dispatch,
-      CALENDAR,
-      {} as userData,
-      STALE_EVENT,
-      'TENTATIVE'
-    )
+      calendar: CALENDAR,
+      user: {} as userData,
+      event: STALE_EVENT,
+      rsvp: 'TENTATIVE'
+    })
 
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(putSpy).not.toHaveBeenCalled()

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -125,4 +125,56 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
     // The lossy regeneration path (redux thunk) was not used.
     expect(dispatch).not.toHaveBeenCalled()
   })
+
+  it('falls back to regeneration when the attendee is absent from the event', async () => {
+    const noMatchJCal: VCalComponent = [
+      'vcalendar',
+      [],
+      [
+        [
+          'vevent',
+          [
+            ['uid', {}, 'text', 'event-abc-uid'],
+            [
+              'attendee',
+              { partstat: 'NEEDS-ACTION', cutype: 'INDIVIDUAL' },
+              'cal-address',
+              'mailto:someone-else@example.com'
+            ]
+          ],
+          []
+        ]
+      ]
+    ]
+    jest.spyOn(EventDao, 'fetchEventJCal').mockResolvedValue(noMatchJCal)
+    const putSpy = jest
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({} as Response)
+    const dispatch = jest.fn()
+
+    await handleRSVP(dispatch, CALENDAR, USER, STALE_EVENT, 'TENTATIVE')
+
+    expect(putSpy).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to regeneration when there is no user email', async () => {
+    const fetchSpy = jest.spyOn(EventDao, 'fetchEventJCal')
+    const putSpy = jest
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({} as Response)
+    const dispatch = jest.fn()
+
+    await handleRSVP(
+      dispatch,
+      CALENDAR,
+      {} as userData,
+      STALE_EVENT,
+      'TENTATIVE'
+    )
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(putSpy).not.toHaveBeenCalled()
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
 })

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -102,7 +102,7 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
   it('updates only PARTSTAT in the stored jCal, leaving DTSTART intact', async () => {
     const putSpy = jest
       .spyOn(EventDao, 'putEvent')
-      .mockResolvedValue({} as Response)
+      .mockResolvedValue({ ok: true, status: 200 } as Response)
     const dispatch = jest.fn()
 
     await handleRSVP({
@@ -155,7 +155,7 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
     jest.spyOn(EventDao, 'fetchEventJCal').mockResolvedValue(noMatchJCal)
     const putSpy = jest
       .spyOn(EventDao, 'putEvent')
-      .mockResolvedValue({} as Response)
+      .mockResolvedValue({ ok: true, status: 200 } as Response)
     const dispatch = jest.fn()
 
     await handleRSVP({
@@ -174,7 +174,7 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
     const fetchSpy = jest.spyOn(EventDao, 'fetchEventJCal')
     const putSpy = jest
       .spyOn(EventDao, 'putEvent')
-      .mockResolvedValue({} as Response)
+      .mockResolvedValue({ ok: true, status: 200 } as Response)
     const dispatch = jest.fn()
 
     await handleRSVP({

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -1,0 +1,128 @@
+import { Calendar } from '@common/types/CalendarTypes'
+import {
+  VCalComponent,
+  VObjectProperty
+} from '@common/features/Calendars/types/CalendarData'
+import * as EventDao from '@common/features/Events/EventDao'
+import { handleRSVP } from '@common/components/Event/eventHandlers/eventHandlers'
+import { CalendarEvent } from '@common/types/EventsTypes'
+import { userData } from '@common/features/User/userDataTypes'
+
+// The DTSTART the server stores, in Europe/Paris. This is what must survive a
+// PARTSTAT update untouched (regression test for #1031).
+const STORED_JCAL: VCalComponent = [
+  'vcalendar',
+  [],
+  [
+    ['vtimezone', [['tzid', {}, 'text', 'Europe/Paris']], []],
+    [
+      'vevent',
+      [
+        ['uid', {}, 'text', 'event-abc-uid'],
+        ['summary', {}, 'text', 'Team standup'],
+        [
+          'dtstart',
+          { tzid: 'Europe/Paris' },
+          'date-time',
+          '2026-06-17T02:00:00'
+        ],
+        ['dtend', { tzid: 'Europe/Paris' }, 'date-time', '2026-06-17T02:30:00'],
+        ['dtstamp', {}, 'date-time', '2026-06-01T00:00:00Z'],
+        [
+          'attendee',
+          {
+            partstat: 'NEEDS-ACTION',
+            rsvp: 'TRUE',
+            role: 'REQ-PARTICIPANT',
+            cutype: 'INDIVIDUAL'
+          },
+          'cal-address',
+          'mailto:me@example.com'
+        ]
+      ],
+      []
+    ]
+  ]
+]
+
+const CALENDAR: Calendar = {
+  id: 'cal-1',
+  name: 'My calendar',
+  owner: { emails: ['me@example.com'] }
+} as Calendar
+
+const USER = { email: 'me@example.com' } as userData
+
+// The in-memory event whose timezone has been lost after a server round-trip.
+// Regenerating the jCal from this event is what used to corrupt DTSTART.
+const STALE_EVENT = {
+  uid: 'event-abc-uid',
+  title: 'Team standup',
+  start: '2026-06-17T00:00:00.000Z',
+  end: '2026-06-17T00:30:00.000Z',
+  timezone: undefined,
+  allday: false,
+  URL: '/calendars/cal-1/event-abc.ics',
+  attendee: [
+    {
+      cn: 'Me',
+      cal_address: 'me@example.com',
+      partstat: 'NEEDS-ACTION',
+      rsvp: 'TRUE',
+      role: 'REQ-PARTICIPANT',
+      cutype: 'INDIVIDUAL'
+    }
+  ]
+} as unknown as CalendarEvent
+
+function veventProps(jCal: VCalComponent): VObjectProperty[] {
+  const components = jCal[2] as VCalComponent[]
+  const vevent = components.find(c => c[0] === 'vevent')
+  return (vevent?.[1] as VObjectProperty[]) ?? []
+}
+
+function dtstartOf(jCal: VCalComponent): VObjectProperty | undefined {
+  return veventProps(jCal).find(p => p[0].toLowerCase() === 'dtstart')
+}
+
+function attendeeOf(jCal: VCalComponent): VObjectProperty | undefined {
+  return veventProps(jCal).find(p => p[0] === 'attendee')
+}
+
+describe('#1031 partstat update preserves DTSTART timezone', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    jest
+      .spyOn(EventDao, 'fetchEventJCal')
+      .mockResolvedValue(
+        JSON.parse(JSON.stringify(STORED_JCAL)) as VCalComponent
+      )
+  })
+
+  it('updates only PARTSTAT in the stored jCal, leaving DTSTART intact', async () => {
+    const putSpy = jest
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({} as Response)
+    const dispatch = jest.fn()
+
+    await handleRSVP(dispatch, CALENDAR, USER, STALE_EVENT, 'TENTATIVE')
+
+    expect(putSpy).toHaveBeenCalledTimes(1)
+    const putJCal = putSpy.mock.calls[0][1] as VCalComponent
+
+    // DTSTART is preserved byte-for-byte (TZID kept, no UTC normalization).
+    expect(dtstartOf(putJCal)).toEqual([
+      'dtstart',
+      { tzid: 'Europe/Paris' },
+      'date-time',
+      '2026-06-17T02:00:00'
+    ])
+
+    // PARTSTAT was actually updated.
+    const attendeeParams = attendeeOf(putJCal)?.[1] as Record<string, string>
+    expect(attendeeParams.partstat).toBe('TENTATIVE')
+
+    // The lossy regeneration path (redux thunk) was not used.
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -23,6 +23,15 @@ import { CalendarEvent } from '@common/types/EventsTypes'
 import { buildFamilyName } from '@common/utils/buildFamilyName'
 import { isEventOrganiser } from '@common/utils/isEventOrganiser'
 
+interface RSVPHandlerParams {
+  dispatch: AppDispatch
+  calendar: Calendar
+  event: CalendarEvent
+  user: userData | undefined
+  rsvp: PartStat
+  typeOfAction?: string
+}
+
 function updateEventAttendees(
   calendar: Calendar,
   event: CalendarEvent,
@@ -120,14 +129,16 @@ function makePartstatMatcher(
   return (_params, calAddress) => calAddress.toLowerCase() === userEmail
 }
 
-async function handleDefaultRSVP(
-  dispatch: AppDispatch,
-  calendar: Calendar,
-  event: CalendarEvent,
-  user: userData | undefined,
-  rsvp: PartStat,
+async function handleDefaultRSVP({
+  dispatch,
+  calendar,
+  event,
+  user,
+  rsvp,
+  fallbackEvent
+}: Omit<RSVPHandlerParams, 'typeOfAction'> & {
   fallbackEvent: CalendarEvent
-): Promise<void> {
+}): Promise<void> {
   // Update the attendee PARTSTAT directly in the stored jCal so that DTSTART,
   // VTIMEZONE and every other property are preserved exactly. Regenerating the
   // event from the parsed model drops the timezone when it is missing (#1031).
@@ -136,7 +147,12 @@ async function handleDefaultRSVP(
     const jCal = await fetchEventJCal(event)
     const patched = updateEventPartstatJCal(jCal, matcher, rsvp)
     if (patched) {
-      await putEvent(event, patched)
+      const response = await putEvent(event, patched)
+      if (!response.ok) {
+        console.error(
+          `RSVP update failed for ${event.URL} with status ${response.status}`
+        )
+      }
       return
     }
   }
@@ -146,14 +162,14 @@ async function handleDefaultRSVP(
   await dispatch(putEventAsync({ cal: calendar, newEvent: fallbackEvent }))
 }
 
-export async function handleRSVP(
-  dispatch: AppDispatch,
-  calendar: Calendar,
-  user: userData | undefined,
-  event: CalendarEvent,
-  rsvp: PartStat,
-  typeOfAction?: string
-): Promise<void> {
+export async function handleRSVP({
+  dispatch,
+  calendar,
+  event,
+  user,
+  rsvp,
+  typeOfAction
+}: RSVPHandlerParams): Promise<void> {
   const newEvent = {
     ...event,
     ...updateEventAttendees(calendar, event, user, rsvp)
@@ -167,7 +183,14 @@ export async function handleRSVP(
     }
     await handleAllRSVP(event, user.email, rsvp)
   } else {
-    await handleDefaultRSVP(dispatch, calendar, event, user, rsvp, newEvent)
+    await handleDefaultRSVP({
+      dispatch,
+      calendar,
+      event,
+      user,
+      rsvp,
+      fallbackEvent: newEvent
+    })
   }
 }
 

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -145,7 +145,6 @@ async function handleDefaultRSVP({
   const matcher = makePartstatMatcher(calendar, user)
   if (matcher) {
     const jCal = await fetchEventJCal(event)
-    console.log('Fetched jCal for RSVP update:', jCal)
     const patched = updateEventPartstatJCal(jCal, matcher, rsvp)
     if (patched) {
       const response = await putEvent(event, patched)

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -145,11 +145,12 @@ async function handleDefaultRSVP({
   const matcher = makePartstatMatcher(calendar, user)
   if (matcher) {
     const jCal = await fetchEventJCal(event)
+    console.log('Fetched jCal for RSVP update:', jCal)
     const patched = updateEventPartstatJCal(jCal, matcher, rsvp)
     if (patched) {
       const response = await putEvent(event, patched)
       if (!response.ok) {
-        console.error(
+        throw new Error(
           `RSVP update failed for ${event.URL} with status ${response.status}`
         )
       }

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -7,9 +7,14 @@ import {
 } from '@common/features/Calendars/CalendarSlice'
 import {
   fetchAllRecurrentVevents,
+  fetchEventJCal,
   putEvent
 } from '@common/features/Events/EventDao'
-import { updateSeriesPartstatJCal } from '@common/features/Events/transformers'
+import {
+  updateEventPartstatJCal,
+  updateSeriesPartstatJCal,
+  type AttendeeMatcher
+} from '@common/features/Events/transformers'
 import { PartStat, userAttendee } from '@common/features/User/models/attendee'
 import { createAttendee } from '@common/features/User/models/attendee.mapper'
 import { userData, userOrganiser } from '@common/features/User/userDataTypes'
@@ -100,12 +105,45 @@ async function handleAllRSVP(
   await putEvent(event, jCal)
 }
 
+function makePartstatMatcher(
+  calendar: Calendar,
+  user: userData | undefined
+): AttendeeMatcher | undefined {
+  if (calendar.owner?.resource) {
+    return (params, _calAddress) =>
+      params.cutype === 'RESOURCE' && params.cn === calendar.name
+  }
+  const userEmail = user?.email?.toLowerCase()
+  if (!userEmail) {
+    return undefined
+  }
+  return (_params, calAddress) => calAddress.toLowerCase() === userEmail
+}
+
 async function handleDefaultRSVP(
   dispatch: AppDispatch,
   calendar: Calendar,
-  newEvent: CalendarEvent
+  event: CalendarEvent,
+  user: userData | undefined,
+  rsvp: PartStat,
+  fallbackEvent: CalendarEvent
 ): Promise<void> {
-  await dispatch(putEventAsync({ cal: calendar, newEvent }))
+  // Update the attendee PARTSTAT directly in the stored jCal so that DTSTART,
+  // VTIMEZONE and every other property are preserved exactly. Regenerating the
+  // event from the parsed model drops the timezone when it is missing (#1031).
+  const matcher = makePartstatMatcher(calendar, user)
+  if (matcher) {
+    const jCal = await fetchEventJCal(event)
+    const patched = updateEventPartstatJCal(jCal, matcher, rsvp)
+    if (patched) {
+      await putEvent(event, patched)
+      return
+    }
+  }
+
+  // No matching attendee in the event (e.g. adding oneself for the first time):
+  // fall back to regenerating the event from the model.
+  await dispatch(putEventAsync({ cal: calendar, newEvent: fallbackEvent }))
 }
 
 export async function handleRSVP(
@@ -129,7 +167,7 @@ export async function handleRSVP(
     }
     await handleAllRSVP(event, user.email, rsvp)
   } else {
-    await handleDefaultRSVP(dispatch, calendar, newEvent)
+    await handleDefaultRSVP(dispatch, calendar, event, user, rsvp, newEvent)
   }
 }
 

--- a/common/src/features/Events/AttendanceValidation/handleRSVPClick.tsx
+++ b/common/src/features/Events/AttendanceValidation/handleRSVPClick.tsx
@@ -31,7 +31,14 @@ export async function handleRSVPClick(
           onLoadingChange?.(true, rsvp)
 
           try {
-            await handleRSVP(dispatch, calendar, user, event, rsvp, type)
+            await handleRSVP({
+              dispatch,
+              calendar,
+              user,
+              event,
+              rsvp,
+              typeOfAction: type
+            })
             onLoadingChange?.(false)
           } catch (error) {
             console.error('Error handling RSVP:', error)
@@ -43,7 +50,13 @@ export async function handleRSVPClick(
     setOpenEditModePopup('attendance')
   } else {
     try {
-      await handleRSVP(dispatch, calendar, user, event, rsvp)
+      await handleRSVP({
+        dispatch,
+        calendar,
+        user,
+        event,
+        rsvp
+      })
       onLoadingChange?.(false)
     } catch (error) {
       console.error('Error handling RSVP:', error)

--- a/common/src/features/Events/EventDao.ts
+++ b/common/src/features/Events/EventDao.ts
@@ -143,6 +143,11 @@ export async function fetchEventJCal(
   event: CalendarEvent
 ): Promise<VCalComponent> {
   const response = await api.get(`dav${event.URL}`)
+  if (!response.ok) {
+    console.error(
+      `fetchEventJCal failed for ${event.URL} with status ${response.status}`
+    )
+  }
   const eventData = await response.text()
   return ICAL.parse(eventData) as VCalComponent
 }

--- a/common/src/features/Events/EventDao.ts
+++ b/common/src/features/Events/EventDao.ts
@@ -135,6 +135,19 @@ export async function fetchAllRecurrentVevents(
 }
 
 /**
+ * Fetches the full VCALENDAR jCal of an event (VEVENTs + VTIMEZONE + props).
+ * Used to update an event in place without regenerating it from the parsed
+ * model, so that properties like DTSTART/VTIMEZONE are preserved byte-for-byte.
+ */
+export async function fetchEventJCal(
+  event: CalendarEvent
+): Promise<VCalComponent> {
+  const response = await api.get(`dav${event.URL}`)
+  const eventData = await response.text()
+  return ICAL.parse(eventData) as VCalComponent
+}
+
+/**
  * POSTs an iTIP COUNTER proposal for a calendar event.
  * Accepts a pre-serialized ICS string and the envelope metadata.
  */

--- a/common/src/features/Events/EventDao.ts
+++ b/common/src/features/Events/EventDao.ts
@@ -144,7 +144,7 @@ export async function fetchEventJCal(
 ): Promise<VCalComponent> {
   const response = await api.get(`dav${event.URL}`)
   if (!response.ok) {
-    console.error(
+    throw new Error(
       `fetchEventJCal failed for ${event.URL} with status ${response.status}`
     )
   }

--- a/common/src/features/Events/transformers/index.ts
+++ b/common/src/features/Events/transformers/index.ts
@@ -1,5 +1,7 @@
 export { makeCounterProposalPayload } from './makeCounterProposalPayload'
 export { updateSeriesPartstatJCal } from './updateSeriesPartstatJCal'
+export { updateEventPartstatJCal } from './updateEventPartstatJCal'
+export type { AttendeeMatcher } from './updateEventPartstatJCal'
 export { makeDeleteEventInstanceJCal } from './makeDeleteEventInstanceJCal'
 export { makeEventWithOverrides } from './makeEventWithOverrides'
 export { makeSearchEventParam } from './makeSearchEventParam'

--- a/common/src/features/Events/transformers/updateEventPartstatJCal.ts
+++ b/common/src/features/Events/transformers/updateEventPartstatJCal.ts
@@ -1,0 +1,75 @@
+import {
+  VCalComponent,
+  VObjectProperty
+} from '@common/features/Calendars/types/CalendarData'
+
+/**
+ * Predicate identifying the ATTENDEE whose PARTSTAT must be updated.
+ * Receives the attendee parameters and its (mailto-stripped) calendar address.
+ */
+export type AttendeeMatcher = (
+  params: Record<string, string>,
+  calAddress: string
+) => boolean
+
+/**
+ * Updates the PARTSTAT of a single attendee directly in the fetched VCALENDAR
+ * jCal, leaving every other property (DTSTART, VTIMEZONE, custom props, ...)
+ * untouched. This avoids regenerating the event from the parsed CalendarEvent
+ * model, which is lossy: when the in-memory timezone is missing, regeneration
+ * silently rewrites DTSTART to UTC and drops the TZID parameter (see #1031).
+ *
+ * Returns the patched jCal, or `null` when no matching attendee was found so
+ * the caller can fall back to the regeneration path (e.g. adding oneself as a
+ * brand-new attendee).
+ */
+export function updateEventPartstatJCal(
+  jcal: VCalComponent,
+  matchAttendee: AttendeeMatcher,
+  partstat: string
+): VCalComponent | null {
+  let matched = false
+
+  const [name, props, components] = jcal as [
+    string,
+    VObjectProperty[],
+    VCalComponent[]
+  ]
+
+  const updatedComponents = (components ?? []).map(
+    (component: VCalComponent): VCalComponent => {
+      if (!Array.isArray(component) || component[0] !== 'vevent') {
+        return component
+      }
+
+      const properties = component[1] as VObjectProperty[]
+      const updatedProperties = properties.map(
+        (prop: VObjectProperty): VObjectProperty => {
+          if (prop[0] !== 'attendee') {
+            return prop
+          }
+
+          const params = (prop[1] ?? {}) as Record<string, string>
+          const calAddress = ((prop[3] as string | undefined) ?? '').replace(
+            /^mailto:/i,
+            ''
+          )
+
+          if (matchAttendee(params, calAddress)) {
+            matched = true
+            return [prop[0], { ...params, partstat }, prop[2], prop[3]]
+          }
+          return prop
+        }
+      )
+
+      return [component[0], updatedProperties, component[2]] as VCalComponent
+    }
+  )
+
+  if (!matched) {
+    return null
+  }
+
+  return [name, props, updatedComponents] as VCalComponent
+}


### PR DESCRIPTION
Updating the partstat of a single (non-recurring) event used to regenerate the whole VEVENT from the in-memory CalendarEvent model. When that model had lost its timezone (e.g. after the server normalized DTSTART to UTC on a previous reply under SABRE_ENFORCE_RFC_6638), makeVevent emitted DTSTART with empty params and a forced UTC value, dropping the original TZID.

Instead, patch only the attendee's PARTSTAT directly in the stored jCal, the same way the recurring series path already does, leaving DTSTART, VTIMEZONE and every other property untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSVP responses to preserve event timezone information, preventing UTC normalization and maintaining original timezone details when updating attendance status.

* **Tests**
  * Added regression test suite for RSVP timezone preservation.
  * Updated RSVP test assertions to verify accurate event updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->