### PR TITLE
1033 adjust no event view

### DIFF
--- a/common/src/components/Calendar/Calendar.styl
+++ b/common/src/components/Calendar/Calendar.styl
@@ -134,3 +134,6 @@
   display flex
   flex-direction column
   align-items center
+
+.fc .fc-list-empty
+  background-color #fff

--- a/common/src/components/Calendar/NoEventsContent.tsx
+++ b/common/src/components/Calendar/NoEventsContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Box, CircularProgress, Typography } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
+import logo from '@common/static/noResult-logo.svg'
 
 export interface NoEventsContentProps {
   isPending: boolean
@@ -15,17 +16,26 @@ export const NoEventsContent: React.FC<NoEventsContentProps> = ({
     <Box
       sx={{
         display: 'flex',
+        flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
+        gap: 1,
         padding: '24px'
       }}
     >
       {isPending ? (
         <CircularProgress size={24} />
       ) : (
-        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          {t('event.noEventsToDisplay')}
-        </Typography>
+        <>
+          <img
+            className="logoNoResults"
+            src={logo}
+            alt={t('event.noEventsToDisplay')}
+          />
+          <Typography variant="h6" sx={{ color: 'text.primary' }}>
+            {t('event.noEventsToDisplay')}
+          </Typography>
+        </>
       )}
     </Box>
   )

--- a/common/src/features/Search/searchResult.styl
+++ b/common/src/features/Search/searchResult.styl
@@ -11,12 +11,12 @@
     .loading,
     .error
       height:  90%
-      align-content center
       align-items center
       bottom 50%
       display flex
       flex-direction column
       gap 10px
+      justify-content center
 
     .logoNoResults
       font-size 1.5rem


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1033

<img width="1512" height="806" alt="image" src="https://github.com/user-attachments/assets/8d66acd2-8972-43d3-b968-0cf9eeb49d94" />

### Blocked by:

https://github.com/linagora/twake-calendar-frontend/pull/1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced styling for empty calendar states with refined background colors.
  * Improved "no events" display with new logo image integration and updated typography styling for better visual hierarchy.
  * Optimized search results alignment with refined flexbox layout rules for consistent visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->