### PR TITLE
[#1027] restored all calendar search

### DIFF
--- a/__test__/features/Search/searchInCalendars.test.tsx
+++ b/__test__/features/Search/searchInCalendars.test.tsx
@@ -53,58 +53,75 @@ describe('getSearchInCalendars', () => {
 })
 
 describe('buildQuery', () => {
-  it('includes all calendar ids when searchIn is empty', () => {
-    const result = buildQuery(
-      'meeting',
-      baseFilters,
-      ALL_IDS,
-      PERSONAL_IDS,
-      SHARED_IDS
-    )
-    expect(result?.filters.searchIn).toEqual(ALL_IDS)
-  })
+  const cases: Array<{
+    label: string
+    keyword: string
+    searchIn: string
+    allIds: string[]
+    personalIds: string[]
+    sharedIds: string[]
+    expected: string[]
+  }> = [
+    {
+      label: 'includes all calendar ids when searchIn is empty',
+      keyword: 'meeting',
+      searchIn: '',
+      allIds: ALL_IDS,
+      personalIds: PERSONAL_IDS,
+      sharedIds: SHARED_IDS,
+      expected: ALL_IDS
+    },
+    {
+      label: 'filters to personal calendars when searchIn is "my-calendars"',
+      keyword: 'meeting',
+      searchIn: 'my-calendars',
+      allIds: ALL_IDS,
+      personalIds: PERSONAL_IDS,
+      sharedIds: SHARED_IDS,
+      expected: PERSONAL_IDS
+    },
+    {
+      label: 'filters to shared calendars when searchIn is "shared-calendars"',
+      keyword: 'standup',
+      searchIn: 'shared-calendars',
+      allIds: ALL_IDS,
+      personalIds: PERSONAL_IDS,
+      sharedIds: SHARED_IDS,
+      expected: SHARED_IDS
+    },
+    {
+      label:
+        'filters to a single calendar when searchIn is a specific calendar id',
+      keyword: 'standup',
+      searchIn: 'other/cal3',
+      allIds: ALL_IDS,
+      personalIds: PERSONAL_IDS,
+      sharedIds: SHARED_IDS,
+      expected: ['other/cal3']
+    },
+    {
+      label:
+        'returns an empty searchIn when shared-calendars is selected but sharedIds is empty',
+      keyword: 'standup',
+      searchIn: 'shared-calendars',
+      allIds: PERSONAL_IDS,
+      personalIds: PERSONAL_IDS,
+      sharedIds: [],
+      expected: []
+    }
+  ]
 
-  it('filters to personal calendars when searchIn is "my-calendars"', () => {
-    const result = buildQuery(
-      'meeting',
-      { ...baseFilters, searchIn: 'my-calendars' },
-      ALL_IDS,
-      PERSONAL_IDS,
-      SHARED_IDS
-    )
-    expect(result?.filters.searchIn).toEqual(PERSONAL_IDS)
-  })
-
-  it('filters to shared calendars when searchIn is "shared-calendars"', () => {
-    const result = buildQuery(
-      'standup',
-      { ...baseFilters, searchIn: 'shared-calendars' },
-      ALL_IDS,
-      PERSONAL_IDS,
-      SHARED_IDS
-    )
-    expect(result?.filters.searchIn).toEqual(SHARED_IDS)
-  })
-
-  it('filters to a single calendar when searchIn is a specific calendar id', () => {
-    const result = buildQuery(
-      'standup',
-      { ...baseFilters, searchIn: 'other/cal3' },
-      ALL_IDS,
-      PERSONAL_IDS,
-      SHARED_IDS
-    )
-    expect(result?.filters.searchIn).toEqual(['other/cal3'])
-  })
-
-  it('returns an empty searchIn when shared-calendars is selected but sharedIds is empty', () => {
-    const result = buildQuery(
-      'standup',
-      { ...baseFilters, searchIn: 'shared-calendars' },
-      PERSONAL_IDS,
-      PERSONAL_IDS,
-      []
-    )
-    expect(result?.filters.searchIn).toEqual([])
-  })
+  it.each(cases)(
+    '$label',
+    ({ keyword, searchIn, allIds, personalIds, sharedIds, expected }) => {
+      const result = buildQuery(
+        keyword,
+        { ...baseFilters, searchIn },
+        allIds,
+        personalIds,
+        sharedIds
+      )
+      expect(result?.filters.searchIn).toEqual(expected)
+    }
+  )
 })

--- a/__test__/features/Search/searchInCalendars.test.tsx
+++ b/__test__/features/Search/searchInCalendars.test.tsx
@@ -1,0 +1,110 @@
+import {
+  getSearchInCalendars,
+  buildQuery
+} from '@common/features/Search/searchUtils'
+import { SearchFilters } from '@common/features/Search/SearchSlice'
+
+const ALL_IDS = ['owner/cal1', 'owner/cal2', 'other/cal3', 'other/cal4']
+const PERSONAL_IDS = ['owner/cal1', 'owner/cal2']
+const SHARED_IDS = ['other/cal3', 'other/cal4']
+
+const baseFilters: SearchFilters = {
+  searchIn: '',
+  keywords: '',
+  organizers: [],
+  attendees: []
+}
+
+describe('getSearchInCalendars', () => {
+  it('returns all ids when searchIn is empty', () => {
+    expect(getSearchInCalendars('', ALL_IDS, PERSONAL_IDS, SHARED_IDS)).toEqual(
+      ALL_IDS
+    )
+  })
+
+  it('returns personal ids when searchIn is "my-calendars"', () => {
+    expect(
+      getSearchInCalendars('my-calendars', ALL_IDS, PERSONAL_IDS, SHARED_IDS)
+    ).toEqual(PERSONAL_IDS)
+  })
+
+  it('returns shared ids when searchIn is "shared-calendars"', () => {
+    expect(
+      getSearchInCalendars(
+        'shared-calendars',
+        ALL_IDS,
+        PERSONAL_IDS,
+        SHARED_IDS
+      )
+    ).toEqual(SHARED_IDS)
+  })
+
+  it('returns a single-element array when searchIn is a specific calendar id', () => {
+    expect(
+      getSearchInCalendars('other/cal3', ALL_IDS, PERSONAL_IDS, SHARED_IDS)
+    ).toEqual(['other/cal3'])
+  })
+
+  it('returns empty shared ids array when there are no shared calendars', () => {
+    expect(
+      getSearchInCalendars('shared-calendars', PERSONAL_IDS, PERSONAL_IDS, [])
+    ).toEqual([])
+  })
+})
+
+describe('buildQuery', () => {
+  it('includes all calendar ids when searchIn is empty', () => {
+    const result = buildQuery(
+      'meeting',
+      baseFilters,
+      ALL_IDS,
+      PERSONAL_IDS,
+      SHARED_IDS
+    )
+    expect(result?.filters.searchIn).toEqual(ALL_IDS)
+  })
+
+  it('filters to personal calendars when searchIn is "my-calendars"', () => {
+    const result = buildQuery(
+      'meeting',
+      { ...baseFilters, searchIn: 'my-calendars' },
+      ALL_IDS,
+      PERSONAL_IDS,
+      SHARED_IDS
+    )
+    expect(result?.filters.searchIn).toEqual(PERSONAL_IDS)
+  })
+
+  it('filters to shared calendars when searchIn is "shared-calendars"', () => {
+    const result = buildQuery(
+      'standup',
+      { ...baseFilters, searchIn: 'shared-calendars' },
+      ALL_IDS,
+      PERSONAL_IDS,
+      SHARED_IDS
+    )
+    expect(result?.filters.searchIn).toEqual(SHARED_IDS)
+  })
+
+  it('filters to a single calendar when searchIn is a specific calendar id', () => {
+    const result = buildQuery(
+      'standup',
+      { ...baseFilters, searchIn: 'other/cal3' },
+      ALL_IDS,
+      PERSONAL_IDS,
+      SHARED_IDS
+    )
+    expect(result?.filters.searchIn).toEqual(['other/cal3'])
+  })
+
+  it('returns an empty searchIn when shared-calendars is selected but sharedIds is empty', () => {
+    const result = buildQuery(
+      'standup',
+      { ...baseFilters, searchIn: 'shared-calendars' },
+      PERSONAL_IDS,
+      PERSONAL_IDS,
+      []
+    )
+    expect(result?.filters.searchIn).toEqual([])
+  })
+})

--- a/common/src/components/Menubar/EventSearchBar.tsx
+++ b/common/src/components/Menubar/EventSearchBar.tsx
@@ -59,6 +59,11 @@ const SearchBar: React.FC<{
   const personnalCalendars = userId
     ? calendars.filter(c => extractEventBaseUuid(c.id) === userId)
     : []
+
+  const sharedCalendars = userId
+    ? calendars.filter(c => c.id.split('/')[0] !== userId)
+    : []
+
   const filters = useAppSelector(
     state => state.searchResult.searchParams.filters
   )
@@ -134,7 +139,8 @@ const SearchBar: React.FC<{
       searchQuery,
       filters,
       calendars.map(calendar => calendar.id),
-      personnalCalendars.map(calendar => calendar.id)
+      personnalCalendars.map(calendar => calendar.id),
+      sharedCalendars.map(calendar => calendar.id)
     )
     if (cleanedQuery) {
       await dispatch(searchEvents(cleanedQuery))

--- a/common/src/components/Menubar/EventSearchBar.tsx
+++ b/common/src/components/Menubar/EventSearchBar.tsx
@@ -61,7 +61,7 @@ const SearchBar: React.FC<{
     : []
 
   const sharedCalendars = userId
-    ? calendars.filter(c => c.id.split('/')[0] !== userId)
+    ? calendars.filter(c => extractEventBaseUuid(c.id) !== userId)
     : []
 
   const filters = useAppSelector(

--- a/common/src/components/Menubar/useMobileSearch.ts
+++ b/common/src/components/Menubar/useMobileSearch.ts
@@ -78,6 +78,7 @@ function useFilterSearchState(
 interface CalendarsResult {
   calendars: Calendar[]
   personalCalendars: Calendar[]
+  sharedCalendars: Calendar[]
 }
 
 function useCalendars(): CalendarsResult {
@@ -90,13 +91,21 @@ function useCalendars(): CalendarsResult {
         : [],
     [calendars, userId]
   )
-  return { calendars, personalCalendars }
+  const sharedCalendars = useMemo(
+    (): Calendar[] =>
+      userId
+        ? calendars.filter(c => extractEventBaseUuid(c.id) !== userId)
+        : [],
+    [calendars, userId]
+  )
+  return { calendars, personalCalendars, sharedCalendars }
 }
 
 function useSearchAction(
   dispatch: AppDispatch,
   calendarIds: string[],
   personalCalendarIds: string[],
+  sharedCalendarsIds: string[],
   setDialogOpen: (b: boolean) => void
 ): (searchQuery: string, currentFilters: SearchFilters) => Promise<void> {
   return useCallback(
@@ -108,7 +117,8 @@ function useSearchAction(
         searchQuery,
         currentFilters,
         calendarIds,
-        personalCalendarIds
+        personalCalendarIds,
+        sharedCalendarsIds
       )
       if (!query) return
       dispatch(setSearchQuery(query.search))
@@ -116,7 +126,13 @@ function useSearchAction(
       dispatch(setView('search'))
       setDialogOpen(false)
     },
-    [dispatch, calendarIds, personalCalendarIds, setDialogOpen]
+    [
+      dispatch,
+      calendarIds,
+      personalCalendarIds,
+      sharedCalendarsIds,
+      setDialogOpen
+    ]
   )
 }
 
@@ -215,7 +231,7 @@ export function useFilterSearch(
   const searchParams = useAppSelector(state => state.searchResult.searchParams)
   const filters = searchParams.filters
   const currentSearch = searchParams.search
-  const { calendars, personalCalendars } = useCalendars()
+  const { calendars, personalCalendars, sharedCalendars } = useCalendars()
   const {
     inputQuery,
     setInputQuery,
@@ -235,6 +251,7 @@ export function useFilterSearch(
     dispatch,
     calendars.map(c => c.id),
     personalCalendars.map(c => c.id),
+    sharedCalendars.map(c => c.id),
     setDialogOpen
   )
   const handleSearchChange = useSearchChangeHandler(

--- a/common/src/features/Search/SearchInFilter.tsx
+++ b/common/src/features/Search/SearchInFilter.tsx
@@ -40,6 +40,10 @@ export const SearchInFilter: React.FC<Props> = ({ mode }) => {
     ? calendars.filter(c => extractEventBaseUuid(c.id) === userId)
     : []
 
+  const sharedCalendars = userId
+    ? calendars.filter(c => extractEventBaseUuid(c.id) !== userId)
+    : []
+
   const selectorRef = useRef<MobileSelectorHandle>(null)
   const mobileSearch = useFilterSearch('organizers', () => {})
 
@@ -58,6 +62,7 @@ export const SearchInFilter: React.FC<Props> = ({ mode }) => {
         selectorRef={selectorRef}
         filters={searchParams.filters}
         personalCalendars={personalCalendars}
+        sharedCalendars={sharedCalendars}
         t={t}
         handleSelect={v => void handleSelect(v)}
       />
@@ -82,18 +87,26 @@ export const SearchInFilter: React.FC<Props> = ({ mode }) => {
         sx={{ height: '40px' }}
       >
         <MenuItem value="">
-          <Typography sx={{ color: '#243B55', fontSize: '16px' }}>
+          <Typography variant="body1" sx={{ color: 'text.secondary' }}>
             {t('search.filter.allCalendar')}
           </Typography>
         </MenuItem>
         <Divider />
         <MenuItem
           value="my-calendars"
-          sx={{ color: '#243B55', fontSize: '12px' }}
+          sx={{ color: 'text.secondary', fontSize: '12px' }}
         >
           {t('search.filter.myCalendar')}
         </MenuItem>
         {CalendarItemList(personalCalendars)}
+        <Divider />
+        <MenuItem
+          value="shared-calendars"
+          sx={{ color: 'text.secondary', fontSize: '12px' }}
+        >
+          {t('search.filter.sharedCalendars')}
+        </MenuItem>
+        {CalendarItemList(sharedCalendars)}
       </Select>
     </Box>
   )
@@ -112,6 +125,10 @@ const getDisplayLabel = (
     return t('search.filter.myCalendar')
   }
 
+  if (filters.searchIn === 'shared-calendars') {
+    return t('search.filter.sharedCalendars')
+  }
+
   const selected = personalCalendars.find(c => c.id === filters.searchIn)
   return selected ? <CalendarName calendar={selected} /> : t('search.searchIn')
 }
@@ -120,13 +137,22 @@ const CalendarMobileSelector: React.FC<{
   selectorRef: React.RefObject<MobileSelectorHandle>
   filters: SearchFilters
   personalCalendars: Calendar[]
+  sharedCalendars: Calendar[]
   t: (key: string) => string
   handleSelect: (value: string) => void
-}> = ({ selectorRef, filters, personalCalendars, t, handleSelect }) => {
+}> = ({
+  selectorRef,
+  filters,
+  personalCalendars,
+  sharedCalendars,
+  t,
+  handleSelect
+}) => {
+  const allCalendar = [...personalCalendars, ...sharedCalendars]
   return (
     <MobileSelector
       ref={selectorRef}
-      displayText={getDisplayLabel(filters, personalCalendars, t)}
+      displayText={getDisplayLabel(filters, allCalendar, t)}
     >
       <List>
         <ListItemButton
@@ -135,17 +161,30 @@ const CalendarMobileSelector: React.FC<{
         >
           <ListItemText primary={t('search.filter.allCalendar')} />
         </ListItemButton>
-
         <Divider />
-
         <ListItemButton
           selected={filters.searchIn === 'my-calendars'}
           onClick={() => handleSelect('my-calendars')}
         >
           <ListItemText primary={t('search.filter.myCalendar')} />
         </ListItemButton>
-
         {personalCalendars.map(c => (
+          <ListItemButton
+            key={c.id}
+            selected={filters.searchIn === c.id}
+            onClick={() => handleSelect(c.id)}
+          >
+            <CalendarName calendar={c} />
+          </ListItemButton>
+        ))}
+        <Divider />
+        <ListItemButton
+          selected={filters.searchIn === 'shared-calendars'}
+          onClick={() => handleSelect('shared-calendars')}
+        >
+          <ListItemText primary={t('search.filter.sharedCalendars')} />
+        </ListItemButton>
+        {sharedCalendars.map(c => (
           <ListItemButton
             key={c.id}
             selected={filters.searchIn === c.id}

--- a/common/src/features/Search/searchUtils.ts
+++ b/common/src/features/Search/searchUtils.ts
@@ -3,10 +3,15 @@ import { SearchFilters } from './SearchSlice'
 export function getSearchInCalendars(
   searchIn: string,
   allIds: string[],
-  personalIds: string[]
+  personalIds: string[],
+  sharedIds: string[]
 ): string[] {
   if (!searchIn) return allIds
+
   if (searchIn === 'my-calendars') return personalIds
+
+  if (searchIn === 'shared-calendars') return sharedIds
+
   return [searchIn]
 }
 
@@ -14,7 +19,8 @@ export function buildQuery(
   searchQuery: string,
   filters: SearchFilters,
   allIds: string[],
-  personalIds: string[]
+  personalIds: string[],
+  sharedIds: string[]
 ):
   | {
       search: string
@@ -42,7 +48,12 @@ export function buildQuery(
       keywords: trimmedKeywords,
       organizers: filters.organizers.map(u => u.cal_address),
       attendees: filters.attendees.map(u => u.cal_address),
-      searchIn: getSearchInCalendars(filters.searchIn, allIds, personalIds)
+      searchIn: getSearchInCalendars(
+        filters.searchIn,
+        allIds,
+        personalIds,
+        sharedIds
+      )
     }
   }
 }


### PR DESCRIPTION
resolves #1027



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search can now be filtered by shared calendars alongside personal calendar filters.
  * Updated the search interface to include “shared calendars” options on both desktop and mobile.
* **Bug Fixes**
  * Improved search query building to correctly include shared calendar IDs and handle cases where shared calendars are unavailable.
* **Tests**
  * Added test coverage for calendar-based search filtering behavior (including shared-calendar edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->