### PR TITLE
#1030 display expend only if exist calendar in section

### DIFF
--- a/common/src/components/Calendar/CalendarSelection.tsx
+++ b/common/src/components/Calendar/CalendarSelection.tsx
@@ -88,16 +88,22 @@ const CalendarAccordion: React.FC<{
     >
       <AccordionSummary
         expandIcon={
-          <Tooltip
-            title={expended ? t('tooltip.collapse') : t('tooltip.expand')}
-          >
-            <ExpandMoreIcon />
-          </Tooltip>
+          calendars.length > 0 ? (
+            <Tooltip
+              title={expended ? t('tooltip.collapse') : t('tooltip.expand')}
+            >
+              <ExpandMoreIcon />
+            </Tooltip>
+          ) : null
         }
         aria-controls={`${title}-content`}
         id={`${title}-header`}
         className="calendarListHeader"
-        onClick={() => setExpended(!expended)}
+        onClick={() => {
+          if (calendars.length > 0) {
+            setExpended(!expended)
+          }
+        }}
         sx={{
           '& .MuiAccordionSummary-content': {
             display: 'flex',


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar selection UI by showing the expand/collapse icon only when calendars are available.
  * Updated expand/collapse behavior to toggle only when there are calendars to display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->