### PR TITLE
[#1044] added ellipsis to name for attachments

### DIFF
--- a/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
@@ -1,6 +1,6 @@
 import { Attachment } from '@common/types/Attachment'
 import { getFileTypeIcon, Icon } from '@linagora/twake-icons'
-import { Box, Link, radius, Typography } from '@linagora/twake-mui'
+import { Box, Link, radius, Tooltip, Typography } from '@linagora/twake-mui'
 import React, { ReactElement } from 'react'
 
 const chipStyle = {
@@ -15,41 +15,76 @@ const chipStyle = {
   cursor: 'pointer',
   '&:hover': {
     backgroundColor: 'action.hover'
-  },
-  height: '44px'
+  }
 }
 
 export const AttachementChip: React.FC<{
   attachment: Attachment
   endAddorments?: ReactElement
 }> = ({ attachment, endAddorments }) => {
+  const filename = attachment.x_filename ?? ''
+  const lastDot = filename.lastIndexOf('.')
+  const hasExtension = lastDot > 0 && lastDot < filename.length - 1
+  const name = hasExtension ? filename.slice(0, lastDot) : filename
+  const extension = hasExtension ? filename.slice(lastDot) : ''
   const fileIcon = (
-    <Icon
-      icon={getFileTypeIcon(attachment.x_filename ?? '', attachment.fmttype)}
-      size={24}
-    />
+    <Icon icon={getFileTypeIcon(filename, attachment.fmttype)} size={24} />
   )
+
+  const safeHref = React.useMemo(() => {
+    try {
+      const url = new URL(attachment.uri, window.location.origin)
+      return ['http:', 'https:'].includes(url.protocol)
+        ? url.toString()
+        : undefined
+    } catch {
+      return undefined
+    }
+  }, [attachment.uri])
+
   return (
-    <Link
-      key={`${attachment.uri}`}
-      href={attachment.uri}
-      target="_blank"
-      rel="noopener noreferrer"
-      underline="none"
-      sx={{
-        textDecoration: 'none',
-        '&:hover': {
-          textDecoration: 'none'
-        }
-      }}
-    >
-      <Box sx={{ ...chipStyle, width: '150px' }}>
-        {fileIcon}
-        <Typography noWrap variant="body2" sx={{ maxWidth: 240 }}>
-          {attachment.x_filename ?? ''}
-        </Typography>
-        {endAddorments}
-      </Box>
-    </Link>
+    <Tooltip title={filename} placement="top">
+      <Link
+        href={safeHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        underline="none"
+        sx={{
+          textDecoration: 'none',
+          '&:hover': { textDecoration: 'none' }
+        }}
+      >
+        <Box sx={{ ...chipStyle, width: '150px' }}>
+          <Box sx={{ mt: '2px', flexShrink: 0 }}>{fileIcon}</Box>
+          <Box sx={{ width: 0, flex: 1, display: 'flex' }}>
+            <Typography
+              variant="body2"
+              sx={{
+                flexShrink: 1,
+                minWidth: 0,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              {name}
+            </Typography>
+            {extension && (
+              <Typography
+                variant="body2"
+                sx={{
+                  flexShrink: 0,
+                  maxWidth: '85%',
+                  wordBreak: 'break-all'
+                }}
+              >
+                {extension}
+              </Typography>
+            )}
+          </Box>
+          {endAddorments}
+        </Box>
+      </Link>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
resolves #1044 

<img width="557" height="202" alt="image" src="https://github.com/user-attachments/assets/00efaeaf-e65e-44ce-a52e-5bad4b85a29f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced attachment file preview display with separated filename and extension formatting, improved truncation handling, and full filename visibility through tooltip hovers for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->