### PR TITLE
#1041 display correct current date in the calendar

### DIFF
--- a/common/src/components/Calendar/MiniCalendar.tsx
+++ b/common/src/components/Calendar/MiniCalendar.tsx
@@ -132,12 +132,11 @@ export const MiniCalendar: React.FC<{
         slotProps={{
           day: ownerState => {
             const date = ownerState.day.toDate()
-            const today = new Date()
-            today.setHours(0, 0, 0, 0)
+            const today = moment()
             const selected = new Date(selectedDate)
             selected.setHours(0, 0, 0, 0)
 
-            const isToday = date.getTime() === today.getTime()
+            const isToday = ownerState.day.isSame(today, 'day')
             const isSelectedDay =
               calendarRef.current?.view.type === CALENDAR_VIEWS.timeGridDay &&
               date.getTime() === selected.getTime()

--- a/common/src/components/Menubar/components/DatePickerMobile.tsx
+++ b/common/src/components/Menubar/components/DatePickerMobile.tsx
@@ -50,11 +50,11 @@ const calculateCalendarHeightByMonth = (
   const adjustedWeekCount = Math.max(4, weekCount) // Minimum 4 weeks for consistency
 
   // Base height per week + some padding
-  const baseHeightPerWeek = 50
-  const padding = 80
+  const baseHeightPerWeek = 32
+  const padding = 50
   const minHeight = 200 // Minimum height for 4 weeks
-  const maxHeight = 400 // Maximum height for 6 weeks
-  const rootMinHeightOffset = 120
+  const maxHeight = 350 // Maximum height for 6 weeks
+  const rootMinHeightOffset = 100
   const slideTransitionOffset = 100
 
   const calculatedHeight = Math.max(
@@ -158,7 +158,7 @@ export const DatePickerMobile: React.FC<DatePickerMobileProps> = ({
           },
           day: {
             sx: {
-              '&.MuiPickerDay2-dayOutsideMonth': {
+              '&.MuiPickerDay-dayOutsideMonth': {
                 color: theme.palette.grey[500]
               }
             }

--- a/common/src/components/Menubar/components/MonthSelector.tsx
+++ b/common/src/components/Menubar/components/MonthSelector.tsx
@@ -48,7 +48,7 @@ export const MonthSelector: React.FC<MonthSelectorProps> = ({
         return (
           <Button
             key={i}
-            size="large"
+            size="medium"
             variant={isSelected ? 'contained' : 'outlined'}
             aria-pressed={isSelected}
             sx={{

--- a/common/src/theme/makeCalendarOverrides.tsx
+++ b/common/src/theme/makeCalendarOverrides.tsx
@@ -61,7 +61,8 @@ function getDateCalendarRootOverrides(theme: Theme) {
       margin: '0',
       color: alpha(theme.palette.grey[900], 0.9)
     },
-    '&.MuiDateCalendar-root .MuiPickerDay-root.MuiPickersDay-today': {
+    '.MuiDateCalendar-root .MuiPickerDay-root.MuiPickerDay-today': {
+      border: 'none',
       outline: 'none'
     },
     '.MuiDateCalendar-root .MuiPickerDay-root.Mui-selected': {


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1041

To test it, we can change the time in the local to `23:59` of the previous day, then go to the app and wait to the time switch to the new day. 
The current date will be shown in the correct style, and yesterday will not show the border.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date detection logic to properly highlight the current day in calendar views.
  * Updated styling for out-of-month dates in the date picker for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->