### PR TITLE
[#1088] Fix solo RSVP update on recurring event instances

### DIFF
--- a/__test__/features/Events/EventRepetition.test.tsx
+++ b/__test__/features/Events/EventRepetition.test.tsx
@@ -493,6 +493,9 @@ describe('RSVP to Recurring Event', () => {
     jest.useRealTimers()
   })
   it('calls updateEventInstance when accepting single instance', async () => {
+    jest
+      .spyOn(EventDao, 'fetchEventJCal')
+      .mockResolvedValue(['vcalendar', [], []] as any)
     const spy = jest
       .spyOn(eventThunks, 'updateEventInstance')
       .mockImplementation(payload => {

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -130,7 +130,13 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
     expect(attendeeParams.partstat).toBe('TENTATIVE')
 
     // The lossy regeneration path (redux thunk) was not used.
-    expect(dispatch).not.toHaveBeenCalled()
+    // Instead, we update the local store and refresh the calendar.
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'calendars/updateEventLocal'
+      })
+    )
   })
 
   it('falls back to regeneration when the attendee is absent from the event', async () => {
@@ -211,11 +217,20 @@ const RECURRING_JCAL: VCalComponent = [
           'date-time',
           '2025-09-19T10:15:00'
         ],
-        ['dtend', { tzid: 'Europe/Brussels' }, 'date-time', '2025-09-19T11:00:00'],
+        [
+          'dtend',
+          { tzid: 'Europe/Brussels' },
+          'date-time',
+          '2025-09-19T11:00:00'
+        ],
         ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 1 }],
         [
           'attendee',
-          { partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT', cutype: 'INDIVIDUAL' },
+          {
+            partstat: 'ACCEPTED',
+            role: 'REQ-PARTICIPANT',
+            cutype: 'INDIVIDUAL'
+          },
           'cal-address',
           'mailto:me@example.com'
         ]
@@ -233,7 +248,12 @@ const RECURRING_JCAL: VCalComponent = [
           'date-time',
           '2026-06-19T10:15:00'
         ],
-        ['dtend', { tzid: 'Europe/Brussels' }, 'date-time', '2026-06-19T11:00:00'],
+        [
+          'dtend',
+          { tzid: 'Europe/Brussels' },
+          'date-time',
+          '2026-06-19T11:00:00'
+        ],
         [
           'recurrence-id',
           { tzid: 'Europe/Brussels' },
@@ -242,7 +262,11 @@ const RECURRING_JCAL: VCalComponent = [
         ],
         [
           'attendee',
-          { partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT', cutype: 'INDIVIDUAL' },
+          {
+            partstat: 'ACCEPTED',
+            role: 'REQ-PARTICIPANT',
+            cutype: 'INDIVIDUAL'
+          },
           'cal-address',
           'mailto:me@example.com'
         ]
@@ -254,12 +278,7 @@ const RECURRING_JCAL: VCalComponent = [
       [
         ['uid', {}, 'text', 'recurring-uid'],
         ['summary', {}, 'text', 'Weekly sync'],
-        [
-          'dtstart',
-          { tzid: 'Etc/UTC' },
-          'date-time',
-          '2026-06-26T08:15:00'
-        ],
+        ['dtstart', { tzid: 'Etc/UTC' }, 'date-time', '2026-06-26T08:15:00'],
         ['dtend', { tzid: 'Etc/UTC' }, 'date-time', '2026-06-26T09:00:00'],
         [
           'recurrence-id',
@@ -269,7 +288,11 @@ const RECURRING_JCAL: VCalComponent = [
         ],
         [
           'attendee',
-          { partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT', cutype: 'INDIVIDUAL' },
+          {
+            partstat: 'ACCEPTED',
+            role: 'REQ-PARTICIPANT',
+            cutype: 'INDIVIDUAL'
+          },
           'cal-address',
           'mailto:me@example.com'
         ]
@@ -344,15 +367,25 @@ describe('#1088 solo RSVP on recurring event patches only the target exception',
 
     // Only the 2026-06-19 exception should have its PARTSTAT updated.
     const master = vevents.find(v => recurrenceIdOf(v) === undefined)
-    const exc0619 = vevents.find(v => recurrenceIdOf(v) === '2026-06-19T10:15:00')
-    const exc0626 = vevents.find(v => recurrenceIdOf(v) === '2026-06-26T08:15:00')
+    const exc0619 = vevents.find(
+      v => recurrenceIdOf(v) === '2026-06-19T10:15:00'
+    )
+    const exc0626 = vevents.find(
+      v => recurrenceIdOf(v) === '2026-06-26T08:15:00'
+    )
 
     expect(attendeePartstatOf(master!)).toBe('ACCEPTED')
     expect(attendeePartstatOf(exc0619!)).toBe('DECLINED')
     expect(attendeePartstatOf(exc0626!)).toBe('ACCEPTED')
 
     // The lossy regeneration path (redux thunk) must not be used.
-    expect(dispatch).not.toHaveBeenCalled()
+    // Instead, we update the local store and refresh the calendar.
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'calendars/updateEventLocal'
+      })
+    )
   })
 
   it('preserves the RECURRENCE-ID and DTSTART of the patched exception byte-for-byte', async () => {
@@ -388,7 +421,9 @@ describe('#1088 solo RSVP on recurring event patches only the target exception',
 
     const putJCal = putSpy.mock.calls[0][1] as VCalComponent
     const vevents = veventsOf(putJCal)
-    const exc0626 = vevents.find(v => recurrenceIdOf(v) === '2026-06-26T08:15:00')!
+    const exc0626 = vevents.find(
+      v => recurrenceIdOf(v) === '2026-06-26T08:15:00'
+    )!
 
     // DTSTART with Etc/UTC timezone must be preserved exactly (not re-generated
     // via makeVevent which would corrupt the time when the browser is not in UTC).

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -437,6 +437,18 @@ describe('#1088 solo RSVP on recurring event patches only the target exception',
       '2026-06-26T08:15:00'
     ])
 
+    // RECURRENCE-ID must also be preserved byte-for-byte: a regression rewriting
+    // it (while keeping the value searchable) would still corrupt the identifier.
+    const recurrenceId = (exc0626[1] as VObjectProperty[]).find(
+      p => p[0] === 'recurrence-id'
+    )
+    expect(recurrenceId).toEqual([
+      'recurrence-id',
+      { tzid: 'Etc/UTC' },
+      'date-time',
+      '2026-06-26T08:15:00'
+    ])
+
     // PARTSTAT updated.
     expect(attendeePartstatOf(exc0626)).toBe('TENTATIVE')
   })

--- a/__test__/features/Events/RSVPTimezonePreservation.test.tsx
+++ b/__test__/features/Events/RSVPTimezonePreservation.test.tsx
@@ -191,3 +191,269 @@ describe('#1031 partstat update preserves DTSTART timezone', () => {
     expect(dispatch).toHaveBeenCalledTimes(1)
   })
 })
+
+// VCALENDAR with a master VEVENT (RRULE) and two exception VEVENTs.
+// Mirrors the ICS from the bug report (#1088): a weekly recurring meeting
+// where the user tries to update their PARTSTAT on a specific occurrence.
+const RECURRING_JCAL: VCalComponent = [
+  'vcalendar',
+  [],
+  [
+    ['vtimezone', [['tzid', {}, 'text', 'Europe/Brussels']], []],
+    [
+      'vevent',
+      [
+        ['uid', {}, 'text', 'recurring-uid'],
+        ['summary', {}, 'text', 'Weekly sync'],
+        [
+          'dtstart',
+          { tzid: 'Europe/Brussels' },
+          'date-time',
+          '2025-09-19T10:15:00'
+        ],
+        ['dtend', { tzid: 'Europe/Brussels' }, 'date-time', '2025-09-19T11:00:00'],
+        ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 1 }],
+        [
+          'attendee',
+          { partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT', cutype: 'INDIVIDUAL' },
+          'cal-address',
+          'mailto:me@example.com'
+        ]
+      ],
+      []
+    ],
+    [
+      'vevent',
+      [
+        ['uid', {}, 'text', 'recurring-uid'],
+        ['summary', {}, 'text', 'Weekly sync'],
+        [
+          'dtstart',
+          { tzid: 'Europe/Brussels' },
+          'date-time',
+          '2026-06-19T10:15:00'
+        ],
+        ['dtend', { tzid: 'Europe/Brussels' }, 'date-time', '2026-06-19T11:00:00'],
+        [
+          'recurrence-id',
+          { tzid: 'Europe/Brussels' },
+          'date-time',
+          '2026-06-19T10:15:00'
+        ],
+        [
+          'attendee',
+          { partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT', cutype: 'INDIVIDUAL' },
+          'cal-address',
+          'mailto:me@example.com'
+        ]
+      ],
+      []
+    ],
+    [
+      'vevent',
+      [
+        ['uid', {}, 'text', 'recurring-uid'],
+        ['summary', {}, 'text', 'Weekly sync'],
+        [
+          'dtstart',
+          { tzid: 'Etc/UTC' },
+          'date-time',
+          '2026-06-26T08:15:00'
+        ],
+        ['dtend', { tzid: 'Etc/UTC' }, 'date-time', '2026-06-26T09:00:00'],
+        [
+          'recurrence-id',
+          { tzid: 'Etc/UTC' },
+          'date-time',
+          '2026-06-26T08:15:00'
+        ],
+        [
+          'attendee',
+          { partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT', cutype: 'INDIVIDUAL' },
+          'cal-address',
+          'mailto:me@example.com'
+        ]
+      ],
+      []
+    ]
+  ]
+]
+
+// Helper to find all VEVENTs in a patched jCal.
+function veventsOf(jCal: VCalComponent): VCalComponent[] {
+  return (jCal[2] as VCalComponent[]).filter(c => c[0] === 'vevent')
+}
+
+function attendeePartstatOf(vevent: VCalComponent): string | undefined {
+  const props = vevent[1] as VObjectProperty[]
+  const attendee = props.find(p => p[0] === 'attendee')
+  return (attendee?.[1] as Record<string, string>)?.partstat
+}
+
+function recurrenceIdOf(vevent: VCalComponent): string | undefined {
+  const props = vevent[1] as VObjectProperty[]
+  const rid = props.find(p => p[0] === 'recurrence-id')
+  return rid?.[3] as string | undefined
+}
+
+describe('#1088 solo RSVP on recurring event patches only the target exception', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks()
+    jest
+      .spyOn(EventDao, 'fetchEventJCal')
+      .mockResolvedValue(
+        JSON.parse(JSON.stringify(RECURRING_JCAL)) as VCalComponent
+      )
+  })
+
+  it('updates PARTSTAT only in the matching exception VEVENT, leaving others intact', async () => {
+    const putSpy = jest
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({ ok: true, status: 200 } as Response)
+    const dispatch = jest.fn()
+
+    const exceptionEvent = {
+      uid: 'recurring-uid/2026-06-19T10:15:00',
+      recurrenceId: '2026-06-19T10:15:00',
+      URL: '/calendars/cal-1/recurring.ics',
+      attendee: [
+        new userAttendee({
+          cal_address: 'me@example.com',
+          partstat: 'ACCEPTED',
+          role: 'REQ-PARTICIPANT',
+          cutype: 'INDIVIDUAL'
+        })
+      ]
+    } as unknown as CalendarEvent
+
+    await handleRSVP({
+      dispatch,
+      calendar: CALENDAR,
+      user: USER,
+      event: exceptionEvent,
+      rsvp: 'DECLINED',
+      typeOfAction: 'solo'
+    })
+
+    expect(putSpy).toHaveBeenCalledTimes(1)
+    const putJCal = putSpy.mock.calls[0][1] as VCalComponent
+    const vevents = veventsOf(putJCal)
+
+    // All three VEVENTs must survive in the jCal.
+    expect(vevents).toHaveLength(3)
+
+    // Only the 2026-06-19 exception should have its PARTSTAT updated.
+    const master = vevents.find(v => recurrenceIdOf(v) === undefined)
+    const exc0619 = vevents.find(v => recurrenceIdOf(v) === '2026-06-19T10:15:00')
+    const exc0626 = vevents.find(v => recurrenceIdOf(v) === '2026-06-26T08:15:00')
+
+    expect(attendeePartstatOf(master!)).toBe('ACCEPTED')
+    expect(attendeePartstatOf(exc0619!)).toBe('DECLINED')
+    expect(attendeePartstatOf(exc0626!)).toBe('ACCEPTED')
+
+    // The lossy regeneration path (redux thunk) must not be used.
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('preserves the RECURRENCE-ID and DTSTART of the patched exception byte-for-byte', async () => {
+    jest
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({ ok: true, status: 200 } as Response)
+    const dispatch = jest.fn()
+
+    const exceptionEvent = {
+      uid: 'recurring-uid/2026-06-26T08:15:00',
+      recurrenceId: '2026-06-26T08:15:00',
+      URL: '/calendars/cal-1/recurring.ics',
+      attendee: [
+        new userAttendee({
+          cal_address: 'me@example.com',
+          partstat: 'ACCEPTED',
+          role: 'REQ-PARTICIPANT',
+          cutype: 'INDIVIDUAL'
+        })
+      ]
+    } as unknown as CalendarEvent
+
+    const putSpy = jest.spyOn(EventDao, 'putEvent')
+
+    await handleRSVP({
+      dispatch,
+      calendar: CALENDAR,
+      user: USER,
+      event: exceptionEvent,
+      rsvp: 'TENTATIVE',
+      typeOfAction: 'solo'
+    })
+
+    const putJCal = putSpy.mock.calls[0][1] as VCalComponent
+    const vevents = veventsOf(putJCal)
+    const exc0626 = vevents.find(v => recurrenceIdOf(v) === '2026-06-26T08:15:00')!
+
+    // DTSTART with Etc/UTC timezone must be preserved exactly (not re-generated
+    // via makeVevent which would corrupt the time when the browser is not in UTC).
+    const dtstart = (exc0626[1] as VObjectProperty[]).find(
+      p => p[0] === 'dtstart'
+    )
+    expect(dtstart).toEqual([
+      'dtstart',
+      { tzid: 'Etc/UTC' },
+      'date-time',
+      '2026-06-26T08:15:00'
+    ])
+
+    // PARTSTAT updated.
+    expect(attendeePartstatOf(exc0626)).toBe('TENTATIVE')
+  })
+
+  it('falls back to the regeneration thunk when the attendee is absent from the exception', async () => {
+    const noAttendeeJCal: VCalComponent = [
+      'vcalendar',
+      [],
+      [
+        [
+          'vevent',
+          [
+            ['uid', {}, 'text', 'recurring-uid'],
+            [
+              'recurrence-id',
+              { tzid: 'Europe/Brussels' },
+              'date-time',
+              '2026-06-19T10:15:00'
+            ],
+            [
+              'attendee',
+              { partstat: 'ACCEPTED', cutype: 'INDIVIDUAL' },
+              'cal-address',
+              'mailto:someone-else@example.com'
+            ]
+          ],
+          []
+        ]
+      ]
+    ]
+    jest.spyOn(EventDao, 'fetchEventJCal').mockResolvedValue(noAttendeeJCal)
+    jest
+      .spyOn(EventDao, 'putEvent')
+      .mockResolvedValue({ ok: true, status: 200 } as Response)
+    const dispatch = jest.fn()
+
+    const exceptionEvent = {
+      uid: 'recurring-uid/2026-06-19T10:15:00',
+      recurrenceId: '2026-06-19T10:15:00',
+      URL: '/calendars/cal-1/recurring.ics',
+      attendee: []
+    } as unknown as CalendarEvent
+
+    await handleRSVP({
+      dispatch,
+      calendar: CALENDAR,
+      user: USER,
+      event: exceptionEvent,
+      rsvp: 'DECLINED',
+      typeOfAction: 'solo'
+    })
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
@@ -154,6 +154,43 @@ describe('makeDeleteEventInstanceJCal', () => {
       expect(exdate![3]).toBe(overrideRecurrenceId)
     })
 
+    it('emits the EXDATE in the same TZID form as the master DTSTART (#1088)', () => {
+      // Master DTSTART is expressed as TZID:Europe/Paris local time. The CalDAV
+      // server rejects an EXDATE in bare UTC form against such a DTSTART, so the
+      // EXDATE must carry the same TZID parameter and a matching local value.
+      const vevents: VCalComponent[] = [
+        [
+          'vevent',
+          [
+            ['uid', {}, 'text', 'event-uid-1'],
+            [
+              'dtstart',
+              { tzid: 'Europe/Paris' },
+              'date-time',
+              '2024-03-15T11:00:00'
+            ],
+            ['rrule', {}, 'recur', { freq: 'WEEKLY' }]
+          ],
+          []
+        ]
+      ]
+      // Occurrence to delete, expressed in UTC (10:00Z === 11:00 Europe/Paris).
+      const event: CalendarEvent = {
+        ...baseCalendarEvent,
+        recurrenceId: '2024-03-15T10:00:00Z'
+      } as unknown as CalendarEvent
+
+      const result = makeDeleteEventInstanceJCal(vevents, event)
+
+      const masterProps = result[2][0][1] as VObjectProperty[]
+      const exdate = masterProps.find(([k]) => k === 'exdate')
+      expect(exdate).toBeDefined()
+      expect(exdate![1]).toEqual({ tzid: 'Europe/Paris' })
+      expect(exdate![2]).toBe('date-time')
+      // Local wall-clock time in Europe/Paris, no trailing Z.
+      expect(exdate![3]).toBe('2024-03-15T11:00:00')
+    })
+
     it('does not add a duplicate EXDATE when one already matches', () => {
       const existingExdate: VObjectProperty = [
         'exdate',

--- a/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
@@ -332,6 +332,31 @@ describe('makeDeleteEventInstanceJCal', () => {
       expect(exdates).toHaveLength(1)
     })
 
+    it('reads an upper-cased TZID parameter when deduplicating an existing EXDATE', () => {
+      // ICAL.js usually lowercases parameter names, but the TZID lookup stays
+      // case-insensitive (getTzidParam). An EXDATE stored with `TZID` must still
+      // resolve to its instant so the matching deletion is recognised as a dup.
+      const existingExdate: VObjectProperty = [
+        'exdate',
+        { TZID: 'Europe/Ulyanovsk' },
+        'date-time',
+        '2026-06-25T05:00:00'
+      ]
+      const event: CalendarEvent = {
+        ...baseCalendarEvent,
+        recurrenceId: '2026-06-25T01:00:00Z' // same instant, bare UTC form
+      } as unknown as CalendarEvent
+
+      const result = makeDeleteEventInstanceJCal(
+        [ulyanovskMaster([existingExdate])],
+        event
+      )
+
+      const masterProps = result[2][0][1] as VObjectProperty[]
+      const exdates = masterProps.filter(([k]) => k === 'exdate')
+      expect(exdates).toHaveLength(1)
+    })
+
     it('removes a matching override whose RECURRENCE-ID is stored in a different form', () => {
       const override: VCalComponent = [
         'vevent',

--- a/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
@@ -273,6 +273,107 @@ describe('makeDeleteEventInstanceJCal', () => {
     })
   })
 
+  describe('cross-timezone form handling (#1088)', () => {
+    /** Master series in Europe/Ulyanovsk local time (UTC+4, no DST). */
+    function ulyanovskMaster(extraProps: VObjectProperty[] = []): VCalComponent {
+      return [
+        'vevent',
+        [
+          ['uid', {}, 'text', 'event-uid-1'],
+          [
+            'dtstart',
+            { tzid: 'Europe/Ulyanovsk' },
+            'date-time',
+            '2026-06-25T05:00:00'
+          ],
+          ['rrule', {}, 'recur', { freq: 'DAILY' }],
+          ...extraProps
+        ],
+        []
+      ]
+    }
+
+    it('emits the EXDATE in TZID form when deleting an occurrence expressed in UTC', () => {
+      // 01:00Z === 05:00 Europe/Ulyanovsk.
+      const event: CalendarEvent = {
+        ...baseCalendarEvent,
+        recurrenceId: '2026-06-25T01:00:00Z'
+      } as unknown as CalendarEvent
+
+      const result = makeDeleteEventInstanceJCal([ulyanovskMaster()], event)
+
+      const masterProps = result[2][0][1] as VObjectProperty[]
+      const exdate = masterProps.find(([k]) => k === 'exdate')
+      expect(exdate).toBeDefined()
+      expect(exdate![1]).toEqual({ tzid: 'Europe/Ulyanovsk' })
+      expect(exdate![2]).toBe('date-time')
+      expect(exdate![3]).toBe('2026-06-25T05:00:00')
+    })
+
+    it('does not add a duplicate EXDATE when an existing one points at the same instant in another form', () => {
+      const existingExdate: VObjectProperty = [
+        'exdate',
+        {},
+        'date-time',
+        '2026-06-25T01:00:00Z' // bare UTC form, same instant as 05:00 Ulyanovsk
+      ]
+      const event: CalendarEvent = {
+        ...baseCalendarEvent,
+        recurrenceId: '2026-06-25T05:00:00' // wall-clock, no tzid param
+      } as unknown as CalendarEvent
+
+      const result = makeDeleteEventInstanceJCal(
+        [ulyanovskMaster([existingExdate])],
+        event
+      )
+
+      const masterProps = result[2][0][1] as VObjectProperty[]
+      const exdates = masterProps.filter(([k]) => k === 'exdate')
+      expect(exdates).toHaveLength(1)
+    })
+
+    it('removes a matching override whose RECURRENCE-ID is stored in a different form', () => {
+      const override: VCalComponent = [
+        'vevent',
+        [
+          ['uid', {}, 'text', 'event-uid-1'],
+          [
+            'recurrence-id',
+            { tzid: 'Europe/Ulyanovsk' },
+            'date-time',
+            '2026-06-25T05:00:00'
+          ],
+          [
+            'dtstart',
+            { tzid: 'Europe/Ulyanovsk' },
+            'date-time',
+            '2026-06-25T05:00:00'
+          ],
+          ['summary', {}, 'text', 'Accepted occurrence']
+        ],
+        []
+      ]
+      const event: CalendarEvent = {
+        ...baseCalendarEvent,
+        recurrenceId: '2026-06-25T01:00:00Z' // same instant, UTC form
+      } as unknown as CalendarEvent
+
+      const result = makeDeleteEventInstanceJCal(
+        [ulyanovskMaster(), override],
+        event
+      )
+
+      const remainingVevents = (result[2] as VCalComponent[]).filter(
+        ([name]) => name === 'vevent'
+      )
+      expect(remainingVevents).toHaveLength(1)
+      const hasOverride = remainingVevents.some(([, props]) =>
+        (props as VObjectProperty[]).some(([k]) => k === 'recurrence-id')
+      )
+      expect(hasOverride).toBe(false)
+    })
+  })
+
   describe('edge cases', () => {
     it('handles a recurrenceId with a trailing Z correctly when adding EXDATE', () => {
       const event: CalendarEvent = {

--- a/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
@@ -275,7 +275,9 @@ describe('makeDeleteEventInstanceJCal', () => {
 
   describe('cross-timezone form handling (#1088)', () => {
     /** Master series in Europe/Ulyanovsk local time (UTC+4, no DST). */
-    function ulyanovskMaster(extraProps: VObjectProperty[] = []): VCalComponent {
+    function ulyanovskMaster(
+      extraProps: VObjectProperty[] = []
+    ): VCalComponent {
       return [
         'vevent',
         [

--- a/__test__/features/Events/updateEventHelpers/makeEventWithOverridesRecurrenceId.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeEventWithOverridesRecurrenceId.test.ts
@@ -1,0 +1,140 @@
+import {
+  VCalComponent,
+  VObjectProperty
+} from '@common/features/Calendars/types/CalendarData'
+import { CalendarEvent } from '@common/types/EventsTypes'
+import { makeEventWithOverrides } from '@common/features/Events/transformers'
+
+/**
+ * Master series expressed as TZID local time (Europe/Ulyanovsk == UTC+4, no DST).
+ */
+function masterVEvent(): VCalComponent {
+  return [
+    'vevent',
+    [
+      ['uid', {}, 'text', 'uid-1'],
+      [
+        'dtstart',
+        { tzid: 'Europe/Ulyanovsk' },
+        'date-time',
+        '2026-06-25T05:00:00'
+      ],
+      ['rrule', {}, 'recur', { freq: 'DAILY' }],
+      ['summary', {}, 'text', 'Master']
+    ],
+    []
+  ]
+}
+
+/**
+ * Exception VEVENT an attendee created when accepting a single occurrence. Its
+ * RECURRENCE-ID is stored in TZID wall-clock form (05:00 Ulyanovsk == 01:00Z).
+ */
+function attendeeOverride(): VCalComponent {
+  return [
+    'vevent',
+    [
+      ['uid', {}, 'text', 'uid-1'],
+      [
+        'recurrence-id',
+        { tzid: 'Europe/Ulyanovsk' },
+        'date-time',
+        '2026-06-25T05:00:00'
+      ],
+      [
+        'dtstart',
+        { tzid: 'Europe/Ulyanovsk' },
+        'date-time',
+        '2026-06-25T05:00:00'
+      ],
+      ['summary', {}, 'text', 'Accepted occurrence'],
+      [
+        'attendee',
+        { partstat: 'ACCEPTED' },
+        'cal-address',
+        'mailto:bob@example.com'
+      ]
+    ],
+    []
+  ]
+}
+
+function listOverrides(jCal: VCalComponent): VCalComponent[] {
+  return (jCal[2] as VCalComponent[]).filter(
+    ([name, props]) =>
+      name === 'vevent' &&
+      (props as VObjectProperty[]).some(([k]) => k === 'recurrence-id')
+  )
+}
+
+describe('makeEventWithOverrides — RECURRENCE-ID form (#1088)', () => {
+  it('replaces the existing override instead of appending a duplicate when the in-memory id is in a different date-time form', () => {
+    // The organiser edits the occurrence whose in-memory RECURRENCE-ID was
+    // derived from the generated series occurrence — a bare UTC value — while
+    // the stored exception keeps the TZID wall-clock form. Both point at the
+    // same instant (01:00Z). A plain string comparison missed the match and the
+    // regenerated VEVENT was appended, producing a second RECURRENCE-ID for the
+    // same occurrence that SabreDAV rejects ("Duplicate RECURRENCE-ID").
+    const updatedInstance = {
+      uid: 'uid-1',
+      timezone: 'Europe/Ulyanovsk',
+      recurrenceId: '2026-06-25T01:00:00Z',
+      start: '2026-06-25T05:00:00',
+      end: '2026-06-25T06:00:00',
+      attendee: [],
+      title: 'Updated by the organiser'
+    } as unknown as CalendarEvent
+
+    const jCal = makeEventWithOverrides(updatedInstance, [
+      masterVEvent(),
+      attendeeOverride()
+    ])
+
+    const overrides = listOverrides(jCal)
+    expect(overrides).toHaveLength(1)
+
+    const recurrenceId = (overrides[0][1] as VObjectProperty[]).find(
+      ([k]) => k === 'recurrence-id'
+    )
+    expect(recurrenceId).toBeDefined()
+    // The original RECURRENCE-ID tuple (TZID + wall-clock value) is preserved
+    // byte-for-byte so the server still recognises the same occurrence.
+    expect(recurrenceId![1]).toEqual({ tzid: 'Europe/Ulyanovsk' })
+    expect(recurrenceId![3]).toBe('2026-06-25T05:00:00')
+  })
+
+  it('still matches when the stored override uses a bare UTC value and the in-memory id is wall-clock', () => {
+    const overrideUtc: VCalComponent = [
+      'vevent',
+      [
+        ['uid', {}, 'text', 'uid-1'],
+        ['recurrence-id', {}, 'date-time', '2026-06-25T01:00:00Z'],
+        ['dtstart', {}, 'date-time', '2026-06-25T01:00:00Z'],
+        ['summary', {}, 'text', 'Accepted occurrence']
+      ],
+      []
+    ]
+
+    const updatedInstance = {
+      uid: 'uid-1',
+      timezone: 'Europe/Ulyanovsk',
+      recurrenceId: '2026-06-25T05:00:00',
+      start: '2026-06-25T05:00:00',
+      end: '2026-06-25T06:00:00',
+      attendee: [],
+      title: 'Updated by the organiser'
+    } as unknown as CalendarEvent
+
+    const jCal = makeEventWithOverrides(updatedInstance, [
+      masterVEvent(),
+      overrideUtc
+    ])
+
+    const overrides = listOverrides(jCal)
+    expect(overrides).toHaveLength(1)
+    const recurrenceId = (overrides[0][1] as VObjectProperty[]).find(
+      ([k]) => k === 'recurrence-id'
+    )
+    expect(recurrenceId![3]).toBe('2026-06-25T01:00:00Z')
+  })
+})

--- a/__test__/features/Events/updateEventHelpers/makeEventWithOverridesRecurrenceId.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeEventWithOverridesRecurrenceId.test.ts
@@ -101,6 +101,12 @@ describe('makeEventWithOverrides — RECURRENCE-ID form (#1088)', () => {
     // byte-for-byte so the server still recognises the same occurrence.
     expect(recurrenceId![1]).toEqual({ tzid: 'Europe/Ulyanovsk' })
     expect(recurrenceId![3]).toBe('2026-06-25T05:00:00')
+    // The VEVENT was actually regenerated from updatedInstance (replacement),
+    // not merely kept untouched: its SUMMARY reflects the organiser's new title.
+    const summary = (overrides[0][1] as VObjectProperty[]).find(
+      ([k]) => k === 'summary'
+    )
+    expect(summary![3]).toBe('Updated by the organiser')
   })
 
   it('still matches when the stored override uses a bare UTC value and the in-memory id is wall-clock', () => {
@@ -136,5 +142,9 @@ describe('makeEventWithOverrides — RECURRENCE-ID form (#1088)', () => {
       ([k]) => k === 'recurrence-id'
     )
     expect(recurrenceId![3]).toBe('2026-06-25T01:00:00Z')
+    const summary = (overrides[0][1] as VObjectProperty[]).find(
+      ([k]) => k === 'summary'
+    )
+    expect(summary![3]).toBe('Updated by the organiser')
   })
 })

--- a/__test__/features/Events/updateEventHelpers/updateEventPartstatJCalRecurrenceId.test.ts
+++ b/__test__/features/Events/updateEventHelpers/updateEventPartstatJCalRecurrenceId.test.ts
@@ -1,0 +1,116 @@
+import {
+  VCalComponent,
+  VObjectProperty
+} from '@common/features/Calendars/types/CalendarData'
+import { updateEventPartstatJCal } from '@common/features/Events/transformers/updateEventPartstatJCal'
+
+/**
+ * Regression for #1088: accepting/declining a single occurrence that already
+ * has a stored exception (e.g. the organiser moved the 3rd occurrence to 4pm)
+ * must patch that exception's PARTSTAT in place. The stored RECURRENCE-ID is in
+ * TZID wall-clock form while the in-memory recurrenceId can be a bare UTC value;
+ * a plain string match missed it, fell back to regeneration and appended a
+ * duplicate RECURRENCE-ID that SabreDAV rejects.
+ */
+function storedJCal(): VCalComponent {
+  return [
+    'vcalendar',
+    [],
+    [
+      [
+        'vevent',
+        [
+          ['uid', {}, 'text', 'uid-1'],
+          [
+            'dtstart',
+            { tzid: 'Europe/Paris' },
+            'date-time',
+            '2026-06-22T02:00:00'
+          ],
+          ['rrule', {}, 'recur', { freq: 'DAILY' }]
+        ],
+        []
+      ],
+      [
+        'vevent',
+        [
+          ['uid', {}, 'text', 'uid-1'],
+          [
+            'recurrence-id',
+            { tzid: 'Europe/Paris' },
+            'date-time',
+            '2026-06-24T02:00:00'
+          ],
+          [
+            'dtstart',
+            { tzid: 'Europe/Paris' },
+            'date-time',
+            '2026-06-24T16:00:00'
+          ],
+          [
+            'attendee',
+            { partstat: 'NEEDS-ACTION' },
+            'cal-address',
+            'mailto:alice@example.com'
+          ]
+        ],
+        []
+      ]
+    ]
+  ]
+}
+
+function overrideAttendeePartstat(
+  jCal: VCalComponent | null
+): string | undefined {
+  const exception = (jCal?.[2] as VCalComponent[] | undefined)?.find(
+    c =>
+      c[0] === 'vevent' &&
+      (c[1] as VObjectProperty[]).some(([k]) => k === 'recurrence-id')
+  )
+  const attendee = (exception?.[1] as VObjectProperty[] | undefined)?.find(
+    ([k]) => k === 'attendee'
+  )
+  return (attendee?.[1] as Record<string, string> | undefined)?.partstat
+}
+
+const matchAlice = (_p: Record<string, string>, addr: string): boolean =>
+  addr === 'alice@example.com'
+
+describe('updateEventPartstatJCal — RECURRENCE-ID form (#1088)', () => {
+  it('patches the override when the in-memory id is a bare UTC value', () => {
+    // 02:00 Paris (summer) == 00:00Z: the same occurrence in another form.
+    const patched = updateEventPartstatJCal(
+      storedJCal(),
+      matchAlice,
+      'ACCEPTED',
+      '2026-06-24T00:00:00Z',
+      'Europe/Paris'
+    )
+    expect(patched).not.toBeNull()
+    expect(overrideAttendeePartstat(patched)).toBe('ACCEPTED')
+  })
+
+  it('patches the override when the in-memory id is the stored wall-clock value', () => {
+    const patched = updateEventPartstatJCal(
+      storedJCal(),
+      matchAlice,
+      'DECLINED',
+      '2026-06-24T02:00:00',
+      'Europe/Paris'
+    )
+    expect(patched).not.toBeNull()
+    expect(overrideAttendeePartstat(patched)).toBe('DECLINED')
+  })
+
+  it('does not match a genuinely different occurrence', () => {
+    const patched = updateEventPartstatJCal(
+      storedJCal(),
+      matchAlice,
+      'ACCEPTED',
+      '2026-06-25T02:00:00',
+      'Europe/Paris'
+    )
+    expect(patched).toBeNull()
+  })
+})

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -3,7 +3,9 @@ import {
   deleteEventInstance,
   deleteEvent,
   putEvent as putEventAsync,
-  updateEventInstance
+  updateEventInstance,
+  updateEventLocal,
+  refreshCalendarWithSyncToken
 } from '@common/features/Calendars/CalendarSlice'
 import {
   fetchAllRecurrentVevents,
@@ -21,6 +23,7 @@ import { Calendar } from '@common/types/CalendarTypes'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { buildFamilyName } from '@common/utils/buildFamilyName'
 import { isEventOrganiser } from '@common/utils/isEventOrganiser'
+import { getDisplayedCalendarRange } from '@common/utils'
 
 interface RSVPHandlerParams {
   dispatch: AppDispatch
@@ -135,6 +138,13 @@ async function handleSoloRSVP({
   const matcher = makePartstatMatcher(calendar, user)
   if (matcher && event.recurrenceId) {
     if (await patchPartstatInJCal(event, matcher, rsvp, event.recurrenceId)) {
+      dispatch(updateEventLocal({ calId: calendar.id, event: fallbackEvent }))
+      void dispatch(
+        refreshCalendarWithSyncToken({
+          calendar,
+          calendarRange: getDisplayedCalendarRange()
+        })
+      )
       return
     }
   }
@@ -178,6 +188,13 @@ async function handleDefaultRSVP({
 }): Promise<void> {
   const matcher = makePartstatMatcher(calendar, user)
   if (matcher && (await patchPartstatInJCal(event, matcher, rsvp))) {
+    dispatch(updateEventLocal({ calId: calendar.id, event: fallbackEvent }))
+    void dispatch(
+      refreshCalendarWithSyncToken({
+        calendar,
+        calendarRange: getDisplayedCalendarRange()
+      })
+    )
     return
   }
   await dispatch(putEventAsync({ cal: calendar, newEvent: fallbackEvent }))

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -112,7 +112,13 @@ async function patchPartstatInJCal(
   recurrenceId?: string
 ): Promise<boolean> {
   const jCal = await fetchEventJCal(event)
-  const patched = updateEventPartstatJCal(jCal, matcher, partstat, recurrenceId)
+  const patched = updateEventPartstatJCal(
+    jCal,
+    matcher,
+    partstat,
+    recurrenceId,
+    event.timezone
+  )
   if (!patched) {
     return false
   }

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -94,6 +94,34 @@ function updateEventAttendees(
   }
 }
 
+/**
+ * Fetches the stored jCal, patches only the attendee PARTSTAT (preserving
+ * DTSTART, VTIMEZONE and every other property byte-for-byte), then writes it
+ * back. Pass `recurrenceId` to restrict the patch to a single exception VEVENT.
+ *
+ * Returns `true` when the patch was applied, `false` when no matching attendee
+ * was found so the caller can fall back to the regeneration path.
+ */
+async function patchPartstatInJCal(
+  event: CalendarEvent,
+  matcher: AttendeeMatcher,
+  partstat: PartStat,
+  recurrenceId?: string
+): Promise<boolean> {
+  const jCal = await fetchEventJCal(event)
+  const patched = updateEventPartstatJCal(jCal, matcher, partstat, recurrenceId)
+  if (!patched) {
+    return false
+  }
+  const response = await putEvent(event, patched)
+  if (!response.ok) {
+    throw new Error(
+      `RSVP update failed for ${event.URL} with status ${response.status}`
+    )
+  }
+  return true
+}
+
 async function handleSoloRSVP({
   dispatch,
   calendar,
@@ -104,25 +132,12 @@ async function handleSoloRSVP({
 }: Omit<RSVPHandlerParams, 'typeOfAction'> & {
   fallbackEvent: CalendarEvent
 }): Promise<void> {
-  // Direct patch: update only the specific exception VEVENT, preserving all
-  // other properties byte-for-byte (avoids lossy DTSTART/RECURRENCE-ID
-  // timezone regeneration via makeVevent, same root cause as #1031).
   const matcher = makePartstatMatcher(calendar, user)
   if (matcher && event.recurrenceId) {
-    const jCal = await fetchEventJCal(event)
-    const patched = updateEventPartstatJCal(jCal, matcher, rsvp, event.recurrenceId)
-    if (patched) {
-      const response = await putEvent(event, patched)
-      if (!response.ok) {
-        throw new Error(
-          `RSVP update failed for ${event.URL} with status ${response.status}`
-        )
-      }
+    if (await patchPartstatInJCal(event, matcher, rsvp, event.recurrenceId)) {
       return
     }
   }
-  // Fallback: no exception VEVENT exists yet (generated occurrence without an
-  // existing override) or the attendee is absent from it — use regeneration.
   await dispatch(updateEventInstance({ cal: calendar, event: fallbackEvent }))
 }
 
@@ -161,26 +176,10 @@ async function handleDefaultRSVP({
 }: Omit<RSVPHandlerParams, 'typeOfAction'> & {
   fallbackEvent: CalendarEvent
 }): Promise<void> {
-  // Update the attendee PARTSTAT directly in the stored jCal so that DTSTART,
-  // VTIMEZONE and every other property are preserved exactly. Regenerating the
-  // event from the parsed model drops the timezone when it is missing (#1031).
   const matcher = makePartstatMatcher(calendar, user)
-  if (matcher) {
-    const jCal = await fetchEventJCal(event)
-    const patched = updateEventPartstatJCal(jCal, matcher, rsvp)
-    if (patched) {
-      const response = await putEvent(event, patched)
-      if (!response.ok) {
-        throw new Error(
-          `RSVP update failed for ${event.URL} with status ${response.status}`
-        )
-      }
-      return
-    }
+  if (matcher && (await patchPartstatInJCal(event, matcher, rsvp))) {
+    return
   }
-
-  // No matching attendee in the event (e.g. adding oneself for the first time):
-  // fall back to regenerating the event from the model.
   await dispatch(putEventAsync({ cal: calendar, newEvent: fallbackEvent }))
 }
 

--- a/common/src/components/Event/eventHandlers/eventHandlers.ts
+++ b/common/src/components/Event/eventHandlers/eventHandlers.ts
@@ -94,12 +94,36 @@ function updateEventAttendees(
   }
 }
 
-async function handleSoloRSVP(
-  dispatch: AppDispatch,
-  calendar: Calendar,
-  event: CalendarEvent
-): Promise<void> {
-  await dispatch(updateEventInstance({ cal: calendar, event }))
+async function handleSoloRSVP({
+  dispatch,
+  calendar,
+  event,
+  user,
+  rsvp,
+  fallbackEvent
+}: Omit<RSVPHandlerParams, 'typeOfAction'> & {
+  fallbackEvent: CalendarEvent
+}): Promise<void> {
+  // Direct patch: update only the specific exception VEVENT, preserving all
+  // other properties byte-for-byte (avoids lossy DTSTART/RECURRENCE-ID
+  // timezone regeneration via makeVevent, same root cause as #1031).
+  const matcher = makePartstatMatcher(calendar, user)
+  if (matcher && event.recurrenceId) {
+    const jCal = await fetchEventJCal(event)
+    const patched = updateEventPartstatJCal(jCal, matcher, rsvp, event.recurrenceId)
+    if (patched) {
+      const response = await putEvent(event, patched)
+      if (!response.ok) {
+        throw new Error(
+          `RSVP update failed for ${event.URL} with status ${response.status}`
+        )
+      }
+      return
+    }
+  }
+  // Fallback: no exception VEVENT exists yet (generated occurrence without an
+  // existing override) or the attendee is absent from it — use regeneration.
+  await dispatch(updateEventInstance({ cal: calendar, event: fallbackEvent }))
 }
 
 async function handleAllRSVP(
@@ -174,7 +198,14 @@ export async function handleRSVP({
   }
 
   if (typeOfAction === 'solo') {
-    await handleSoloRSVP(dispatch, calendar, newEvent)
+    await handleSoloRSVP({
+      dispatch,
+      calendar,
+      event,
+      user,
+      rsvp,
+      fallbackEvent: newEvent
+    })
   } else if (typeOfAction === 'all') {
     if (!user?.email) {
       throw new Error('Cannot update all occurrences without user email')

--- a/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
+++ b/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
@@ -10,6 +10,7 @@ import { CalendarEvent } from '@common/types/EventsTypes'
 import { TIMEZONES } from '@common/utils/timezone-data'
 import moment from 'moment-timezone'
 import { filterComponents } from './parseFetchedEvent'
+import { getTzidParam, sameRecurrence } from './recurrenceInstant'
 
 export function makeDeleteEventInstanceJCal(
   vevents: VCalComponent[],
@@ -44,8 +45,7 @@ export function makeDeleteEventInstanceJCal(
   // occurrence as local wall-clock time in that zone instead of a bare UTC value.
   // See #1088.
   const dtstartProp = masterProps.find(([k]) => k.toLowerCase() === 'dtstart')
-  const dtParams = (dtstartProp?.[1] ?? {}) as Record<string, string>
-  const dtstartTzid = dtParams.tzid
+  const dtstartTzid = getTzidParam(dtstartProp?.[1])
 
   const valueType = seriesEvent.allday ? 'date' : 'date-time'
   const useTzidForm = !seriesEvent.allday && Boolean(dtstartTzid)
@@ -60,10 +60,14 @@ export function makeDeleteEventInstanceJCal(
   }
 
   const isDuplicate = masterProps.some((prop: VObjectProperty) => {
-    return (
-      prop[0].toLowerCase() === 'exdate' &&
-      prop[3] &&
-      normalizeRecurrenceId(prop[3]) === normalizeRecurrenceId(exdateProperty)
+    if (prop[0].toLowerCase() !== 'exdate' || !prop[3]) {
+      return false
+    }
+    const existingTzid = getTzidParam(prop[1])
+    return sameRecurrence(
+      { value: prop[3], tzid: existingTzid },
+      { value: exdateProperty, tzid: useTzidForm ? dtstartTzid : undefined },
+      seriesEvent.timezone
     )
   })
 
@@ -75,19 +79,19 @@ export function makeDeleteEventInstanceJCal(
   // Update the master VEVENT with the new properties
   vevents[masterIndex][1] = masterProps
 
-  // Remove the override instance if it exists (in case it was an override being deleted)
+  // Remove the override instance if it exists (in case it was an override being
+  // deleted). Match by instant so an override stored in TZID/UTC form is still
+  // recognised against the deleted occurrence expressed in another form.
   const filteredVevents = vevents.filter(([, props]) => {
     const recurrenceIdProp = (props as VObjectProperty[]).find(
       ([k]) => k.toLowerCase() === 'recurrence-id'
     )
     if (!recurrenceIdProp) return true // Keep master
-    return (
-      normalizeRecurrenceId(recurrenceIdProp[3]) !==
-      normalizeRecurrenceId(
-        moment
-          .tz(exdateValue, seriesEvent.timezone)
-          .format('YYYY-MM-DDTHH:mm:ss') as VObjectValue
-      )
+    const overrideTzid = getTzidParam(recurrenceIdProp[1])
+    return !sameRecurrence(
+      { value: recurrenceIdProp[3], tzid: overrideTzid },
+      { value: exdateValue },
+      seriesEvent.timezone
     ) // Remove matching override
   })
 
@@ -101,9 +105,3 @@ export function makeDeleteEventInstanceJCal(
     [...filteredVevents, vtimezone.component.jCal as VCalComponent]
   ]
 }
-
-const normalizeRecurrenceId = (id: VObjectValue): string =>
-  (typeof id === 'string' || typeof id === 'number' ? String(id) : '').replace(
-    /Z$/,
-    ''
-  )

--- a/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
+++ b/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
@@ -35,19 +35,39 @@ export function makeDeleteEventInstanceJCal(
   })
   const masterProps = vevents[masterIndex][1] as VObjectProperty[]
 
+  // EXDATE must use the same date-time form as the master DTSTART, otherwise the
+  // CalDAV server rejects the update ("EXDATE date-time form (UTC) must match
+  // DTSTART date-time form (TZID:...)"). When the series DTSTART carries a TZID we
+  // therefore emit the EXDATE with that same TZID parameter and express the
+  // occurrence as local wall-clock time in that zone instead of a bare UTC value.
+  // See #1088.
+  const dtstartProp = masterProps.find(([k]) => k.toLowerCase() === 'dtstart')
+  const dtstartTzid = (
+    (dtstartProp?.[1] as Record<string, string> | undefined) ?? {}
+  ).tzid
+
+  const valueType = seriesEvent.allday ? 'date' : 'date-time'
+  const useTzidForm = !seriesEvent.allday && Boolean(dtstartTzid)
+  const exdateParams: Record<string, string> = useTzidForm
+    ? { tzid: dtstartTzid as string }
+    : {}
+  const exdateProperty: VObjectValue = useTzidForm
+    ? (moment
+        .tz(exdateValue, seriesEvent.timezone)
+        .format('YYYY-MM-DDTHH:mm:ss') as VObjectValue)
+    : (exdateValue as VObjectValue)
+
   const isDuplicate = masterProps.some((prop: VObjectProperty) => {
     return (
       prop[0].toLowerCase() === 'exdate' &&
       prop[3] &&
-      normalizeRecurrenceId(prop[3]) ===
-        normalizeRecurrenceId(exdateValue as VObjectValue)
+      normalizeRecurrenceId(prop[3]) === normalizeRecurrenceId(exdateProperty)
     )
   })
 
   if (!isDuplicate) {
     // Add new EXDATE property as a separate entry
-    const valueType = seriesEvent.allday ? 'date' : 'date-time'
-    masterProps.push(['exdate', {}, valueType, exdateValue])
+    masterProps.push(['exdate', exdateParams, valueType, exdateProperty])
   }
 
   // Update the master VEVENT with the new properties

--- a/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
+++ b/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
@@ -44,20 +44,20 @@ export function makeDeleteEventInstanceJCal(
   // occurrence as local wall-clock time in that zone instead of a bare UTC value.
   // See #1088.
   const dtstartProp = masterProps.find(([k]) => k.toLowerCase() === 'dtstart')
-  const dtstartTzid = (
-    (dtstartProp?.[1] as Record<string, string> | undefined) ?? {}
-  ).tzid
+  const dtParams = (dtstartProp?.[1] ?? {}) as Record<string, string>
+  const dtstartTzid = dtParams.tzid
 
   const valueType = seriesEvent.allday ? 'date' : 'date-time'
   const useTzidForm = !seriesEvent.allday && Boolean(dtstartTzid)
   const exdateParams: Record<string, string> = useTzidForm
-    ? { tzid: dtstartTzid as string }
+    ? { tzid: dtstartTzid }
     : {}
-  const exdateProperty: VObjectValue = useTzidForm
-    ? (moment
-        .tz(exdateValue, dtstartTzid as string)
-        .format('YYYY-MM-DDTHH:mm:ss') as VObjectValue)
-    : (exdateValue as VObjectValue)
+
+  let exdateProperty = exdateValue as VObjectValue
+  if (useTzidForm) {
+    const zoned = moment.tz(exdateValue, dtstartTzid)
+    exdateProperty = zoned.format('YYYY-MM-DDTHH:mm:ss') as VObjectValue
+  }
 
   const isDuplicate = masterProps.some((prop: VObjectProperty) => {
     return (

--- a/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
+++ b/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
@@ -55,7 +55,7 @@ export function makeDeleteEventInstanceJCal(
     : {}
   const exdateProperty: VObjectValue = useTzidForm
     ? (moment
-        .tz(exdateValue, seriesEvent.timezone)
+        .tz(exdateValue, dtstartTzid as string)
         .format('YYYY-MM-DDTHH:mm:ss') as VObjectValue)
     : (exdateValue as VObjectValue)
 

--- a/common/src/features/Events/transformers/makeEventWithOverrides.ts
+++ b/common/src/features/Events/transformers/makeEventWithOverrides.ts
@@ -6,6 +6,7 @@ import {
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { makeTimezone, makeVevent } from '@common/features/Events/utils'
 import { VcalendarProperties } from '@common/features/Calendars/types/VcalendarProperties'
+import { getTzidParam, sameRecurrence } from './recurrenceInstant'
 
 export function makeEventWithOverrides(
   updatedEvent: CalendarEvent,
@@ -23,10 +24,24 @@ export function makeEventWithOverrides(
     const recurrenceId = (ve[1] as VObjectProperty[]).find(
       ([k]) => k === 'recurrence-id'
     )
+    const storedTzid = getTzidParam(recurrenceId?.[1])
     if (
       recurrenceId &&
-      normalizeId(recurrenceId[3]) === normalizeId(updatedEvent.recurrenceId)
+      updatedEvent.recurrenceId &&
+      sameRecurrence(
+        { value: recurrenceId[3], tzid: storedTzid },
+        { value: updatedEvent.recurrenceId },
+        updatedEvent.timezone
+      )
     ) {
+      // Preserve the stored RECURRENCE-ID tuple (its TZID parameter and exact
+      // wall-clock form) on the regenerated VEVENT. makeVevent re-derives the
+      // RECURRENCE-ID through `new Date()`, which parses the tz-naive string as
+      // browser-local time and can shift it into another form. Emitting that
+      // shifted id alongside the original one made the server reject the update
+      // with "Duplicate RECURRENCE-ID". RECURRENCE-ID identifies the original
+      // occurrence and must never change on an instance edit. See #1088.
+      preserveRecurrenceId(updatedVevent, recurrenceId)
       nextVevents[i] = updatedVevent as VCalComponent // replace
       replaced = true
       break
@@ -46,5 +61,13 @@ export function makeEventWithOverrides(
   ]
 }
 
-const normalizeId = (id: unknown): string =>
-  ((id ?? '') as string).replace(/Z$/, '')
+function preserveRecurrenceId(
+  vevent: [string, unknown[]],
+  storedRecurrenceId: VObjectProperty
+): void {
+  const props = vevent[1] as VObjectProperty[]
+  const index = props.findIndex(([k]) => k.toLowerCase() === 'recurrence-id')
+  if (index !== -1) {
+    props[index] = storedRecurrenceId
+  }
+}

--- a/common/src/features/Events/transformers/makeEventWithOverrides.ts
+++ b/common/src/features/Events/transformers/makeEventWithOverrides.ts
@@ -22,7 +22,7 @@ export function makeEventWithOverrides(
   for (let i = 0; i < nextVevents.length; i++) {
     const ve = nextVevents[i]
     const recurrenceId = (ve[1] as VObjectProperty[]).find(
-      ([k]) => k === 'recurrence-id'
+      ([k]) => k.toLowerCase() === 'recurrence-id'
     )
     const storedTzid = getTzidParam(recurrenceId?.[1])
     if (

--- a/common/src/features/Events/transformers/recurrenceInstant.ts
+++ b/common/src/features/Events/transformers/recurrenceInstant.ts
@@ -1,0 +1,82 @@
+import moment from 'moment-timezone'
+
+/**
+ * Converts a RECURRENCE-ID / EXDATE jCal value into a comparable instant
+ * (epoch milliseconds). The same occurrence can be expressed in several
+ * date-time forms — a bare UTC value (trailing `Z`), a TZID local wall-clock
+ * value, or a floating value — and a plain string comparison treats them as
+ * different occurrences. That made the CalDAV server reject the update with a
+ * "Duplicate RECURRENCE-ID" / EXDATE form error, because the same occurrence
+ * ended up emitted twice in two different forms. See #1088.
+ *
+ * Resolution order:
+ * - a trailing `Z` is treated as UTC,
+ * - otherwise the explicit `tzid` parameter (when present) fixes the zone,
+ * - otherwise the value is interpreted in `fallbackTz` (the series timezone).
+ *
+ * Returns `NaN` for empty/unparseable values so callers can skip them.
+ */
+export function recurrenceInstant(
+  value: unknown,
+  tzid?: string,
+  fallbackTz?: string
+): number {
+  const raw = value == null ? '' : String(value)
+  if (!raw) {
+    return NaN
+  }
+  if (/Z$/.test(raw)) {
+    return moment.utc(raw).valueOf()
+  }
+  const zone = tzid ?? fallbackTz
+  if (zone && moment.tz.zone(zone)) {
+    return moment.tz(raw, zone).valueOf()
+  }
+  return moment(raw).valueOf()
+}
+
+/**
+ * True when two RECURRENCE-ID / EXDATE values designate the same occurrence.
+ * Keeps the historical lenient string match (a trailing `Z` is ignored) and
+ * additionally recognises values that resolve to the same instant even when
+ * written in different forms (UTC vs TZID local time).
+ */
+export function sameRecurrence(
+  a: { value: unknown; tzid?: string },
+  b: { value: unknown; tzid?: string },
+  fallbackTz?: string
+): boolean {
+  if (normalizeRecurrenceId(a.value) === normalizeRecurrenceId(b.value)) {
+    return true
+  }
+  const instantA = recurrenceInstant(a.value, a.tzid, fallbackTz)
+  const instantB = recurrenceInstant(b.value, b.tzid, fallbackTz)
+  return (
+    Number.isFinite(instantA) &&
+    Number.isFinite(instantB) &&
+    instantA === instantB
+  )
+}
+
+/** Strips a trailing `Z` for the lenient string-form comparison. */
+export function normalizeRecurrenceId(id: unknown): string {
+  const raw = typeof id === 'string' || typeof id === 'number' ? String(id) : ''
+  return raw.replace(/Z$/, '')
+}
+
+/**
+ * Reads the `TZID` parameter of a jCal property regardless of key casing.
+ * ICAL.js normally lowercases parameter names, but the lookup stays
+ * case-insensitive so an upper-cased `TZID` cannot silently fall back to the
+ * bare UTC form and break SabreDAV's date-time form validation.
+ */
+export function getTzidParam(
+  params: Record<string, unknown> | undefined
+): string | undefined {
+  if (!params) {
+    return undefined
+  }
+  const key = Object.keys(params).find(k => k.toLowerCase() === 'tzid')
+  const value = key ? params[key] : undefined
+  return typeof value === 'string' ? value : undefined
+}

--- a/common/src/features/Events/transformers/recurrenceInstant.ts
+++ b/common/src/features/Events/transformers/recurrenceInstant.ts
@@ -59,6 +59,22 @@ function hasDefiniteZone(
 }
 
 /**
+ * Resolves a value to a trustworthy instant: the epoch milliseconds when the
+ * value carries a definite zone, or `NaN` when it is tz-naive (so callers fall
+ * back to the lenient string comparison instead of trusting a system-local
+ * instant).
+ */
+function definiteInstant(
+  value: unknown,
+  tzid?: string,
+  fallbackTz?: string
+): number {
+  return hasDefiniteZone(value, tzid, fallbackTz)
+    ? recurrenceInstant(value, tzid, fallbackTz)
+    : NaN
+}
+
+/**
  * True when two RECURRENCE-ID / EXDATE values designate the same occurrence.
  * Compares the resolved instants when both sides carry an unambiguous zone, so
  * two forms of the same occurrence (UTC vs TZID local time) match while
@@ -78,12 +94,9 @@ export function sameRecurrence(
   b: { value: unknown; tzid?: string },
   fallbackTz?: string
 ): boolean {
-  const instantA = recurrenceInstant(a.value, a.tzid, fallbackTz)
-  const instantB = recurrenceInstant(b.value, b.tzid, fallbackTz)
-  const bothDefinite =
-    hasDefiniteZone(a.value, a.tzid, fallbackTz) &&
-    hasDefiniteZone(b.value, b.tzid, fallbackTz)
-  if (bothDefinite && Number.isFinite(instantA) && Number.isFinite(instantB)) {
+  const instantA = definiteInstant(a.value, a.tzid, fallbackTz)
+  const instantB = definiteInstant(b.value, b.tzid, fallbackTz)
+  if (Number.isFinite(instantA) && Number.isFinite(instantB)) {
     return instantA === instantB
   }
 

--- a/common/src/features/Events/transformers/recurrenceInstant.ts
+++ b/common/src/features/Events/transformers/recurrenceInstant.ts
@@ -36,12 +36,42 @@ export function recurrenceInstant(
 }
 
 /**
+ * True when a value resolves to an unambiguous instant: it carries a trailing
+ * `Z`, an explicit `tzid`, or a `fallbackTz` is supplied to anchor the bare
+ * wall-clock value. Without any of these the value is tz-naive and would be
+ * resolved in the (arbitrary) system-local zone, so its instant cannot be
+ * trusted for comparison.
+ */
+function hasDefiniteZone(
+  value: unknown,
+  tzid?: string,
+  fallbackTz?: string
+): boolean {
+  const raw = value == null ? '' : String(value)
+  if (!raw) {
+    return false
+  }
+  if (/Z$/.test(raw)) {
+    return true
+  }
+  const zone = tzid ?? fallbackTz
+  return Boolean(zone && moment.tz.zone(zone))
+}
+
+/**
  * True when two RECURRENCE-ID / EXDATE values designate the same occurrence.
- * Compares the resolved instants first so two forms of the same occurrence
- * (UTC vs TZID local time) match while genuinely different occurrences stay
- * distinct — even when `fallbackTz` is non-UTC, where a bare value and its
- * `Z`-suffixed form resolve to different instants. The lenient string match
- * (a trailing `Z` is ignored) is only a fallback for legacy/unparseable values.
+ * Compares the resolved instants when both sides carry an unambiguous zone, so
+ * two forms of the same occurrence (UTC vs TZID local time) match while
+ * genuinely different occurrences stay distinct — even when `fallbackTz` is
+ * non-UTC, where a bare value and its `Z`-suffixed form resolve to different
+ * instants.
+ *
+ * When either side is tz-naive (no `Z`, no `tzid`, no `fallbackTz`) its instant
+ * would be resolved in the arbitrary system-local zone and cannot be trusted,
+ * so the comparison falls back to the lenient wall-clock string match (a
+ * trailing `Z` is ignored). This is the only signal available, and it keeps the
+ * solo recurring-instance RSVP matching when the in-memory event carries no
+ * timezone. See #1088.
  */
 export function sameRecurrence(
   a: { value: unknown; tzid?: string },
@@ -50,7 +80,10 @@ export function sameRecurrence(
 ): boolean {
   const instantA = recurrenceInstant(a.value, a.tzid, fallbackTz)
   const instantB = recurrenceInstant(b.value, b.tzid, fallbackTz)
-  if (Number.isFinite(instantA) && Number.isFinite(instantB)) {
+  const bothDefinite =
+    hasDefiniteZone(a.value, a.tzid, fallbackTz) &&
+    hasDefiniteZone(b.value, b.tzid, fallbackTz)
+  if (bothDefinite && Number.isFinite(instantA) && Number.isFinite(instantB)) {
     return instantA === instantB
   }
 

--- a/common/src/features/Events/transformers/recurrenceInstant.ts
+++ b/common/src/features/Events/transformers/recurrenceInstant.ts
@@ -37,25 +37,26 @@ export function recurrenceInstant(
 
 /**
  * True when two RECURRENCE-ID / EXDATE values designate the same occurrence.
- * Keeps the historical lenient string match (a trailing `Z` is ignored) and
- * additionally recognises values that resolve to the same instant even when
- * written in different forms (UTC vs TZID local time).
+ * Compares the resolved instants first so two forms of the same occurrence
+ * (UTC vs TZID local time) match while genuinely different occurrences stay
+ * distinct — even when `fallbackTz` is non-UTC, where a bare value and its
+ * `Z`-suffixed form resolve to different instants. The lenient string match
+ * (a trailing `Z` is ignored) is only a fallback for legacy/unparseable values.
  */
 export function sameRecurrence(
   a: { value: unknown; tzid?: string },
   b: { value: unknown; tzid?: string },
   fallbackTz?: string
 ): boolean {
-  if (normalizeRecurrenceId(a.value) === normalizeRecurrenceId(b.value)) {
-    return true
-  }
   const instantA = recurrenceInstant(a.value, a.tzid, fallbackTz)
   const instantB = recurrenceInstant(b.value, b.tzid, fallbackTz)
-  return (
-    Number.isFinite(instantA) &&
-    Number.isFinite(instantB) &&
-    instantA === instantB
-  )
+  if (Number.isFinite(instantA) && Number.isFinite(instantB)) {
+    return instantA === instantB
+  }
+
+  const normalizedA = normalizeRecurrenceId(a.value)
+  const normalizedB = normalizeRecurrenceId(b.value)
+  return Boolean(normalizedA) && normalizedA === normalizedB
 }
 
 /** Strips a trailing `Z` for the lenient string-form comparison. */

--- a/common/src/features/Events/transformers/updateEventPartstatJCal.ts
+++ b/common/src/features/Events/transformers/updateEventPartstatJCal.ts
@@ -19,6 +19,10 @@ export type AttendeeMatcher = (
  * model, which is lossy: when the in-memory timezone is missing, regeneration
  * silently rewrites DTSTART to UTC and drops the TZID parameter (see #1031).
  *
+ * When `recurrenceId` is provided the patch is restricted to the single VEVENT
+ * whose RECURRENCE-ID matches that value (solo recurring-instance RSVP, see
+ * #1088). Omit it to update every VEVENT (non-recurring events).
+ *
  * Returns the patched jCal, or `null` when no matching attendee was found so
  * the caller can fall back to the regeneration path (e.g. adding oneself as a
  * brand-new attendee).
@@ -26,7 +30,8 @@ export type AttendeeMatcher = (
 export function updateEventPartstatJCal(
   jcal: VCalComponent,
   matchAttendee: AttendeeMatcher,
-  partstat: string
+  partstat: string,
+  recurrenceId?: string
 ): VCalComponent | null {
   let matched = false
 
@@ -40,6 +45,18 @@ export function updateEventPartstatJCal(
     (component: VCalComponent): VCalComponent => {
       if (!Array.isArray(component) || component[0] !== 'vevent') {
         return component
+      }
+
+      if (recurrenceId !== undefined) {
+        const veventProps = component[1] as VObjectProperty[]
+        const ridProp = veventProps.find(([k]) => k === 'recurrence-id')
+        if (!ridProp) {
+          return component
+        }
+        const veventRid = normalizeId(ridProp[3] as string)
+        if (veventRid !== normalizeId(recurrenceId)) {
+          return component
+        }
       }
 
       const properties = component[1] as VObjectProperty[]
@@ -73,3 +90,6 @@ export function updateEventPartstatJCal(
 
   return [name, props, updatedComponents] as VCalComponent
 }
+
+const normalizeId = (id: unknown): string =>
+  ((id ?? '') as string).replace(/Z$/, '')

--- a/common/src/features/Events/transformers/updateEventPartstatJCal.ts
+++ b/common/src/features/Events/transformers/updateEventPartstatJCal.ts
@@ -2,6 +2,7 @@ import {
   VCalComponent,
   VObjectProperty
 } from '@common/features/Calendars/types/CalendarData'
+import { getTzidParam, sameRecurrence } from './recurrenceInstant'
 
 /**
  * Predicate identifying the ATTENDEE whose PARTSTAT must be updated.
@@ -20,8 +21,15 @@ export type AttendeeMatcher = (
  * silently rewrites DTSTART to UTC and drops the TZID parameter (see #1031).
  *
  * When `recurrenceId` is provided the patch is restricted to the single VEVENT
- * whose RECURRENCE-ID matches that value (solo recurring-instance RSVP, see
- * #1088). Omit it to update every VEVENT (non-recurring events).
+ * whose RECURRENCE-ID designates that occurrence (solo recurring-instance RSVP,
+ * see #1088). Omit it to update every VEVENT (non-recurring events).
+ *
+ * The RECURRENCE-ID match is instant-aware: the same occurrence can be stored
+ * in a TZID wall-clock form while the in-memory `recurrenceId` is a bare UTC
+ * value (or vice versa). A plain string comparison missed that and fell back to
+ * regenerating the VEVENT, which appended a second exception for the same
+ * occurrence — SabreDAV then rejected the PUT with "Duplicate RECURRENCE-ID".
+ * `fallbackTz` (the series timezone) resolves tz-naive values. See #1088.
  *
  * Returns the patched jCal, or `null` when no matching attendee was found so
  * the caller can fall back to the regeneration path (e.g. adding oneself as a
@@ -31,7 +39,8 @@ export function updateEventPartstatJCal(
   jcal: VCalComponent,
   matchAttendee: AttendeeMatcher,
   partstat: string,
-  recurrenceId?: string
+  recurrenceId?: string,
+  fallbackTz?: string
 ): VCalComponent | null {
   let matched = false
 
@@ -49,12 +58,20 @@ export function updateEventPartstatJCal(
 
       if (recurrenceId !== undefined) {
         const veventProps = component[1] as VObjectProperty[]
-        const ridProp = veventProps.find(([k]) => k === 'recurrence-id')
+        const ridProp = veventProps.find(
+          ([k]) => k.toLowerCase() === 'recurrence-id'
+        )
         if (!ridProp) {
           return component
         }
-        const veventRid = normalizeId(ridProp[3] as string)
-        if (veventRid !== normalizeId(recurrenceId)) {
+        const storedTzid = getTzidParam(ridProp[1] as Record<string, unknown>)
+        if (
+          !sameRecurrence(
+            { value: ridProp[3], tzid: storedTzid },
+            { value: recurrenceId },
+            fallbackTz
+          )
+        ) {
           return component
         }
       }
@@ -90,6 +107,3 @@ export function updateEventPartstatJCal(
 
   return [name, props, updatedComponents] as VCalComponent
 }
-
-const normalizeId = (id: unknown): string =>
-  ((id ?? '') as string).replace(/Z$/, '')


### PR DESCRIPTION
## Summary

- `handleSoloRSVP` used `makeEventWithOverrides` → `makeVevent` to regenerate the exception VEVENT when the user accepted/declined a specific occurrence. `makeVevent` converts the stored jCal local-time strings (`recurrenceId`, `dtstart`) via `new Date()`, which JavaScript parses as **browser local time** — not the event timezone. When the browser timezone differs from the event timezone, the regenerated `RECURRENCE-ID` has the wrong time value, so the server treats the updated VEVENT as a different occurrence and the original `PARTSTAT` survives unchanged.
- Extended `updateEventPartstatJCal` with an optional `recurrenceId` filter so it can target a single exception VEVENT without touching the master or other overrides.
- `handleSoloRSVP` now uses `fetchEventJCal` + `updateEventPartstatJCal(…, recurrenceId)` — patching the ATTENDEE PARTSTAT directly in the stored jCal — and only falls back to `updateEventInstance` for generated occurrences that do not yet have an exception VEVENT, or when the attendee is absent from it.

## Test plan

- [ ] Added three regression tests in `RSVPTimezonePreservation.test.tsx`:
  1. Solo RSVP on an existing exception updates only that exception's PARTSTAT, leaving the master and other exceptions unchanged.
  2. DTSTART and RECURRENCE-ID of the patched exception are preserved byte-for-byte (no timezone re-conversion via `makeVevent`), specifically tested with a non-standard `Etc/UTC` timezone.
  3. Falls back to the regeneration thunk when the attendee is absent from the exception VEVENT.
- [ ] Manual: accept/decline a specific occurrence of a recurring event → status persists after refresh.
- [ ] Manual: accepting/declining all occurrences still works (the `all` path is unchanged).

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSVP handling for recurring events to preserve DTSTART/RECURRENCE-ID timezone and local wall-clock values, updating PARTSTAT only on the matching exception instance.
  * “Solo” and default RSVP flows now apply targeted local updates + refresh to avoid lossy regeneration when possible.
  * Recurring-event deletion now writes timezone-aware EXDATE (including TZID when applicable) and better matches/removes overrides across UTC vs local representations, preventing duplicates.

* **Tests**
  * Expanded regression coverage for recurring RSVP timezone preservation (`#1031`), solo RSVP patching for exceptions (`#1088`), and CalDAV-style EXDATE/RECURRENCE-ID behavior across time forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->