### PR TITLE
#1071 generate visio link in saas

### DIFF
--- a/common/src/components/Event/fields/VideoConferenceField.tsx
+++ b/common/src/components/Event/fields/VideoConferenceField.tsx
@@ -1,11 +1,5 @@
 import iconCamera from '@common/static/images/icon-camera.svg'
-import {
-  addVideoConferenceToDescription,
-  generateMeetingLink,
-  removeVideoConferenceFromDescription,
-  getVisioBaseUrl
-} from '@common/utils/videoConferenceUtils'
-import { useAppSelector } from '@common/app/hooks'
+import { useVideoConference } from '../hooks/useVideoConference'
 import { alpha, Box, Button, IconButton, useTheme } from '@linagora/twake-mui'
 import { Close as DeleteIcon } from '@mui/icons-material'
 import React from 'react'
@@ -146,30 +140,16 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
-  const workplaceFqdn = useAppSelector(
-    state => state.user.userData?.workplaceFqdn
-  )
 
-  const handleAddVideoConference = (): void => {
-    const baseUrl = workplaceFqdn ? getVisioBaseUrl(workplaceFqdn) : undefined
-    const newMeetingLink = generateMeetingLink(baseUrl)
-    const updatedDescription = addVideoConferenceToDescription(
+  const { handleAddVideoConference, handleDeleteVideoConference } =
+    useVideoConference({
       description,
-      newMeetingLink
-    )
-    setDescription(updatedDescription)
-    setHasVideoConference(true)
-    setMeetingLink(newMeetingLink)
-    if (showMore) {
-      setShowDescription?.(true)
-    }
-  }
-
-  const handleDeleteVideoConference = (): void => {
-    setDescription(removeVideoConferenceFromDescription(description))
-    setHasVideoConference(false)
-    setMeetingLink(null)
-  }
+      setDescription,
+      setHasVideoConference,
+      setMeetingLink,
+      showMore,
+      setShowDescription
+    })
 
   const cameraIcon = (
     <img src={iconCamera} alt="camera" width={24} height={24} />

--- a/common/src/components/Event/fields/VideoConferenceField.tsx
+++ b/common/src/components/Event/fields/VideoConferenceField.tsx
@@ -2,8 +2,10 @@ import iconCamera from '@common/static/images/icon-camera.svg'
 import {
   addVideoConferenceToDescription,
   generateMeetingLink,
-  removeVideoConferenceFromDescription
+  removeVideoConferenceFromDescription,
+  getVisioBaseUrl
 } from '@common/utils/videoConferenceUtils'
+import { useAppSelector } from '@common/app/hooks'
 import { alpha, Box, Button, IconButton, useTheme } from '@linagora/twake-mui'
 import { Close as DeleteIcon } from '@mui/icons-material'
 import React from 'react'
@@ -144,9 +146,13 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const workplaceFqdn = useAppSelector(
+    state => state.user.userData?.workplaceFqdn
+  )
 
   const handleAddVideoConference = (): void => {
-    const newMeetingLink = generateMeetingLink()
+    const baseUrl = workplaceFqdn ? getVisioBaseUrl(workplaceFqdn) : undefined
+    const newMeetingLink = generateMeetingLink(baseUrl)
     const updatedDescription = addVideoConferenceToDescription(
       description,
       newMeetingLink

--- a/common/src/components/Event/hooks/useVideoConference.ts
+++ b/common/src/components/Event/hooks/useVideoConference.ts
@@ -1,0 +1,64 @@
+import { useAppSelector } from '@common/app/hooks'
+import {
+  addVideoConferenceToDescription,
+  generateMeetingLink,
+  removeVideoConferenceFromDescription,
+  getVisioBaseUrl
+} from '@common/utils/videoConferenceUtils'
+
+interface UseVideoConferenceProps {
+  description: string
+  setDescription: (value: string) => void
+  setHasVideoConference: (value: boolean) => void
+  setMeetingLink: (value: string | null) => void
+  showMore: boolean
+  setShowDescription?: (value: boolean) => void
+}
+
+interface UseVideoConferenceReturn {
+  handleAddVideoConference: () => void
+  handleDeleteVideoConference: () => void
+}
+
+export const useVideoConference = ({
+  description,
+  setDescription,
+  setHasVideoConference,
+  setMeetingLink,
+  showMore,
+  setShowDescription
+}: UseVideoConferenceProps): UseVideoConferenceReturn => {
+  const workplaceFqdn = useAppSelector(
+    state => state.user.userData?.workplaceFqdn
+  )
+  const sub = useAppSelector(state => state.user.userData?.sub)
+
+  const handleAddVideoConference = (): void => {
+    const baseUrl = workplaceFqdn ? getVisioBaseUrl(workplaceFqdn) : undefined
+    const newMeetingLink = generateMeetingLink(
+      baseUrl,
+      workplaceFqdn ? undefined : sub
+    )
+    const updatedDescription = addVideoConferenceToDescription(
+      description,
+      newMeetingLink
+    )
+    setDescription(updatedDescription)
+    setHasVideoConference(true)
+    setMeetingLink(newMeetingLink)
+    if (showMore) {
+      setShowDescription?.(true)
+    }
+  }
+
+  const handleDeleteVideoConference = (): void => {
+    setDescription(removeVideoConferenceFromDescription(description))
+    setHasVideoConference(false)
+    setMeetingLink(null)
+  }
+
+  return {
+    handleAddVideoConference,
+    handleDeleteVideoConference
+  }
+}

--- a/common/src/features/User/userDataTypes.ts
+++ b/common/src/features/User/userDataTypes.ts
@@ -8,6 +8,7 @@ export interface userData {
   openpaasId?: string
   language?: string
   timezone?: string | null
+  workplaceFqdn?: string
 }
 
 export interface UserConfigurations {

--- a/common/src/utils/__test__/videoConferenceUtils.test.ts
+++ b/common/src/utils/__test__/videoConferenceUtils.test.ts
@@ -45,6 +45,33 @@ describe('videoConferenceUtils', () => {
         /^https:\/\/custom-meet\.example\.com\/[a-z]{3}-[a-z]{4}-[a-z]{3}$/
       )
     })
+
+    it('should replace {localpart} with sub when present in custom base URL', () => {
+      const baseWithLocalpart = 'https://{localpart}-visio.example.com'
+      const link = generateMeetingLink(baseWithLocalpart, 'user123')
+      expect(link).toMatch(
+        /^https:\/\/user123-visio\.example\.com\/[a-z]{3}-[a-z]{4}-[a-z]{3}$/
+      )
+    })
+
+    it('should replace {localpart} with empty string when sub is missing in custom base URL', () => {
+      const baseWithLocalpart = 'https://{localpart}-visio.example.com'
+      const link = generateMeetingLink(baseWithLocalpart)
+      expect(link).toMatch(
+        /^https:\/\/-visio\.example\.com\/[a-z]{3}-[a-z]{4}-[a-z]{3}$/
+      )
+    })
+
+    it('should replace {localpart} with sub in default base URL when default has {localpart}', () => {
+      const originalDefault = window.VIDEO_CONFERENCE_BASE_URL
+      window.VIDEO_CONFERENCE_BASE_URL =
+        'https://{localpart}-visio.stg.lin-saas.com'
+      const link = generateMeetingLink(undefined, 'user123')
+      expect(link).toMatch(
+        /^https:\/\/user123-visio\.stg\.lin-saas\.com\/[a-z]{3}-[a-z]{4}-[a-z]{3}$/
+      )
+      window.VIDEO_CONFERENCE_BASE_URL = originalDefault
+    })
   })
 
   describe('addVideoConferenceToDescription', () => {

--- a/common/src/utils/__test__/videoConferenceUtils.test.ts
+++ b/common/src/utils/__test__/videoConferenceUtils.test.ts
@@ -3,12 +3,14 @@ import {
   extractVideoConferenceFromDescription,
   generateMeetingId,
   generateMeetingLink,
-  removeVideoConferenceFromDescription
+  removeVideoConferenceFromDescription,
+  getVisioBaseUrl
 } from '@common/utils/videoConferenceUtils'
 
 // Mock window object for Node.js environment
 const mockWindow = {
-  VIDEO_CONFERENCE_BASE_URL: 'https://meet.linagora.com'
+  VIDEO_CONFERENCE_BASE_URL: 'https://meet.linagora.com',
+  VISIO_PATH: '/#/bridge'
 }
 
 // @ts-expect-error :  Mock window object for Node.js environment
@@ -116,6 +118,57 @@ describe('videoConferenceUtils', () => {
         'Visio: https://meet.linagora.com/abc-defg-hij\nRest of the text'
       const result = removeVideoConferenceFromDescription(description)
       expect(result).toBe('Rest of the text')
+    })
+  })
+
+  describe('getVisioBaseUrl', () => {
+    it('should return empty string for empty input', () => {
+      expect(getVisioBaseUrl('')).toBe('')
+    })
+
+    it('should append -visio and /#/bridge to the first subdomain segment of domain xxxx.twake.app', () => {
+      expect(getVisioBaseUrl('xxxx.twake.app')).toBe(
+        'https://xxxx-visio.twake.app/#/bridge'
+      )
+    })
+
+    it('should handle domain with sub-subdomain', () => {
+      expect(getVisioBaseUrl('sub.xxxx.twake.app')).toBe(
+        'https://sub-visio.xxxx.twake.app/#/bridge'
+      )
+    })
+
+    it('should keep http/https protocol if already provided', () => {
+      expect(getVisioBaseUrl('http://xxxx.twake.app')).toBe(
+        'http://xxxx-visio.twake.app/#/bridge'
+      )
+      expect(getVisioBaseUrl('https://xxxx.twake.app')).toBe(
+        'https://xxxx-visio.twake.app/#/bridge'
+      )
+    })
+
+    it('should handle single label hostname', () => {
+      expect(getVisioBaseUrl('localhost')).toBe(
+        'https://localhost-visio/#/bridge'
+      )
+    })
+
+    it('should handle missing VISIO_PATH', () => {
+      const originalPath = window.VISIO_PATH
+      delete window.VISIO_PATH
+      expect(getVisioBaseUrl('xxxx.twake.app')).toBe(
+        'https://xxxx-visio.twake.app'
+      )
+      window.VISIO_PATH = originalPath
+    })
+
+    it('should handle custom VISIO_PATH without leading slash', () => {
+      const originalPath = window.VISIO_PATH
+      window.VISIO_PATH = 'custom-bridge'
+      expect(getVisioBaseUrl('xxxx.twake.app')).toBe(
+        'https://xxxx-visio.twake.app/custom-bridge'
+      )
+      window.VISIO_PATH = originalPath
     })
   })
 })

--- a/common/src/utils/videoConferenceUtils.ts
+++ b/common/src/utils/videoConferenceUtils.ts
@@ -20,12 +20,15 @@ export function generateMeetingId(): string {
 
 /**
  * Generate a complete meeting link
- * @param {string} baseUrl - Base URL for video conference (from .env.js)
- * @returns {string} Complete meeting link
  */
-export function generateMeetingLink(baseUrl?: string): string {
-  const base = baseUrl || window.VIDEO_CONFERENCE_BASE_URL
+export function generateMeetingLink(baseUrl?: string, sub?: string): string {
+  let base = baseUrl || window.VIDEO_CONFERENCE_BASE_URL
   if (!base) return ''
+
+  if (base.includes('{localpart}')) {
+    base = base.replace('{localpart}', sub || '')
+  }
+
   const meetingId = generateMeetingId()
   return `${base}/${meetingId}`
 }
@@ -33,9 +36,6 @@ export function generateMeetingLink(baseUrl?: string): string {
 /**
  * Add video conference footer to event description.
  * If description is empty, adds on first line; otherwise adds on the line below existing content.
- * @param {string} description - Original description
- * @param {string} meetingLink - Generated meeting link
- * @returns {string} Description with video conference footer
  */
 export function addVideoConferenceToDescription(
   description: string,
@@ -48,8 +48,6 @@ export function addVideoConferenceToDescription(
 
 /**
  * Extract video conference link from description
- * @param {string} description - Event description
- * @returns {string | null} Video conference link if found, null otherwise
  */
 export function extractVideoConferenceFromDescription(
   description: string
@@ -63,8 +61,6 @@ const VISIO_LINE_REGEX = /^Visio:\s*https?:\/\/\S+$/
 /**
  * Remove the Visio video conference line from description.
  * Finds and removes the line matching "Visio: <url>" regardless of position (start, middle, end).
- * @param {string} description - Event description
- * @returns {string} Description with the Visio line removed
  */
 export function removeVideoConferenceFromDescription(
   description: string
@@ -72,14 +68,6 @@ export function removeVideoConferenceFromDescription(
   const lines = description.split('\n')
   const filtered = lines.filter(line => !VISIO_LINE_REGEX.test(line.trim()))
   return filtered.join('\n').trimEnd()
-}
-
-function getProtocol(url: string): string {
-  return url.startsWith('http://') ? 'http://' : 'https://'
-}
-
-function stripProtocol(url: string): string {
-  return url.replace(/^https?:\/\//, '')
 }
 
 function injectVisioIntoHost(host: string): string {
@@ -96,15 +84,13 @@ function getCleanPath(visioPath?: string): string {
 /**
  * Convert a workplace FQDN to a Visio base URL by appending -visio to the first subdomain segment.
  * E.g., xxxx.twake.app -> https://xxxx-visio.twake.app
- * @param {string} workplaceFqdn - The workplace FQDN
- * @returns {string} The constructed Visio base URL
  */
 export function getVisioBaseUrl(workplaceFqdn: string): string {
   if (!workplaceFqdn) return ''
 
   const trimmed = workplaceFqdn.trim()
-  const protocol = getProtocol(trimmed)
-  const host = stripProtocol(trimmed)
+  const protocol = trimmed.startsWith('http://') ? 'http://' : 'https://'
+  const host = trimmed.replace(/^https?:\/\//, '')
   const hostWithVisio = injectVisioIntoHost(host)
   const cleanPath = getCleanPath(window.VISIO_PATH)
 

--- a/common/src/utils/videoConferenceUtils.ts
+++ b/common/src/utils/videoConferenceUtils.ts
@@ -73,3 +73,40 @@ export function removeVideoConferenceFromDescription(
   const filtered = lines.filter(line => !VISIO_LINE_REGEX.test(line.trim()))
   return filtered.join('\n').trimEnd()
 }
+
+function getProtocol(url: string): string {
+  return url.startsWith('http://') ? 'http://' : 'https://'
+}
+
+function stripProtocol(url: string): string {
+  return url.replace(/^https?:\/\//, '')
+}
+
+function injectVisioIntoHost(host: string): string {
+  const parts = host.split('.')
+  parts[0] = `${parts[0]}-visio`
+  return parts.join('.')
+}
+
+function getCleanPath(visioPath?: string): string {
+  if (!visioPath) return ''
+  return `/${visioPath.replace(/^\//, '')}`
+}
+
+/**
+ * Convert a workplace FQDN to a Visio base URL by appending -visio to the first subdomain segment.
+ * E.g., xxxx.twake.app -> https://xxxx-visio.twake.app
+ * @param {string} workplaceFqdn - The workplace FQDN
+ * @returns {string} The constructed Visio base URL
+ */
+export function getVisioBaseUrl(workplaceFqdn: string): string {
+  if (!workplaceFqdn) return ''
+
+  const trimmed = workplaceFqdn.trim()
+  const protocol = getProtocol(trimmed)
+  const host = stripProtocol(trimmed)
+  const hostWithVisio = injectVisioIntoHost(host)
+  const cleanPath = getCleanPath(window.VISIO_PATH)
+
+  return `${protocol}${hostWithVisio}${cleanPath}`
+}

--- a/common/src/window.d.ts
+++ b/common/src/window.d.ts
@@ -54,5 +54,6 @@ declare global {
     __ws?: WebSocket
 
     HIDE_LANGUAGE_SELECTOR: boolean
+    VISIO_PATH?: string
   }
 }

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -26,3 +26,4 @@ var DISABLE_PUBLIC_VISIBILITY = false
 var ASK_FOR_TZ_UPDATE = true
 var TOOLTIP_DELAY_MS = 2000
 var HIDE_LANGUAGE_SELECTOR = false
+var VISIO_PATH = '/#/bridge'


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1071

Currently, to generate a Visio link, I'm using `workplaceFqdn` which exists in `userData` state if it is SAAS. If it does not exist, then we will generate based on the variable `VIDEO_CONFERENCE_BASE_URL`.


https://github.com/user-attachments/assets/92f37aef-1178-4c85-83a8-bcbefdc488c9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video conference links now use the user’s workplace domain to generate a more relevant meeting URL.
  * Support was added for workplace domain-based Visio links, including subdomains and existing web prefixes.

* **Bug Fixes**
  * Improved link generation when workplace information is missing or inconsistently formatted.
  * Updated behavior to keep existing protocol settings intact when creating meeting links.

* **Tests**
  * Added coverage for workplace domain handling and URL formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->