### PR TITLE
[#1098] Support URI template in MAIL_SPA_URL for platform mode

### DIFF
--- a/common/src/components/EventPreview/EventPreviewActionMenu.tsx
+++ b/common/src/components/EventPreview/EventPreviewActionMenu.tsx
@@ -2,6 +2,8 @@ import EventDuplication from '@common/components/Event/EventDuplicate'
 import { Menu, MenuItem } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { CalendarEvent } from '@common/types/EventsTypes'
+import { useAppSelector } from '@common/app/hooks'
+import { resolveMailSpaUrl } from '@common/utils/mailUrlUtils'
 
 interface EventPreviewActionMenuProps {
   anchorEl: Element | null
@@ -23,7 +25,13 @@ export const EventPreviewActionMenu: React.FC<EventPreviewActionMenuProps> = ({
   onEdit
 }) => {
   const { t } = useI18n()
-  const mailSpaUrl = window.MAIL_SPA_URL ?? null
+  const workplaceFqdn = useAppSelector(
+    state => state.user.userData?.workplaceFqdn
+  )
+  const mailSpaUrl = resolveMailSpaUrl({
+    localpart: userEmail?.split('@')[0],
+    workplaceFqdn
+  })
 
   const attendees = event.attendee ?? []
   const otherAttendees = attendees.filter(

--- a/common/src/utils/__test__/mailUrlUtils.test.ts
+++ b/common/src/utils/__test__/mailUrlUtils.test.ts
@@ -31,9 +31,9 @@ describe('resolveMailSpaUrl', () => {
   it('should resolve workplaceFqdn expressions', () => {
     window.MAIL_SPA_URL =
       'https://{workplaceFqdn.localpart}-mail.{workplaceFqdn.domain}'
-    expect(
-      resolveMailSpaUrl({ workplaceFqdn: 'tmle.stg.lin-saas.com' })
-    ).toBe('https://tmle-mail.stg.lin-saas.com')
+    expect(resolveMailSpaUrl({ workplaceFqdn: 'tmle.stg.lin-saas.com' })).toBe(
+      'https://tmle-mail.stg.lin-saas.com'
+    )
   })
 
   it('should return null when MAIL_SPA_URL is not configured', () => {

--- a/common/src/utils/__test__/mailUrlUtils.test.ts
+++ b/common/src/utils/__test__/mailUrlUtils.test.ts
@@ -1,0 +1,44 @@
+import { resolveMailSpaUrl } from '@common/utils/mailUrlUtils'
+
+// Mock window object for Node.js environment
+const mockWindow = {
+  MAIL_SPA_URL: 'https://mail.example.com'
+}
+
+// @ts-expect-error : Mock window object for Node.js environment
+global.window = mockWindow
+
+describe('resolveMailSpaUrl', () => {
+  const originalUrl = window.MAIL_SPA_URL
+
+  afterEach(() => {
+    window.MAIL_SPA_URL = originalUrl
+  })
+
+  it('should return the plain URL when no template expression is used', () => {
+    expect(resolveMailSpaUrl({ localpart: 'alice' })).toBe(
+      'https://mail.example.com'
+    )
+  })
+
+  it('should resolve {localpart}', () => {
+    window.MAIL_SPA_URL = 'https://{localpart}-mail.twake.app'
+    expect(resolveMailSpaUrl({ localpart: 'alice' })).toBe(
+      'https://alice-mail.twake.app'
+    )
+  })
+
+  it('should resolve workplaceFqdn expressions', () => {
+    window.MAIL_SPA_URL =
+      'https://{workplaceFqdn.localpart}-mail.{workplaceFqdn.domain}'
+    expect(
+      resolveMailSpaUrl({ workplaceFqdn: 'tmle.stg.lin-saas.com' })
+    ).toBe('https://tmle-mail.stg.lin-saas.com')
+  })
+
+  it('should return null when MAIL_SPA_URL is not configured', () => {
+    // @ts-expect-error : simulate missing configuration
+    window.MAIL_SPA_URL = undefined
+    expect(resolveMailSpaUrl({ localpart: 'alice' })).toBeNull()
+  })
+})

--- a/common/src/utils/__test__/uriTemplateUtils.test.ts
+++ b/common/src/utils/__test__/uriTemplateUtils.test.ts
@@ -1,0 +1,41 @@
+import { resolveUriTemplate } from '@common/utils/uriTemplateUtils'
+
+describe('resolveUriTemplate', () => {
+  const fqdn = 'tmle.stg.lin-saas.com'
+
+  it('should resolve {localpart}', () => {
+    const template = 'https://visio-{localpart}.twake.app/#/bridge'
+    const result = resolveUriTemplate(template, { localpart: 'alice' })
+    expect(result).toBe('https://visio-alice.twake.app/#/bridge')
+  })
+
+  it('should resolve {workplaceFqdn}', () => {
+    const template = 'https://mail-{workplaceFqdn}'
+    const result = resolveUriTemplate(template, { workplaceFqdn: fqdn })
+    expect(result).toBe('https://mail-tmle.stg.lin-saas.com')
+  })
+
+  it('should resolve {workplaceFqdn.localpart} and {workplaceFqdn.domain}', () => {
+    const template =
+      'https://{workplaceFqdn.localpart}-mail.{workplaceFqdn.domain}'
+    const result = resolveUriTemplate(template, { workplaceFqdn: fqdn })
+    expect(result).toBe('https://tmle-mail.stg.lin-saas.com')
+  })
+
+  it('should resolve {workplaceFqdn.domain} to empty for a single-label FQDN', () => {
+    const template =
+      'https://{workplaceFqdn.localpart}-mail.{workplaceFqdn.domain}'
+    const result = resolveUriTemplate(template, { workplaceFqdn: 'localhost' })
+    expect(result).toBe('https://localhost-mail.')
+  })
+
+  it('should leave unknown expressions untouched', () => {
+    const template = 'https://{unknown}.example.com'
+    expect(resolveUriTemplate(template, {})).toBe(template)
+  })
+
+  it('should resolve missing context values to empty string', () => {
+    const template = 'https://{localpart}-mail.{workplaceFqdn}'
+    expect(resolveUriTemplate(template, {})).toBe('https://-mail.')
+  })
+})

--- a/common/src/utils/mailUrlUtils.ts
+++ b/common/src/utils/mailUrlUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * Utility functions for the mail application (mail composer) URL.
+ */
+
+import {
+  resolveUriTemplate,
+  UriTemplateContext
+} from '@common/utils/uriTemplateUtils'
+
+/**
+ * Resolve the MAIL_SPA_URL configuration entry.
+ *
+ * MAIL_SPA_URL is a URI template (RFC 6570 style) so it can support platform
+ * mode, the same way VIDEO_CONFERENCE_BASE_URL does. See
+ * {@link resolveUriTemplate} for the list of supported expressions.
+ *
+ * @returns the resolved base URL, or null when MAIL_SPA_URL is not configured.
+ */
+export function resolveMailSpaUrl(
+  context: UriTemplateContext = {}
+): string | null {
+  const template = window.MAIL_SPA_URL
+  if (!template) return null
+
+  return resolveUriTemplate(template, context)
+}

--- a/common/src/utils/uriTemplateUtils.ts
+++ b/common/src/utils/uriTemplateUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Utilities to resolve URI templates used by platform-mode configuration
+ * entries such as VIDEO_CONFERENCE_BASE_URL and MAIL_SPA_URL.
+ */
+
+/**
+ * Context used to resolve the expressions of a URI template.
+ */
+export interface UriTemplateContext {
+  localpart?: string
+  workplaceFqdn?: string
+}
+
+/**
+ * Resolve a URI-template (RFC 6570 style) configuration value.
+ *
+ * Supported expressions:
+ *  - {localpart}               the user local part
+ *  - {workplaceFqdn}           the full workplace FQDN (e.g. tmle.stg.lin-saas.com)
+ *  - {workplaceFqdn.localpart} the first label of the FQDN (e.g. tmle)
+ *  - {workplaceFqdn.domain}    the FQDN without its first label (e.g. stg.lin-saas.com)
+ *
+ * Unknown expressions are left untouched.
+ */
+export function resolveUriTemplate(
+  template: string,
+  { localpart = '', workplaceFqdn = '' }: UriTemplateContext
+): string {
+  const [fqdnLocalpart = '', ...fqdnRest] = workplaceFqdn.split('.')
+  const fqdnDomain = fqdnRest.join('.')
+
+  const values: Record<string, string> = {
+    localpart,
+    workplaceFqdn,
+    'workplaceFqdn.localpart': fqdnLocalpart,
+    'workplaceFqdn.domain': fqdnDomain
+  }
+
+  return template.replace(/\{([^}]+)\}/g, (match, expression: string) => {
+    const key = expression.trim()
+    return key in values ? values[key] : match
+  })
+}

--- a/common/src/utils/videoConferenceUtils.ts
+++ b/common/src/utils/videoConferenceUtils.ts
@@ -2,6 +2,11 @@
  * Utility functions for video conference meeting generation
  */
 
+import {
+  resolveUriTemplate,
+  UriTemplateContext
+} from '@common/utils/uriTemplateUtils'
+
 /**
  * Generate a random meeting ID in format xxx-xxxx-xxx
  * @returns {string} Random meeting ID
@@ -21,40 +26,18 @@ export function generateMeetingId(): string {
 /**
  * Context used to resolve the template expressions of VIDEO_CONFERENCE_BASE_URL.
  */
-export interface VisioTemplateContext {
-  localpart?: string
-  workplaceFqdn?: string
-}
+export type VisioTemplateContext = UriTemplateContext
 
 /**
  * Resolve a URI-template (RFC 6570 style) VIDEO_CONFERENCE_BASE_URL.
  *
- * Supported expressions:
- *  - {localpart}             the user local part
- *  - {workplaceFqdn}         the full workplace FQDN (e.g. tmle.stg.lin-saas.com)
- *  - {workplaceFqdn.localpart} the first label of the FQDN (e.g. tmle)
- *  - {workplaceFqdn.domain}  the FQDN without its first label (e.g. stg.lin-saas.com)
- *
- * Unknown expressions are left untouched.
+ * See {@link resolveUriTemplate} for the list of supported expressions.
  */
 export function resolveVisioTemplate(
   template: string,
-  { localpart = '', workplaceFqdn = '' }: VisioTemplateContext
+  context: VisioTemplateContext
 ): string {
-  const [fqdnLocalpart = '', ...fqdnRest] = workplaceFqdn.split('.')
-  const fqdnDomain = fqdnRest.join('.')
-
-  const values: Record<string, string> = {
-    localpart,
-    workplaceFqdn,
-    'workplaceFqdn.localpart': fqdnLocalpart,
-    'workplaceFqdn.domain': fqdnDomain
-  }
-
-  return template.replace(/\{([^}]+)\}/g, (match, expression: string) => {
-    const key = expression.trim()
-    return key in values ? values[key] : match
-  })
+  return resolveUriTemplate(template, context)
 }
 
 /**
@@ -67,7 +50,7 @@ export function generateMeetingLink(
   const template = baseUrl || window.VIDEO_CONFERENCE_BASE_URL
   if (!template) return ''
 
-  const base = resolveVisioTemplate(template, context)
+  const base = resolveUriTemplate(template, context)
   const meetingId = generateMeetingId()
   return `${base}/${meetingId}`
 }

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -8,6 +8,12 @@ var SSO_POST_LOGOUT_REDIRECT = 'http://example.com?logout=1'
 var CALENDAR_BASE_URL = 'https://calendar.example.com'
 var DAV_BASE_URL = 'https://dav.example.com'
 var CALDAV_PREFER_HANDLING = 'strict'
+// MAIL_SPA_URL is a URI template (RFC 6570 style).
+// Supported expressions: {localpart}, {workplaceFqdn},
+// {workplaceFqdn.localpart}, {workplaceFqdn.domain}
+// Examples:
+//   'https://mail-{workplaceFqdn}'
+//   'https://{workplaceFqdn.localpart}-mail.{workplaceFqdn.domain}'
 var MAIL_SPA_URL = 'https://mail.example.com'
 // VIDEO_CONFERENCE_BASE_URL is a URI template (RFC 6570 style).
 // Supported expressions: {localpart}, {workplaceFqdn},


### PR DESCRIPTION
Closes #1098

Apply the same URI-template (RFC 6570 style) interpolation to `MAIL_SPA_URL` that `VIDEO_CONFERENCE_BASE_URL` already supports, so the mail composer (mail application) URL can be resolved per platform ("platform mode").

## Changes
- Extract the template resolution into a shared `resolveUriTemplate` util (`common/src/utils/uriTemplateUtils.ts`), supporting `{localpart}`, `{workplaceFqdn}`, `{workplaceFqdn.localpart}` and `{workplaceFqdn.domain}`.
- `videoConferenceUtils` now delegates to it (`resolveVisioTemplate` kept as a thin wrapper, behaviour unchanged).
- Resolve `MAIL_SPA_URL` through a new `resolveMailSpaUrl` helper when building the *email attendees* link in `EventPreviewActionMenu`, using the user local part and `workplaceFqdn`.
- Document the supported expressions for `MAIL_SPA_URL` in `public/.env.example.js`.

## Notes
- Plain (non-templated) `MAIL_SPA_URL` values keep working unchanged, so existing deployments are unaffected.
- Unit tests added for the shared resolver and for `resolveMailSpaUrl`. Dependencies could not be installed in this sandbox, so the JS test suite was not executed locally.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for template-based mail and video meeting URLs, allowing links to be generated from account and workplace details.
  * The email attendees action now opens the correct mail composer link when available.

* **Bug Fixes**
  * Improved mail link handling by deriving the URL from app state instead of relying on browser globals.
  * Kept link generation consistent across different URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->