### PR TITLE
1055 filter dates to only allow booking events on dates set in the booking preset

### DIFF
--- a/__test__/features/booking/BookingTimeSlotSection.test.tsx
+++ b/__test__/features/booking/BookingTimeSlotSection.test.tsx
@@ -41,7 +41,6 @@ describe('BookingTimeSlotSection', () => {
       />
     )
 
-    expect(screen.getByTestId('day-badge')).toHaveTextContent('26')
     expect(screen.getByText('booking.noSlots')).toBeInTheDocument()
   })
 

--- a/apps/public/src/components/Booking/BookingCalendarSection.tsx
+++ b/apps/public/src/components/Booking/BookingCalendarSection.tsx
@@ -7,7 +7,7 @@ import {
   PickerDayProps
 } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
-import { Dayjs } from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import 'dayjs/locale/en'
 import 'dayjs/locale/fr'
 import 'dayjs/locale/ru'
@@ -50,12 +50,14 @@ const AvailableDay = (props: AvailableDayProps): React.ReactElement => {
     )
   }
   const isSlot = availableDays?.has(day.toDate().toDateString()) ?? false
+  const isBeforeToday = day.isBefore(dayjs(), 'day')
+
   return (
     <PickerDay
       {...other}
       day={day}
       outsideCurrentMonth={outsideCurrentMonth}
-      disabled={!isSlot}
+      disabled={!isSlot || isBeforeToday}
       sx={{
         boxSizing: 'border-box',
         width: CELL_SIZE,
@@ -69,10 +71,13 @@ const AvailableDay = (props: AvailableDayProps): React.ReactElement => {
         padding: 0,
         borderRadius: '50%',
         fontSize: '14px',
-        ...(isSlot && {
-          '&:not(.Mui-selected)': { backgroundColor: theme.palette.grey[200] },
-          '&.Mui-selected': { backgroundColor: 'text.secondary' }
-        })
+        ...(isSlot &&
+          !isBeforeToday && {
+            '&:not(.Mui-selected)': {
+              backgroundColor: theme.palette.grey[200]
+            },
+            '&.Mui-selected': { backgroundColor: 'text.secondary' }
+          })
       }}
     />
   )

--- a/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
+++ b/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
@@ -2,7 +2,7 @@ import { Slot } from '@common/features/booking/types/BookingTypes'
 import { DayBadge } from '@common/features/Search/searchResultsComponents'
 import { Box, Button, Typography } from '@linagora/twake-mui'
 import dayjs, { Dayjs } from 'dayjs'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { CALENDAR_CONTENT_HEIGHT } from './LayoutConstants'
 
@@ -11,6 +11,8 @@ const SLOT_LIST_GAP = 16
 
 const SLOT_LIST_MAX_HEIGHT =
   CALENDAR_CONTENT_HEIGHT - DAY_BADGE_ROW_HEIGHT - SLOT_LIST_GAP
+
+const NOW_REFRESH_INTERVAL_MS = 60_000 // 1 min: slot granularity doesn't need finer resolution
 
 const containerSx = {
   display: 'flex',
@@ -97,11 +99,16 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
 }) => {
   const { t, lang } = useI18n()
 
-  const [now] = useState(() => Date.now())
+  const [now, setNow] = useState(() => Date.now())
   const isSelectedDayToday = selectedDay?.isSame(dayjs(), 'day')
   const visibleSlots = isSelectedDayToday
     ? slots.filter(slot => new Date(slot.start).getTime() >= now)
     : slots
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), NOW_REFRESH_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [])
 
   if (!selectedDay) {
     return <EmptyMessage message={t('booking.selectDayPrompt')} />

--- a/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
+++ b/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
@@ -2,15 +2,85 @@ import { Slot } from '@common/features/booking/types/BookingTypes'
 import { DayBadge } from '@common/features/Search/searchResultsComponents'
 import { Box, Button, Typography } from '@linagora/twake-mui'
 import dayjs, { Dayjs } from 'dayjs'
-import { useMemo } from 'react'
+import { useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { CALENDAR_CONTENT_HEIGHT } from './LayoutConstants'
 
-const DAY_BADGE_ROW_HEIGHT = 48 // measure actual DayBadge row height, adjust
-const SLOT_LIST_GAP = 16 // matches gap: '16px' on the parent Box
+const DAY_BADGE_ROW_HEIGHT = 48
+const SLOT_LIST_GAP = 16
 
 const SLOT_LIST_MAX_HEIGHT =
   CALENDAR_CONTENT_HEIGHT - DAY_BADGE_ROW_HEIGHT - SLOT_LIST_GAP
+
+const containerSx = {
+  display: 'flex',
+  flexDirection: 'column',
+  p: 3,
+  gap: 2
+} as const
+
+const scrollableListSx = (theme: { palette: { grey: { 400: string } } }) => ({
+  scrollbarWidth: 'thin',
+  scrollbarColor: 'transparent transparent',
+  scrollbarGutter: 'stable',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 1,
+  pr: 1,
+  maxHeight: `${SLOT_LIST_MAX_HEIGHT}px`,
+  overflowY: 'auto',
+  '&:hover': {
+    scrollbarColor: `${theme.palette.grey[400]} transparent`
+  },
+  '&:hover::-webkit-scrollbar-thumb': {
+    backgroundColor: 'divider'
+  }
+})
+
+const EmptyMessage: React.FC<{ message: string }> = ({ message }) => (
+  <Box sx={containerSx}>
+    <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+      {message}
+    </Typography>
+  </Box>
+)
+
+interface SlotListProps {
+  slots: Slot[]
+  selectedSlot: Slot | null
+  onSelectSlot: (slot: Slot) => void
+  lang: string
+}
+
+const SlotList: React.FC<SlotListProps> = ({
+  slots,
+  selectedSlot,
+  onSelectSlot,
+  lang
+}) => (
+  <Box sx={scrollableListSx}>
+    {slots.map(slot => {
+      const time = new Date(slot.start).toLocaleTimeString(lang, {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      })
+      const isSelected = selectedSlot?.start === slot.start
+
+      return (
+        <Button
+          key={slot.start}
+          variant="outlined"
+          color={isSelected ? 'warning' : 'inherit'}
+          onClick={() => onSelectSlot(slot)}
+          sx={{ justifyContent: 'center' }}
+        >
+          {time}
+        </Button>
+      )
+    })}
+  </Box>
+)
 
 interface BookingTimeSlotSectionProps {
   selectedDay: Dayjs | null
@@ -27,33 +97,22 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
 }) => {
   const { t, lang } = useI18n()
 
-  const now = useMemo(() => Date.now(), [])
+  const [now] = useState(() => Date.now())
   const isSelectedDayToday = selectedDay?.isSame(dayjs(), 'day')
   const visibleSlots = isSelectedDayToday
     ? slots.filter(slot => new Date(slot.start).getTime() >= now)
     : slots
 
-  if (!selectedDay || !visibleSlots) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          p: '24px',
-          gap: '16px'
-        }}
-      >
-        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          {t('booking.selectDayPrompt')}
-        </Typography>
-      </Box>
-    )
+  if (!selectedDay) {
+    return <EmptyMessage message={t('booking.selectDayPrompt')} />
+  }
+
+  if (!visibleSlots.length) {
+    return <EmptyMessage message={t('booking.noSlots')} />
   }
 
   return (
-    <Box
-      sx={{ display: 'flex', flexDirection: 'column', p: '24px', gap: '16px' }}
-    >
+    <Box sx={containerSx}>
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
         <DayBadge
           dayNum={selectedDay.date().toString()}
@@ -63,51 +122,12 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
           isToday
         />
       </Box>
-      <Box
-        sx={theme => ({
-          scrollbarWidth: 'thin',
-          scrollbarColor: 'transparent transparent',
-          scrollbarGutter: 'stable',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '8px',
-          pr: '8px',
-          maxHeight: `${SLOT_LIST_MAX_HEIGHT}px`,
-          overflowY: 'auto',
-          '&:hover': {
-            scrollbarColor: `${theme.palette.grey[400]} transparent`
-          },
-          '&:hover::-webkit-scrollbar-thumb': {
-            backgroundColor: 'divider'
-          }
-        })}
-      >
-        {visibleSlots.map(slot => {
-          const time = new Date(slot.start).toLocaleTimeString(lang, {
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: false
-          })
-          const isSelected = selectedSlot?.start === slot.start
-
-          return (
-            <Button
-              key={slot.start}
-              variant="outlined"
-              color={isSelected ? 'warning' : 'inherit'}
-              onClick={() => onSelectSlot(slot)}
-              sx={{ justifyContent: 'center' }}
-            >
-              {time}
-            </Button>
-          )
-        })}
-        {slots.length === 0 && (
-          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-            {t('booking.noSlots')}
-          </Typography>
-        )}
-      </Box>
+      <SlotList
+        slots={visibleSlots}
+        selectedSlot={selectedSlot}
+        onSelectSlot={onSelectSlot}
+        lang={lang}
+      />
     </Box>
   )
 }

--- a/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
+++ b/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
@@ -2,6 +2,7 @@ import { Slot } from '@common/features/booking/types/BookingTypes'
 import { DayBadge } from '@common/features/Search/searchResultsComponents'
 import { Box, Button, Typography } from '@linagora/twake-mui'
 import dayjs, { Dayjs } from 'dayjs'
+import { useMemo } from 'react'
 import { useI18n } from 'twake-i18n'
 import { CALENDAR_CONTENT_HEIGHT } from './LayoutConstants'
 
@@ -26,9 +27,10 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
 }) => {
   const { t, lang } = useI18n()
 
+  const now = useMemo(() => Date.now(), [])
   const isSelectedDayToday = selectedDay?.isSame(dayjs(), 'day')
   const visibleSlots = isSelectedDayToday
-    ? slots.filter(slot => new Date(slot.start).getTime() >= Date.now())
+    ? slots.filter(slot => new Date(slot.start).getTime() >= now)
     : slots
 
   if (!selectedDay || !visibleSlots) {

--- a/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
+++ b/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@common/features/booking/types/BookingTypes'
 import { DayBadge } from '@common/features/Search/searchResultsComponents'
 import { Box, Button, Typography } from '@linagora/twake-mui'
-import { Dayjs } from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import { useI18n } from 'twake-i18n'
 import { CALENDAR_CONTENT_HEIGHT } from './LayoutConstants'
 
@@ -26,7 +26,12 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
 }) => {
   const { t, lang } = useI18n()
 
-  if (!selectedDay) {
+  const isSelectedDayToday = selectedDay?.isSame(dayjs(), 'day')
+  const visibleSlots = isSelectedDayToday
+    ? slots.filter(slot => new Date(slot.start).getTime() >= Date.now())
+    : slots
+
+  if (!selectedDay || !visibleSlots) {
     return (
       <Box
         sx={{
@@ -75,7 +80,7 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
           }
         })}
       >
-        {slots.map(slot => {
+        {visibleSlots.map(slot => {
           const time = new Date(slot.start).toLocaleTimeString(lang, {
             hour: '2-digit',
             minute: '2-digit',


### PR DESCRIPTION
resolves #1056 and #1055 

filtering was already done by the data we get. The only relevant filtering left was to prevent user to book events in the past.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from selecting past dates in the booking calendar.
  * Updated calendar styling so days before today are disabled and no longer appear selectable.
  * Hides earlier time slots when booking for today, showing only slots from the current time onward.
  * Ensured the “no available slots” state correctly reflects the filtered slots for the selected day.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->