### PR TITLE
#1103 allow attendee to set their own timezone

### DIFF
--- a/__test__/features/booking/BookingMetaInfo.test.tsx
+++ b/__test__/features/booking/BookingMetaInfo.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BookingMetaInfo } from '@public/components/Booking/BookingHeader/BookingMetaInfo'
+
+jest.mock('twake-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    lang: 'en-US'
+  })
+}))
+
+jest.mock('@common/components/Timezone/TimezoneSelector', () => ({
+  TimezoneSelector: ({ value, onChange }: any) => (
+    <select
+      data-testid="timezone-selector"
+      value={value}
+      onChange={e => onChange(e.target.value)}
+    >
+      <option value="Europe/Paris">Europe/Paris</option>
+      <option value="Asia/Tokyo">Asia/Tokyo</option>
+    </select>
+  )
+}))
+
+describe('BookingMetaInfo', () => {
+  it('renders timezone selector with selected timezone and calls onTimezoneChange', () => {
+    const onTimezoneChange = jest.fn()
+    const referenceDate = new Date('2036-01-26T00:00:00.000Z')
+
+    render(
+      <BookingMetaInfo
+        selectedTimezone="Europe/Paris"
+        onTimezoneChange={onTimezoneChange}
+        referenceDate={referenceDate}
+      />
+    )
+
+    const select = screen.getByTestId('timezone-selector')
+    expect(select).toHaveValue('Europe/Paris')
+
+    fireEvent.change(select, { target: { value: 'Asia/Tokyo' } })
+    expect(onTimezoneChange).toHaveBeenCalledWith('Asia/Tokyo')
+  })
+})

--- a/__test__/features/booking/BookingTimeSlotSection.test.tsx
+++ b/__test__/features/booking/BookingTimeSlotSection.test.tsx
@@ -25,6 +25,7 @@ describe('BookingTimeSlotSection', () => {
         slots={[]}
         selectedSlot={null}
         onSelectSlot={jest.fn()}
+        selectedTimezone="UTC"
       />
     )
 
@@ -38,6 +39,7 @@ describe('BookingTimeSlotSection', () => {
         slots={[]}
         selectedSlot={null}
         onSelectSlot={jest.fn()}
+        selectedTimezone="UTC"
       />
     )
 
@@ -55,14 +57,34 @@ describe('BookingTimeSlotSection', () => {
         slots={[firstSlot, secondSlot]}
         selectedSlot={secondSlot}
         onSelectSlot={onSelectSlot}
+        selectedTimezone="UTC"
       />
     )
 
     const buttons = screen.getAllByRole('button')
     expect(buttons).toHaveLength(2)
+    // 09:00:00 in UTC
+    expect(screen.getByText('09:00')).toBeInTheDocument()
 
     fireEvent.click(buttons[0])
 
     expect(onSelectSlot).toHaveBeenCalledWith(firstSlot)
+  })
+
+  it('renders available slots in the selected timezone', async () => {
+    const firstSlot = { start: '2036-01-26T09:00:00.000Z' } // 09:00 UTC
+    // UTC+9 for Asia/Tokyo = 18:00
+
+    render(
+      <BookingTimeSlotSection
+        selectedDay={dayjs('2036-01-26T00:00:00.000Z')}
+        slots={[firstSlot]}
+        selectedSlot={null}
+        onSelectSlot={jest.fn()}
+        selectedTimezone="Asia/Tokyo"
+      />
+    )
+
+    expect(screen.getByText('18:00')).toBeInTheDocument()
   })
 })

--- a/__test__/features/booking/useBookingData.test.tsx
+++ b/__test__/features/booking/useBookingData.test.tsx
@@ -39,6 +39,7 @@ describe('useBookingData', () => {
       useBookingData({
         bookingLinkPublicId: 'public-booking-link-id',
         visibleMonth,
+        timezone: 'UTC',
         loadErrorMessage: 'Unable to load slots'
       })
     )
@@ -74,6 +75,7 @@ describe('useBookingData', () => {
         useBookingData({
           bookingLinkPublicId: 'public-booking-link-id',
           visibleMonth,
+          timezone: 'UTC',
           loadErrorMessage: 'Unable to load slots'
         }),
       { initialProps: { visibleMonth: new Date(2036, 0, 1) } }
@@ -123,6 +125,7 @@ describe('useBookingData', () => {
       useBookingData({
         bookingLinkPublicId: 'public-booking-link-id',
         visibleMonth,
+        timezone: 'UTC',
         loadErrorMessage: 'Translated load error'
       })
     )
@@ -142,6 +145,7 @@ describe('useBookingData', () => {
       useBookingData({
         bookingLinkPublicId: undefined,
         visibleMonth,
+        timezone: 'UTC',
         loadErrorMessage: 'Unable to load slots'
       })
     )

--- a/apps/public/src/components/Booking/BookingCalendarSection.tsx
+++ b/apps/public/src/components/Booking/BookingCalendarSection.tsx
@@ -8,6 +8,8 @@ import {
 } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import dayjs, { Dayjs } from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
 import 'dayjs/locale/en'
 import 'dayjs/locale/fr'
 import 'dayjs/locale/ru'
@@ -17,17 +19,28 @@ import { useI18n } from 'twake-i18n'
 import { getLayoutConstants } from './LayoutConstants'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
 interface AvailableDayProps extends PickerDayProps {
   availableDays?: Set<string>
+  selectedTimezone?: string
 }
 interface BookingCalendarSectionProps {
   selectedDay: Dayjs | null
   availableDays: Set<string>
   onSelectDay: (date: Dayjs | null) => void
   onMonthChange: (month: Dayjs) => void
+  selectedTimezone: string
 }
 const AvailableDay = (props: AvailableDayProps): React.ReactElement => {
-  const { availableDays, day, outsideCurrentMonth, ...other } = props
+  const {
+    availableDays,
+    selectedTimezone,
+    day,
+    outsideCurrentMonth,
+    ...other
+  } = props
   const theme = useTheme()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
   const { CELL_SIZE } = getLayoutConstants(isMobile)
@@ -47,8 +60,13 @@ const AvailableDay = (props: AvailableDayProps): React.ReactElement => {
       />
     )
   }
-  const isSlot = availableDays?.has(day.toDate().toDateString()) ?? false
-  const isBeforeToday = day.isBefore(dayjs(), 'day')
+  const isSlot = availableDays?.has(day.format('YYYY-MM-DD')) ?? false
+
+  const todayInTimezone = selectedTimezone
+    ? dayjs().tz(selectedTimezone).startOf('day')
+    : dayjs().startOf('day')
+
+  const isBeforeToday = (day as Dayjs).isBefore(todayInTimezone, 'day')
 
   return (
     <PickerDay
@@ -84,7 +102,8 @@ export const BookingCalendarSection: React.FC<BookingCalendarSectionProps> = ({
   selectedDay,
   availableDays,
   onSelectDay,
-  onMonthChange
+  onMonthChange,
+  selectedTimezone
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
@@ -120,7 +139,7 @@ export const BookingCalendarSection: React.FC<BookingCalendarSectionProps> = ({
           views={['day', 'month']}
           fixedWeekNumber={6}
           slotProps={{
-            day: { availableDays } as AvailableDayProps
+            day: { availableDays, selectedTimezone } as AvailableDayProps
           }}
           sx={{
             width: '100%',

--- a/apps/public/src/components/Booking/BookingHeader/BookingHeaderDesktop.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingHeaderDesktop.tsx
@@ -1,19 +1,19 @@
-import { stringAvatar } from '@common/components/Event/utils/eventUtils'
 import { BookingSlotsResponse } from '@common/features/booking/types/BookingTypes'
-import { formatTimezoneLabel } from '@common/utils/timezone'
-import { Avatar, Box, Typography } from '@linagora/twake-mui'
+import { Box } from '@linagora/twake-mui'
 import React from 'react'
-import { useI18n } from 'twake-i18n'
-import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
-import LanguageOutlinedIcon from '@mui/icons-material/LanguageOutlined'
-import iconCamera from '@common/static/images/icon-camera.svg'
+import {
+  BookingOwnerAvatar,
+  BookingOwnerName,
+  BookingEventDetails
+} from './BookingOwnerInfo'
+import { BookingMetaInfo } from './BookingMetaInfo'
 
 export const BookingHeaderDesktop: React.FC<{
   bookingInfo: BookingSlotsResponse
-}> = ({ bookingInfo }) => {
-  const { t } = useI18n()
-  const timeZoneLabel = formatTimezoneLabel()
-  const cameraIcon = <img src={iconCamera} width={24} height={24} />
+  selectedTimezone: string
+  onTimezoneChange: (tz: string) => void
+  referenceDate: Date
+}> = ({ bookingInfo, selectedTimezone, onTimezoneChange, referenceDate }) => {
   return (
     <Box
       sx={{
@@ -25,94 +25,17 @@ export const BookingHeaderDesktop: React.FC<{
       }}
     >
       <Box sx={{ display: 'flex', gap: '10px', alignItems: 'flex-start' }}>
-        <Avatar
-          {...stringAvatar(
-            bookingInfo.owner.displayName || bookingInfo.owner.email
-          )}
-        />
-
+        <BookingOwnerAvatar owner={bookingInfo.owner} />
         <Box>
-          <Typography variant="subtitle1">
-            {bookingInfo.owner.displayName || bookingInfo.owner.email}
-          </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <Typography variant="subtitle1">{bookingInfo.name}</Typography>
-            <TimerOutlinedIcon sx={{ color: 'text.secondary' }} />
-            <Typography
-              variant="caption"
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '4px',
-                color: 'text.secondary'
-              }}
-            >
-              {t('booking.durationMinutes', {
-                count: bookingInfo.durationMinutes
-              })}
-            </Typography>
-          </Box>
-          {bookingInfo.description && (
-            <Typography
-              variant="body2"
-              sx={{ color: 'text.secondary', mt: '4px', maxWidth: '320px' }}
-            >
-              {bookingInfo.description}
-            </Typography>
-          )}
+          <BookingOwnerName owner={bookingInfo.owner} />
+          <BookingEventDetails bookingInfo={bookingInfo} />
         </Box>
       </Box>
-      <Box
-        sx={{
-          textAlign: 'right',
-          fontSize: '13px',
-          color: 'text.secondary',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '12px',
-          whiteSpace: 'nowrap'
-        }}
-      >
-        <Box>
-          <Typography
-            variant="caption"
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              justifyContent: 'flex-start'
-            }}
-          >
-            <LanguageOutlinedIcon sx={{ color: 'text.secondary' }} />
-            {timeZoneLabel}
-          </Typography>
-        </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            gap: '8px',
-            alignItems: 'center',
-            justifyContent: 'flex-start'
-          }}
-        >
-          {cameraIcon}
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '6px',
-              alignItems: 'flex-start'
-            }}
-          >
-            <Typography variant="caption">
-              {t('event.form.videoMeeting')}
-            </Typography>
-            <Typography variant="overline">
-              {t('booking.videoMeetingCaption')}
-            </Typography>
-          </Box>
-        </Box>
-      </Box>
+      <BookingMetaInfo
+        selectedTimezone={selectedTimezone}
+        onTimezoneChange={onTimezoneChange}
+        referenceDate={referenceDate}
+      />
     </Box>
   )
 }

--- a/apps/public/src/components/Booking/BookingHeader/BookingHeaderMobile.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingHeaderMobile.tsx
@@ -1,29 +1,15 @@
-import { stringAvatar } from '@common/components/Event/utils/eventUtils'
 import { BookingSlotsResponse } from '@common/features/booking/types/BookingTypes'
-import {
-  browserDefaultTimeZone,
-  getTimezoneOffset
-} from '@common/utils/timezone'
-import { Avatar, Box, Typography } from '@linagora/twake-mui'
+import { Box } from '@linagora/twake-mui'
 import React from 'react'
-import { useI18n } from 'twake-i18n'
-import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
-import LanguageOutlinedIcon from '@mui/icons-material/LanguageOutlined'
-import iconCamera from '@common/static/images/icon-camera.svg'
+import { BookingOwnerAvatar, BookingEventDetails } from './BookingOwnerInfo'
+import { BookingMetaInfo } from './BookingMetaInfo'
 
 export const BookingHeaderMobile: React.FC<{
   bookingInfo: BookingSlotsResponse
-}> = ({ bookingInfo }) => {
-  const { t } = useI18n()
-  const timeZoneLabel = `(${getTimezoneOffset(browserDefaultTimeZone)}) ${browserDefaultTimeZone.replace(/_/g, ' ')}`
-  const cameraIcon = (
-    <img
-      src={iconCamera}
-      alt={t('booking.cameraIcon')}
-      width={24}
-      height={24}
-    />
-  )
+  selectedTimezone: string
+  onTimezoneChange: (tz: string) => void
+  referenceDate: Date
+}> = ({ bookingInfo, selectedTimezone, onTimezoneChange, referenceDate }) => {
   return (
     <Box
       sx={{
@@ -44,90 +30,14 @@ export const BookingHeaderMobile: React.FC<{
           flexDirection: 'column'
         }}
       >
-        <Avatar
-          size="s"
-          {...stringAvatar(
-            bookingInfo.owner.displayName || bookingInfo.owner.email
-          )}
-        />
-
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <Typography variant="subtitle1">{bookingInfo.name}</Typography>
-          <TimerOutlinedIcon sx={{ color: 'text.secondary' }} />
-          <Typography
-            variant="caption"
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '4px',
-              color: 'text.secondary'
-            }}
-          >
-            {t('booking.durationMinutes', {
-              count: bookingInfo.durationMinutes
-            })}
-          </Typography>
-        </Box>
-        {bookingInfo.description && (
-          <Typography
-            variant="body2"
-            sx={{ color: 'text.secondary', mt: '4px', maxWidth: '320px' }}
-          >
-            {bookingInfo.description}
-          </Typography>
-        )}
+        <BookingOwnerAvatar owner={bookingInfo.owner} size="s" />
+        <BookingEventDetails bookingInfo={bookingInfo} />
       </Box>
-      <Box
-        sx={{
-          textAlign: 'right',
-          fontSize: '13px',
-          color: 'text.secondary',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '12px',
-          whiteSpace: 'nowrap'
-        }}
-      >
-        <Box>
-          <Typography
-            variant="caption"
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-              justifyContent: 'flex-start'
-            }}
-          >
-            <LanguageOutlinedIcon sx={{ color: 'text.secondary' }} />
-            {timeZoneLabel}
-          </Typography>
-        </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            gap: '8px',
-            alignItems: 'center',
-            justifyContent: 'flex-start'
-          }}
-        >
-          {cameraIcon}
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '6px',
-              alignItems: 'flex-start'
-            }}
-          >
-            <Typography variant="caption">
-              {t('event.form.videoMeeting')}
-            </Typography>
-            <Typography variant="overline">
-              {t('booking.videoMeetingCaption')}
-            </Typography>
-          </Box>
-        </Box>
-      </Box>
+      <BookingMetaInfo
+        selectedTimezone={selectedTimezone}
+        onTimezoneChange={onTimezoneChange}
+        referenceDate={referenceDate}
+      />
     </Box>
   )
 }

--- a/apps/public/src/components/Booking/BookingHeader/BookingMetaInfo.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingMetaInfo.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { Box, Typography } from '@linagora/twake-mui'
+import { useI18n } from 'twake-i18n'
+import LanguageOutlinedIcon from '@mui/icons-material/LanguageOutlined'
+import { TimezoneSelector } from '@common/components/Timezone/TimezoneSelector'
+import iconCamera from '@common/static/images/icon-camera.svg'
+
+export const BookingMetaInfo: React.FC<{
+  selectedTimezone: string
+  onTimezoneChange: (tz: string) => void
+  referenceDate: Date
+}> = ({ selectedTimezone, onTimezoneChange, referenceDate }) => {
+  const { t } = useI18n()
+  const cameraIcon = (
+    <img
+      src={iconCamera}
+      alt={t('booking.cameraIcon')}
+      width={24}
+      height={24}
+    />
+  )
+  return (
+    <Box
+      sx={{
+        textAlign: 'right',
+        fontSize: '13px',
+        color: 'text.secondary',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+        whiteSpace: 'nowrap'
+      }}
+    >
+      <Box>
+        <Typography
+          variant="caption"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            justifyContent: 'flex-start'
+          }}
+        >
+          <LanguageOutlinedIcon sx={{ color: 'text.secondary' }} />
+          <TimezoneSelector
+            value={selectedTimezone}
+            onChange={onTimezoneChange}
+            referenceDate={referenceDate}
+          />
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '8px',
+          alignItems: 'center',
+          justifyContent: 'flex-start'
+        }}
+      >
+        {cameraIcon}
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '6px',
+            alignItems: 'flex-start'
+          }}
+        >
+          <Typography variant="caption">
+            {t('event.form.videoMeeting')}
+          </Typography>
+          <Typography variant="overline">
+            {t('booking.videoMeetingCaption')}
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/public/src/components/Booking/BookingHeader/BookingOwnerInfo.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingOwnerInfo.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { Box, Typography, Avatar } from '@linagora/twake-mui'
+import { useI18n } from 'twake-i18n'
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
+import { BookingSlotsResponse } from '@common/features/booking/types/BookingTypes'
+import { stringAvatar } from '@common/components/Event/utils/eventUtils'
+
+export const BookingOwnerAvatar: React.FC<{
+  owner: BookingSlotsResponse['owner']
+  size?: 's' | 'm' | 'l'
+}> = ({ owner, size }) => {
+  return (
+    <Avatar size={size} {...stringAvatar(owner.displayName || owner.email)} />
+  )
+}
+
+export const BookingOwnerName: React.FC<{
+  owner: BookingSlotsResponse['owner']
+}> = ({ owner }) => {
+  return (
+    <Typography variant="subtitle1">
+      {owner.displayName || owner.email}
+    </Typography>
+  )
+}
+
+export const BookingEventDetails: React.FC<{
+  bookingInfo: BookingSlotsResponse
+}> = ({ bookingInfo }) => {
+  const { t } = useI18n()
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <Typography variant="subtitle1">{bookingInfo.name}</Typography>
+        <TimerOutlinedIcon sx={{ color: 'text.secondary' }} />
+        <Typography
+          variant="caption"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            color: 'text.secondary'
+          }}
+        >
+          {t('booking.durationMinutes', {
+            count: bookingInfo.durationMinutes
+          })}
+        </Typography>
+      </Box>
+      {bookingInfo.description && (
+        <Typography
+          variant="body2"
+          sx={{ color: 'text.secondary', mt: '4px', maxWidth: '320px' }}
+        >
+          {bookingInfo.description}
+        </Typography>
+      )}
+    </>
+  )
+}

--- a/apps/public/src/components/Booking/BookingHeader/index.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/index.tsx
@@ -3,14 +3,31 @@ import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 import { BookingHeaderDesktop } from './BookingHeaderDesktop'
 import { BookingHeaderMobile } from './BookingHeaderMobile'
 
-export const BookingHeader: React.FC<{ bookingInfo: BookingSlotsResponse }> = ({
-  bookingInfo
-}) => {
+export const BookingHeader: React.FC<{
+  bookingInfo: BookingSlotsResponse
+  selectedTimezone: string
+  onTimezoneChange: (tz: string) => void
+  referenceDate: Date
+}> = ({ bookingInfo, selectedTimezone, onTimezoneChange, referenceDate }) => {
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
   if (isMobile) {
-    return <BookingHeaderMobile bookingInfo={bookingInfo} />
+    return (
+      <BookingHeaderMobile
+        bookingInfo={bookingInfo}
+        selectedTimezone={selectedTimezone}
+        onTimezoneChange={onTimezoneChange}
+        referenceDate={referenceDate}
+      />
+    )
   }
 
-  return <BookingHeaderDesktop bookingInfo={bookingInfo} />
+  return (
+    <BookingHeaderDesktop
+      bookingInfo={bookingInfo}
+      selectedTimezone={selectedTimezone}
+      onTimezoneChange={onTimezoneChange}
+      referenceDate={referenceDate}
+    />
+  )
 }

--- a/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
+++ b/apps/public/src/components/Booking/BookingTimeSlotSection.tsx
@@ -9,10 +9,15 @@ import {
   useTheme
 } from '@linagora/twake-mui'
 import dayjs, { Dayjs } from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
 import { useEffect, useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { getLayoutConstants } from './LayoutConstants'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
 
 const DAY_BADGE_ROW_HEIGHT = 48
 const SLOT_LIST_GAP = 16
@@ -60,13 +65,15 @@ interface SlotListProps {
   selectedSlot: Slot | null
   onSelectSlot: (slot: Slot) => void
   lang: string
+  selectedTimezone: string
 }
 
 const SlotList: React.FC<SlotListProps> = ({
   slots,
   selectedSlot,
   onSelectSlot,
-  lang
+  lang,
+  selectedTimezone
 }) => {
   const theme = useTheme()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
@@ -80,7 +87,8 @@ const SlotList: React.FC<SlotListProps> = ({
         const time = new Date(slot.start).toLocaleTimeString(lang, {
           hour: '2-digit',
           minute: '2-digit',
-          hour12: false
+          hour12: false,
+          timeZone: selectedTimezone
         })
         const isSelected = selectedSlot?.start === slot.start
 
@@ -105,18 +113,23 @@ interface BookingTimeSlotSectionProps {
   slots: Slot[]
   selectedSlot: Slot | null
   onSelectSlot: (slot: Slot) => void
+  selectedTimezone: string
 }
 
 export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
   selectedDay,
   slots,
   selectedSlot,
-  onSelectSlot
+  onSelectSlot,
+  selectedTimezone
 }) => {
   const { t, lang } = useI18n()
 
   const [now, setNow] = useState(() => Date.now())
-  const isSelectedDayToday = selectedDay?.isSame(dayjs(), 'day')
+
+  const todayInTimezone = dayjs().tz(selectedTimezone)
+  const isSelectedDayToday =
+    selectedDay?.format('YYYY-MM-DD') === todayInTimezone.format('YYYY-MM-DD')
   const visibleSlots = isSelectedDayToday
     ? slots.filter(slot => new Date(slot.start).getTime() >= now)
     : slots
@@ -142,7 +155,7 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
           dayName={selectedDay.toDate().toLocaleDateString(lang, {
             weekday: 'short'
           })}
-          isToday
+          isToday={isSelectedDayToday}
         />
       </Box>
       <SlotList
@@ -150,6 +163,7 @@ export const BookingTimeSlotSection: React.FC<BookingTimeSlotSectionProps> = ({
         selectedSlot={selectedSlot}
         onSelectSlot={onSelectSlot}
         lang={lang}
+        selectedTimezone={selectedTimezone}
       />
     </Box>
   )

--- a/apps/public/src/features/booking/BookingPage.tsx
+++ b/apps/public/src/features/booking/BookingPage.tsx
@@ -12,6 +12,7 @@ import { BookingTimeSlotSection } from '../../components/Booking/BookingTimeSlot
 import { useI18n } from 'twake-i18n'
 import { useBookingData } from './hooks/useBookingData'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
+import { browserDefaultTimeZone } from '@common/utils/timezone'
 
 export const BookingPage: React.FC = () => {
   const { t } = useI18n()
@@ -25,10 +26,14 @@ export const BookingPage: React.FC = () => {
     const now = new Date()
     return new Date(now.getFullYear(), now.getMonth(), 1)
   })
+  const [selectedTimezone, setSelectedTimezone] = useState<string>(
+    browserDefaultTimeZone
+  )
   const { slots, bookingInfo, initialLoading, monthLoading, error, refetch } =
     useBookingData({
       bookingLinkPublicId,
       visibleMonth,
+      timezone: selectedTimezone,
       loadErrorMessage: t('booking.error.loadFailed')
     })
 
@@ -40,18 +45,27 @@ export const BookingPage: React.FC = () => {
     string | null
   >(null)
 
+  const tzFormatter = useMemo(
+    () => new Intl.DateTimeFormat('en-CA', { timeZone: selectedTimezone }),
+    [selectedTimezone]
+  )
+
+  const [nowMs] = useState(Date.now)
+
   // Group slots by calendar day for quick lookup when rendering the grid
   const slotsByDay = useMemo(() => {
     const map = new Map<string, Slot[]>()
     slots.forEach(slot => {
-      const date = new Date(slot.start)
-      const key = date.toDateString()
+      if (new Date(slot.start).getTime() < nowMs) {
+        return
+      }
+      const key = tzFormatter.format(new Date(slot.start))
       const existing = map.get(key) ?? []
       existing.push(slot)
       map.set(key, existing)
     })
     return map
-  }, [slots])
+  }, [slots, tzFormatter, nowMs])
 
   const availableDays = useMemo(() => new Set(slotsByDay.keys()), [slotsByDay])
 
@@ -59,7 +73,7 @@ export const BookingPage: React.FC = () => {
     if (!selectedDay) {
       return []
     }
-    return slotsByDay.get(selectedDay.toDate().toDateString()) ?? []
+    return slotsByDay.get(selectedDay.format('YYYY-MM-DD')) ?? []
   }, [selectedDay, slotsByDay])
 
   const handleMonthChange = (month: Dayjs): void => {
@@ -122,6 +136,12 @@ export const BookingPage: React.FC = () => {
     }
   }
 
+  const handleTimezoneChange = (timezone: string): void => {
+    setSelectedTimezone(timezone)
+    setSelectedDay(null)
+    setSelectedSlot(null)
+  }
+
   const showPanel = !initialLoading && !(error && !bookingInfo)
 
   return (
@@ -150,7 +170,14 @@ export const BookingPage: React.FC = () => {
         </Typography>
       )}
 
-      {showPanel && bookingInfo && <BookingHeader bookingInfo={bookingInfo} />}
+      {showPanel && bookingInfo && (
+        <BookingHeader
+          bookingInfo={bookingInfo}
+          selectedTimezone={selectedTimezone}
+          onTimezoneChange={handleTimezoneChange}
+          referenceDate={visibleMonth}
+        />
+      )}
       {showPanel && !isMobile && <Divider />}
 
       {showPanel && (
@@ -188,6 +215,7 @@ export const BookingPage: React.FC = () => {
               availableDays={availableDays}
               onSelectDay={handleSelectDay}
               onMonthChange={handleMonthChange}
+              selectedTimezone={selectedTimezone}
             />
             {showPanel && isMobile && <Divider />}
             <BookingTimeSlotSection
@@ -195,6 +223,7 @@ export const BookingPage: React.FC = () => {
               slots={slotsForSelectedDay}
               selectedSlot={selectedSlot}
               onSelectSlot={handleSelectSlot}
+              selectedTimezone={selectedTimezone}
             />
           </Box>
         </Box>
@@ -206,6 +235,7 @@ export const BookingPage: React.FC = () => {
         selectedSlot={selectedSlot}
         bookingInfo={bookingInfo}
         onConfirm={handleConfirmBooking}
+        selectedTimezone={selectedTimezone}
       />
       <BookingSuccessDialog
         open={successOpen}
@@ -213,7 +243,7 @@ export const BookingPage: React.FC = () => {
         selectedSlot={selectedSlot}
         bookingInfo={bookingInfo}
         eventLink={`${window.location.origin}/booking/confirmed/${bookingConfirmationToken}`}
-        onCancelMeeting={handleCancelMeeting}
+        onCancelMeeting={() => void handleCancelMeeting()}
       />
     </Box>
   )

--- a/apps/public/src/features/booking/components/BookingDialog.tsx
+++ b/apps/public/src/features/booking/components/BookingDialog.tsx
@@ -4,7 +4,6 @@ import {
   Slot
 } from '@common/features/booking/types/BookingTypes'
 import { isValidEmail } from '@common/utils/isValidEmail'
-import { browserDefaultTimeZone } from '@common/utils/timezone'
 import {
   Avatar,
   Box,
@@ -18,7 +17,6 @@ import {
   Typography
 } from '@linagora/twake-mui'
 import CloseIcon from '@mui/icons-material/Close'
-import dayjs from 'dayjs'
 import React, { useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { StaticDateTimeSummary } from './StaticDateTimeSummary'
@@ -29,6 +27,7 @@ interface BookingConfirmDialogProps {
   selectedSlot: Slot | null
   bookingInfo: BookingSlotsResponse | null
   onConfirm: (name: string, email: string) => Promise<void>
+  selectedTimezone: string
 }
 
 interface DialogHeaderProps {
@@ -65,18 +64,40 @@ const DialogHeader: React.FC<DialogHeaderProps> = ({ owner, onClose }) => {
 interface BookingDetailsProps {
   bookingInfo: BookingSlotsResponse | null
   selectedSlot: Slot | null
+  selectedTimezone: string
 }
 
 const BookingDetails: React.FC<BookingDetailsProps> = ({
   bookingInfo,
-  selectedSlot
+  selectedSlot,
+  selectedTimezone
 }) => {
-  const endDateTime = selectedSlot
-    ? dayjs(selectedSlot.start).add(
-        bookingInfo?.durationMinutes ?? 30,
-        'minute'
-      )
-    : null
+  let startDateStr = ''
+  let startTimeStr = ''
+  let endDateStr = ''
+  let endTimeStr = ''
+
+  if (selectedSlot) {
+    const start = new Date(selectedSlot.start)
+    const end = new Date(
+      start.getTime() + (bookingInfo?.durationMinutes ?? 30) * 60000
+    )
+
+    const dateFmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: selectedTimezone
+    })
+    const timeFmt = new Intl.DateTimeFormat('en-GB', {
+      timeZone: selectedTimezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    })
+
+    startDateStr = dateFmt.format(start)
+    startTimeStr = timeFmt.format(start)
+    endDateStr = dateFmt.format(end)
+    endTimeStr = timeFmt.format(end)
+  }
 
   return (
     <>
@@ -85,13 +106,13 @@ const BookingDetails: React.FC<BookingDetailsProps> = ({
           {bookingInfo.name}
         </Typography>
       )}
-      {selectedSlot && endDateTime && (
+      {selectedSlot && (
         <StaticDateTimeSummary
-          startDate={dayjs(selectedSlot.start).format('YYYY-MM-DD')}
-          startTime={dayjs(selectedSlot.start).format('HH:mm')}
-          endDate={endDateTime.format('YYYY-MM-DD')}
-          endTime={endDateTime.format('HH:mm')}
-          timezone={browserDefaultTimeZone}
+          startDate={startDateStr}
+          startTime={startTimeStr}
+          endDate={endDateStr}
+          endTime={endTimeStr}
+          timezone={selectedTimezone}
         />
       )}
     </>
@@ -152,7 +173,8 @@ export const BookingConfirmDialog: React.FC<BookingConfirmDialogProps> = ({
   onClose,
   selectedSlot,
   bookingInfo,
-  onConfirm
+  onConfirm,
+  selectedTimezone
 }) => {
   const { t } = useI18n()
   const [name, setName] = useState<string>('')
@@ -207,7 +229,11 @@ export const BookingConfirmDialog: React.FC<BookingConfirmDialogProps> = ({
     <Dialog open={open} onClose={handleClose}>
       <DialogHeader owner={bookingInfo?.owner} onClose={handleClose} />
       <DialogContent>
-        <BookingDetails bookingInfo={bookingInfo} selectedSlot={selectedSlot} />
+        <BookingDetails
+          bookingInfo={bookingInfo}
+          selectedSlot={selectedSlot}
+          selectedTimezone={selectedTimezone}
+        />
         <BookingForm
           name={name}
           email={email}
@@ -226,7 +252,7 @@ export const BookingConfirmDialog: React.FC<BookingConfirmDialogProps> = ({
           {t('common.cancel')}
         </Button>
         <Button
-          onClick={handleConfirm}
+          onClick={() => void handleConfirm()}
           variant="contained"
           disabled={bookingInProgress}
         >

--- a/apps/public/src/features/booking/hooks/useBookingData.ts
+++ b/apps/public/src/features/booking/hooks/useBookingData.ts
@@ -2,13 +2,13 @@ import {
   BookingSlotsResponse,
   Slot
 } from '@common/features/booking/types/BookingTypes'
-import { browserDefaultTimeZone } from '@common/utils/timezone'
 import { useEffect, useRef, useState } from 'react'
 import { fetchBookingSlots } from '../BookingDao'
 
 interface UseBookingDataParams {
   bookingLinkPublicId?: string
   visibleMonth: Date
+  timezone: string
   loadErrorMessage: string
 }
 
@@ -24,6 +24,7 @@ interface UseBookingDataResult {
 export const useBookingData = ({
   bookingLinkPublicId,
   visibleMonth,
+  timezone,
   loadErrorMessage
 }: UseBookingDataParams): UseBookingDataResult => {
   const [slots, setSlots] = useState<Slot[]>([])
@@ -68,7 +69,7 @@ export const useBookingData = ({
           bookingLinkPublicId,
           from,
           to,
-          browserDefaultTimeZone
+          timezone
         )
 
         if (cancelled) {
@@ -100,7 +101,13 @@ export const useBookingData = ({
     return () => {
       cancelled = true
     }
-  }, [bookingLinkPublicId, loadErrorMessage, visibleMonth, refreshVersion])
+  }, [
+    bookingLinkPublicId,
+    loadErrorMessage,
+    visibleMonth,
+    refreshVersion,
+    timezone
+  ])
 
   const refetch = (): void => {
     setRefreshVersion(v => v + 1)


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1103

https://github.com/user-attachments/assets/31617101-8156-4667-a159-968db6b0cf27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking views now respect the selected time zone across the calendar, time slots, header, and confirmation dialog.
  * Time slots and dates are displayed in the chosen time zone, with “today” and available-day logic updated accordingly.
  * Booking details now show clearer owner, event, duration, and description information in the header.

* **Bug Fixes**
  * Improved booking slot grouping and selection so availability stays aligned with the displayed date in the selected time zone.
  * Confirmation details now match the selected time zone for start and end times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->