### PR TITLE
[#1115] fixed alarms display for single attendee event edit

### DIFF
--- a/__test__/features/Events/updateEventHelpers/prepareUpdatedEvent.test.ts
+++ b/__test__/features/Events/updateEventHelpers/prepareUpdatedEvent.test.ts
@@ -159,15 +159,11 @@ describe('prepareUpdatedEvent', () => {
       newCalId: 'cal-1'
     })
 
-    // The alarm should now have both attendees (owner + other)
+    // The alarm should preserve its original attendee (owner)
+    // because prepareUpdatedEvent preserves existing attendees
     const alarm = updatedEvent.alarms?.getAlarm(0)
-    expect(alarm?.attendees).toHaveLength(2)
-    expect(alarm?.attendees?.map(a => a.cal_address)).toContain(
-      'mailto:owner@example.com'
-    )
-    expect(alarm?.attendees?.map(a => a.cal_address)).toContain(
-      'mailto:other@example.com'
-    )
+    expect(alarm?.attendees).toHaveLength(1)
+    expect(alarm?.attendees?.[0]?.cal_address).toBe('mailto:owner@example.com')
   })
 
   it('keeps personal alarm when event stays single-user', () => {

--- a/__test__/features/Events/updateEventHelpers/prepareUpdatedEvent.test.ts
+++ b/__test__/features/Events/updateEventHelpers/prepareUpdatedEvent.test.ts
@@ -1,4 +1,5 @@
 import { prepareUpdatedEvent } from '@common/features/Events/hooks/submitUpdateHelpers/utils'
+import { userAttendee } from '@common/features/User/models/attendee'
 import { Calendar } from '@common/types/CalendarTypes'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { VAlarm } from '@common/types/VAlarm'
@@ -101,5 +102,125 @@ describe('prepareUpdatedEvent', () => {
     // Verify other event properties are unchanged
     expect(updatedEvent.location).toBe('')
     expect(updatedEvent.description).toBe('')
+  })
+
+  it('converts personal alarm to global alarm when adding attendees', () => {
+    // Start with a single-user event that has a personal alarm
+    const singleUserEvent = {
+      ...baseEvent,
+      alarms: new Valarms([
+        new VAlarm({
+          trigger: '-PT10M',
+          action: 'EMAIL',
+          attendees: [
+            new userAttendee({
+              cal_address: 'mailto:owner@example.com',
+              cn: 'Owner'
+            })
+          ]
+        })
+      ])
+    } as unknown as CalendarEvent
+
+    // Now add another attendee
+    const valuesWithNewAttendee = {
+      ...baseValues,
+      attendees: [
+        new userAttendee({
+          cal_address: 'mailto:other@example.com',
+          cn: 'Other'
+        })
+      ],
+      alarms: new Valarms([
+        new VAlarm({
+          trigger: '-PT10M',
+          action: 'EMAIL',
+          attendees: [
+            new userAttendee({
+              cal_address: 'mailto:owner@example.com',
+              cn: 'Owner'
+            })
+          ]
+        })
+      ])
+    }
+
+    const updatedEvent = prepareUpdatedEvent({
+      event: singleUserEvent,
+      values: valuesWithNewAttendee,
+      startISO: '2025-01-01T10:00:00.000Z',
+      endISO: '2025-01-01T11:00:00.000Z',
+      timeChanged: false,
+      targetCalendar: {
+        id: 'cal-1',
+        owner: { emails: ['owner@example.com'] }
+      } as Calendar,
+      calId: 'cal-1',
+      newCalId: 'cal-1'
+    })
+
+    // The alarm should now have both attendees (owner + other)
+    const alarm = updatedEvent.alarms?.getAlarm(0)
+    expect(alarm?.attendees).toHaveLength(2)
+    expect(alarm?.attendees?.map(a => a.cal_address)).toContain(
+      'mailto:owner@example.com'
+    )
+    expect(alarm?.attendees?.map(a => a.cal_address)).toContain(
+      'mailto:other@example.com'
+    )
+  })
+
+  it('keeps personal alarm when event stays single-user', () => {
+    const singleUserEvent = {
+      ...baseEvent,
+      alarms: new Valarms([
+        new VAlarm({
+          trigger: '-PT10M',
+          action: 'EMAIL',
+          attendees: [
+            new userAttendee({
+              cal_address: 'mailto:owner@example.com',
+              cn: 'Owner'
+            })
+          ]
+        })
+      ])
+    } as unknown as CalendarEvent
+
+    const valuesSingleUser = {
+      ...baseValues,
+      attendees: [],
+      alarms: new Valarms([
+        new VAlarm({
+          trigger: '-PT10M',
+          action: 'EMAIL',
+          attendees: [
+            new userAttendee({
+              cal_address: 'mailto:owner@example.com',
+              cn: 'Owner'
+            })
+          ]
+        })
+      ])
+    }
+
+    const updatedEvent = prepareUpdatedEvent({
+      event: singleUserEvent,
+      values: valuesSingleUser,
+      startISO: '2025-01-01T10:00:00.000Z',
+      endISO: '2025-01-01T11:00:00.000Z',
+      timeChanged: false,
+      targetCalendar: {
+        id: 'cal-1',
+        owner: { emails: ['owner@example.com'] }
+      } as Calendar,
+      calId: 'cal-1',
+      newCalId: 'cal-1'
+    })
+
+    // The alarm should still have only the owner as attendee
+    const alarm = updatedEvent.alarms?.getAlarm(0)
+    expect(alarm?.attendees).toHaveLength(1)
+    expect(alarm?.attendees?.[0]?.cal_address).toBe('mailto:owner@example.com')
   })
 })

--- a/__test__/types/Valarms.test.ts
+++ b/__test__/types/Valarms.test.ts
@@ -6,6 +6,15 @@ describe('Valarms', () => {
   const createAttendee = (email: string): userAttendee =>
     new userAttendee({ cal_address: `mailto:${email}`, cn: email })
 
+  const createAlarm = (trigger: string, attendees?: userAttendee[]): VAlarm =>
+    new VAlarm({
+      trigger,
+      action: 'EMAIL',
+      attendees,
+      summary: 'Test',
+      description: 'Test'
+    })
+
   describe('getEditableAlarms', () => {
     it('returns global alarms when no attendee is provided', () => {
       const globalAlarm = new VAlarm({
@@ -122,6 +131,194 @@ describe('Valarms', () => {
 
       expect(result).toHaveLength(1)
       expect(result[0].trigger).toBe('-PT10M')
+    })
+  })
+
+  describe('mergeForPersonalSettingsUpdate', () => {
+    it('preserves original alarm attendees when alarm is selected', () => {
+      const currentUser = createAttendee('current@example.com')
+      const otherUser = createAttendee('other@example.com')
+
+      // Original has a global alarm with both attendees
+      const originalAlarms = new Valarms([
+        createAlarm('-PT15M', [currentUser, otherUser]),
+        createAlarm('-PT10M', [currentUser, otherUser])
+      ])
+
+      // Form only has -15M selected (form data may lack attendees)
+      const formAlarms = new Valarms([
+        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
+      ])
+
+      const result = originalAlarms.mergeForPersonalSettingsUpdate(
+        formAlarms,
+        currentUser
+      )
+
+      // -15M should be preserved with original attendees
+      const keptAlarm = result.getAlarms().find(a => a.trigger === '-PT15M')
+      expect(keptAlarm?.attendees).toHaveLength(2)
+      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
+        'mailto:current@example.com'
+      )
+      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
+        'mailto:other@example.com'
+      )
+
+      // -10M should have current user removed (now single attendee = other)
+      const removedAlarm = result.getAlarms().find(a => a.trigger === '-PT10M')
+      expect(removedAlarm?.attendees).toHaveLength(1)
+      expect(removedAlarm?.attendees?.[0]?.cal_address).toBe(
+        'mailto:other@example.com'
+      )
+    })
+
+    it('drops alarm when user is the only attendee and deselects it', () => {
+      const currentUser = createAttendee('current@example.com')
+
+      // Original has a personal alarm for current user
+      const originalAlarms = new Valarms([
+        createAlarm('-PT15M', [currentUser]),
+        createAlarm('-PT10M', [currentUser])
+      ])
+
+      // Form only has -15M selected
+      const formAlarms = new Valarms([
+        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
+      ])
+
+      const result = originalAlarms.mergeForPersonalSettingsUpdate(
+        formAlarms,
+        currentUser
+      )
+
+      // Only -15M should remain
+      expect(result.getAlarms()).toHaveLength(1)
+      expect(result.getAlarm(0)?.trigger).toBe('-PT15M')
+    })
+
+    it('preserves alarms user was never part of', () => {
+      const currentUser = createAttendee('current@example.com')
+      const otherUser1 = createAttendee('other1@example.com')
+      const otherUser2 = createAttendee('other2@example.com')
+
+      // Original has an alarm for other users only
+      const originalAlarms = new Valarms([
+        createAlarm('-PT15M', [currentUser]),
+        createAlarm('-PT10M', [otherUser1, otherUser2]) // current user not here
+      ])
+
+      // Form has -15M selected
+      const formAlarms = new Valarms([
+        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
+      ])
+
+      const result = originalAlarms.mergeForPersonalSettingsUpdate(
+        formAlarms,
+        currentUser
+      )
+
+      // Both should be in result
+      expect(result.getAlarms()).toHaveLength(2)
+      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT15M')
+      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT10M')
+
+      // -10M should still have original attendees
+      const otherAlarm = result.getAlarms().find(a => a.trigger === '-PT10M')
+      expect(otherAlarm?.attendees).toHaveLength(2)
+    })
+
+    it('handles adding new alarms from form', () => {
+      const currentUser = createAttendee('current@example.com')
+
+      const originalAlarms = new Valarms([createAlarm('-PT15M', [currentUser])])
+
+      // Form adds a new alarm
+      const formAlarms = new Valarms([
+        createAlarm('-PT15M', [currentUser]),
+        new VAlarm({ trigger: '-PT5M', action: 'EMAIL' })
+      ])
+
+      const result = originalAlarms.mergeForPersonalSettingsUpdate(
+        formAlarms,
+        currentUser
+      )
+
+      expect(result.getAlarms()).toHaveLength(2)
+      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT15M')
+      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT5M')
+    })
+
+    it('removes user from global alarm when deselected (2 attendees)', () => {
+      const currentUser = createAttendee('current@example.com')
+      const otherUser = createAttendee('other@example.com')
+
+      // Original has 2 global alarms with both attendees
+      const originalAlarms = new Valarms([
+        createAlarm('-PT15M', [currentUser, otherUser]),
+        createAlarm('-PT10M', [currentUser, otherUser])
+      ])
+
+      // Form only has -15M selected (current user deselected -10M)
+      const formAlarms = new Valarms([
+        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
+      ])
+
+      const result = originalAlarms.mergeForPersonalSettingsUpdate(
+        formAlarms,
+        currentUser
+      )
+
+      // -15M should be preserved with original attendees
+      const keptAlarm = result.getAlarms().find(a => a.trigger === '-PT15M')
+      expect(keptAlarm?.attendees).toHaveLength(2)
+      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
+        'mailto:current@example.com'
+      )
+      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
+        'mailto:other@example.com'
+      )
+
+      // -10M should have current user removed (now single attendee = other)
+      const removedAlarm = result.getAlarms().find(a => a.trigger === '-PT10M')
+      expect(removedAlarm?.attendees).toHaveLength(1)
+      expect(removedAlarm?.attendees?.[0]?.cal_address).toBe(
+        'mailto:other@example.com'
+      )
+    })
+
+    it('drops global alarm entirely when user is the only attendee left', () => {
+      const currentUser = createAttendee('current@example.com')
+      const otherUser = createAttendee('other@example.com')
+
+      // Original has a global alarm with both attendees
+      const originalAlarms = new Valarms([
+        createAlarm('-PT15M', [currentUser, otherUser]),
+        createAlarm('-PT10M', [currentUser, otherUser])
+      ])
+
+      // Form has no alarms selected (user removed all)
+      const formAlarms = new Valarms([])
+
+      const result = originalAlarms.mergeForPersonalSettingsUpdate(
+        formAlarms,
+        currentUser
+      )
+
+      // Both alarms should have current user removed, leaving only other user
+      expect(result.getAlarms()).toHaveLength(2)
+
+      const alarm15m = result.getAlarms().find(a => a.trigger === '-PT15M')
+      expect(alarm15m?.attendees).toHaveLength(1)
+      expect(alarm15m?.attendees?.[0]?.cal_address).toBe(
+        'mailto:other@example.com'
+      )
+
+      const alarm10m = result.getAlarms().find(a => a.trigger === '-PT10M')
+      expect(alarm10m?.attendees).toHaveLength(1)
+      expect(alarm10m?.attendees?.[0]?.cal_address).toBe(
+        'mailto:other@example.com'
+      )
     })
   })
 })

--- a/__test__/types/Valarms.test.ts
+++ b/__test__/types/Valarms.test.ts
@@ -29,7 +29,9 @@ describe('Valarms', () => {
       const alarm = new VAlarm({ trigger: '-PT15M', action: 'DISPLAY' })
       const valarms = new Valarms([alarm])
 
-      const result = valarms.getEditableAlarms(createAttendee('user@example.com'))
+      const result = valarms.getEditableAlarms(
+        createAttendee('user@example.com')
+      )
 
       expect(result).toHaveLength(1)
       expect(result[0].trigger).toBe('-PT15M')
@@ -46,7 +48,9 @@ describe('Valarms', () => {
       })
       const valarms = new Valarms([alarm])
 
-      const result = valarms.getEditableAlarms(createAttendee('user@example.com'))
+      const result = valarms.getEditableAlarms(
+        createAttendee('user@example.com')
+      )
 
       expect(result).toHaveLength(1)
       expect(result[0].trigger).toBe('-PT15M')
@@ -65,7 +69,9 @@ describe('Valarms', () => {
       })
       const valarms = new Valarms([currentUserAlarm, otherUserAlarm])
 
-      const result = valarms.getEditableAlarms(createAttendee('current@example.com'))
+      const result = valarms.getEditableAlarms(
+        createAttendee('current@example.com')
+      )
 
       expect(result).toHaveLength(1)
       expect(result[0].trigger).toBe('-PT10M')
@@ -86,9 +92,15 @@ describe('Valarms', () => {
         action: 'EMAIL',
         attendees: [createAttendee('other@example.com')]
       })
-      const valarms = new Valarms([globalAlarm, currentUserAlarm, otherUserAlarm])
+      const valarms = new Valarms([
+        globalAlarm,
+        currentUserAlarm,
+        otherUserAlarm
+      ])
 
-      const result = valarms.getEditableAlarms(createAttendee('current@example.com'))
+      const result = valarms.getEditableAlarms(
+        createAttendee('current@example.com')
+      )
 
       expect(result).toHaveLength(2)
       expect(result.map(a => a.trigger)).toContain('-PT15M')
@@ -104,7 +116,9 @@ describe('Valarms', () => {
       })
       const valarms = new Valarms([alarm])
 
-      const result = valarms.getEditableAlarms(createAttendee('user@example.com'))
+      const result = valarms.getEditableAlarms(
+        createAttendee('user@example.com')
+      )
 
       expect(result).toHaveLength(1)
       expect(result[0].trigger).toBe('-PT10M')

--- a/__test__/types/Valarms.test.ts
+++ b/__test__/types/Valarms.test.ts
@@ -1,0 +1,113 @@
+import { userAttendee } from '@common/features/User/models/attendee'
+import { VAlarm } from '@common/types/VAlarm'
+import { Valarms } from '@common/types/Valarms'
+
+describe('Valarms', () => {
+  const createAttendee = (email: string): userAttendee =>
+    new userAttendee({ cal_address: `mailto:${email}`, cn: email })
+
+  describe('getEditableAlarms', () => {
+    it('returns global alarms when no attendee is provided', () => {
+      const globalAlarm = new VAlarm({
+        trigger: '-PT15M',
+        action: 'DISPLAY'
+      })
+      const personalAlarm = new VAlarm({
+        trigger: '-PT10M',
+        action: 'EMAIL',
+        attendees: [createAttendee('user@example.com')]
+      })
+      const valarms = new Valarms([globalAlarm, personalAlarm])
+
+      const result = valarms.getEditableAlarms(undefined)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].trigger).toBe('-PT15M')
+    })
+
+    it('returns global alarms (no attendees)', () => {
+      const alarm = new VAlarm({ trigger: '-PT15M', action: 'DISPLAY' })
+      const valarms = new Valarms([alarm])
+
+      const result = valarms.getEditableAlarms(createAttendee('user@example.com'))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].trigger).toBe('-PT15M')
+    })
+
+    it('returns global alarms (multiple attendees)', () => {
+      const alarm = new VAlarm({
+        trigger: '-PT15M',
+        action: 'EMAIL',
+        attendees: [
+          createAttendee('user1@example.com'),
+          createAttendee('user2@example.com')
+        ]
+      })
+      const valarms = new Valarms([alarm])
+
+      const result = valarms.getEditableAlarms(createAttendee('user@example.com'))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].trigger).toBe('-PT15M')
+    })
+
+    it('returns personal alarms for the current user', () => {
+      const currentUserAlarm = new VAlarm({
+        trigger: '-PT10M',
+        action: 'EMAIL',
+        attendees: [createAttendee('current@example.com')]
+      })
+      const otherUserAlarm = new VAlarm({
+        trigger: '-PT5M',
+        action: 'EMAIL',
+        attendees: [createAttendee('other@example.com')]
+      })
+      const valarms = new Valarms([currentUserAlarm, otherUserAlarm])
+
+      const result = valarms.getEditableAlarms(createAttendee('current@example.com'))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].trigger).toBe('-PT10M')
+    })
+
+    it('returns both global and current user personal alarms', () => {
+      const globalAlarm = new VAlarm({
+        trigger: '-PT15M',
+        action: 'DISPLAY'
+      })
+      const currentUserAlarm = new VAlarm({
+        trigger: '-PT10M',
+        action: 'EMAIL',
+        attendees: [createAttendee('current@example.com')]
+      })
+      const otherUserAlarm = new VAlarm({
+        trigger: '-PT5M',
+        action: 'EMAIL',
+        attendees: [createAttendee('other@example.com')]
+      })
+      const valarms = new Valarms([globalAlarm, currentUserAlarm, otherUserAlarm])
+
+      const result = valarms.getEditableAlarms(createAttendee('current@example.com'))
+
+      expect(result).toHaveLength(2)
+      expect(result.map(a => a.trigger)).toContain('-PT15M')
+      expect(result.map(a => a.trigger)).toContain('-PT10M')
+      expect(result.map(a => a.trigger)).not.toContain('-PT5M')
+    })
+
+    it('handles email comparison case-insensitively', () => {
+      const alarm = new VAlarm({
+        trigger: '-PT10M',
+        action: 'EMAIL',
+        attendees: [createAttendee('User@Example.COM')]
+      })
+      const valarms = new Valarms([alarm])
+
+      const result = valarms.getEditableAlarms(createAttendee('user@example.com'))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].trigger).toBe('-PT10M')
+    })
+  })
+})

--- a/__test__/types/Valarms.test.ts
+++ b/__test__/types/Valarms.test.ts
@@ -15,17 +15,22 @@ describe('Valarms', () => {
       description: 'Test'
     })
 
+  const expectAlarmAttendees = (
+    alarm: VAlarm | undefined,
+    expectedEmails: string[]
+  ): void => {
+    expect(alarm?.attendees).toHaveLength(expectedEmails.length)
+    expectedEmails.forEach(email => {
+      expect(alarm?.attendees?.map(a => a.cal_address)).toContain(email)
+    })
+  }
+
   describe('getEditableAlarms', () => {
     it('returns global alarms when no attendee is provided', () => {
-      const globalAlarm = new VAlarm({
-        trigger: '-PT15M',
-        action: 'DISPLAY'
-      })
-      const personalAlarm = new VAlarm({
-        trigger: '-PT10M',
-        action: 'EMAIL',
-        attendees: [createAttendee('user@example.com')]
-      })
+      const globalAlarm = createAlarm('-PT15M')
+      const personalAlarm = createAlarm('-PT10M', [
+        createAttendee('user@example.com')
+      ])
       const valarms = new Valarms([globalAlarm, personalAlarm])
 
       const result = valarms.getEditableAlarms(undefined)
@@ -34,8 +39,8 @@ describe('Valarms', () => {
       expect(result[0].trigger).toBe('-PT15M')
     })
 
-    it('returns global alarms (no attendees)', () => {
-      const alarm = new VAlarm({ trigger: '-PT15M', action: 'DISPLAY' })
+    it('returns global alarms with no attendees', () => {
+      const alarm = createAlarm('-PT15M')
       const valarms = new Valarms([alarm])
 
       const result = valarms.getEditableAlarms(
@@ -46,15 +51,11 @@ describe('Valarms', () => {
       expect(result[0].trigger).toBe('-PT15M')
     })
 
-    it('returns global alarms (multiple attendees)', () => {
-      const alarm = new VAlarm({
-        trigger: '-PT15M',
-        action: 'EMAIL',
-        attendees: [
-          createAttendee('user1@example.com'),
-          createAttendee('user2@example.com')
-        ]
-      })
+    it('returns global alarms with multiple attendees', () => {
+      const alarm = createAlarm('-PT15M', [
+        createAttendee('user1@example.com'),
+        createAttendee('user2@example.com')
+      ])
       const valarms = new Valarms([alarm])
 
       const result = valarms.getEditableAlarms(
@@ -66,63 +67,41 @@ describe('Valarms', () => {
     })
 
     it('returns personal alarms for the current user', () => {
-      const currentUserAlarm = new VAlarm({
-        trigger: '-PT10M',
-        action: 'EMAIL',
-        attendees: [createAttendee('current@example.com')]
-      })
-      const otherUserAlarm = new VAlarm({
-        trigger: '-PT5M',
-        action: 'EMAIL',
-        attendees: [createAttendee('other@example.com')]
-      })
-      const valarms = new Valarms([currentUserAlarm, otherUserAlarm])
+      const currentUser = createAttendee('current@example.com')
+      const otherUser = createAttendee('other@example.com')
 
-      const result = valarms.getEditableAlarms(
-        createAttendee('current@example.com')
-      )
+      const valarms = new Valarms([
+        createAlarm('-PT10M', [currentUser]),
+        createAlarm('-PT5M', [otherUser])
+      ])
+
+      const result = valarms.getEditableAlarms(currentUser)
 
       expect(result).toHaveLength(1)
       expect(result[0].trigger).toBe('-PT10M')
     })
 
     it('returns both global and current user personal alarms', () => {
-      const globalAlarm = new VAlarm({
-        trigger: '-PT15M',
-        action: 'DISPLAY'
-      })
-      const currentUserAlarm = new VAlarm({
-        trigger: '-PT10M',
-        action: 'EMAIL',
-        attendees: [createAttendee('current@example.com')]
-      })
-      const otherUserAlarm = new VAlarm({
-        trigger: '-PT5M',
-        action: 'EMAIL',
-        attendees: [createAttendee('other@example.com')]
-      })
+      const currentUser = createAttendee('current@example.com')
+      const otherUser = createAttendee('other@example.com')
+
       const valarms = new Valarms([
-        globalAlarm,
-        currentUserAlarm,
-        otherUserAlarm
+        createAlarm('-PT15M'),
+        createAlarm('-PT10M', [currentUser]),
+        createAlarm('-PT5M', [otherUser])
       ])
 
-      const result = valarms.getEditableAlarms(
-        createAttendee('current@example.com')
-      )
+      const result = valarms.getEditableAlarms(currentUser)
+      const triggers = result.map(a => a.trigger)
 
       expect(result).toHaveLength(2)
-      expect(result.map(a => a.trigger)).toContain('-PT15M')
-      expect(result.map(a => a.trigger)).toContain('-PT10M')
-      expect(result.map(a => a.trigger)).not.toContain('-PT5M')
+      expect(triggers).toContain('-PT15M')
+      expect(triggers).toContain('-PT10M')
+      expect(triggers).not.toContain('-PT5M')
     })
 
     it('handles email comparison case-insensitively', () => {
-      const alarm = new VAlarm({
-        trigger: '-PT10M',
-        action: 'EMAIL',
-        attendees: [createAttendee('User@Example.COM')]
-      })
+      const alarm = createAlarm('-PT10M', [createAttendee('User@Example.COM')])
       const valarms = new Valarms([alarm])
 
       const result = valarms.getEditableAlarms(
@@ -135,66 +114,70 @@ describe('Valarms', () => {
   })
 
   describe('mergeForPersonalSettingsUpdate', () => {
-    it('preserves original alarm attendees when alarm is selected', () => {
-      const currentUser = createAttendee('current@example.com')
-      const otherUser = createAttendee('other@example.com')
+    describe('when alarm is selected', () => {
+      it('preserves original alarm with both attendees', () => {
+        const currentUser = createAttendee('current@example.com')
+        const otherUser = createAttendee('other@example.com')
 
-      // Original has a global alarm with both attendees
-      const originalAlarms = new Valarms([
-        createAlarm('-PT15M', [currentUser, otherUser]),
-        createAlarm('-PT10M', [currentUser, otherUser])
-      ])
+        const originalAlarms = new Valarms([
+          createAlarm('-PT15M', [currentUser, otherUser])
+        ])
 
-      // Form only has -15M selected (form data may lack attendees)
-      const formAlarms = new Valarms([
-        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
-      ])
+        const formAlarms = new Valarms([
+          new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
+        ])
 
-      const result = originalAlarms.mergeForPersonalSettingsUpdate(
-        formAlarms,
-        currentUser
-      )
+        const result = originalAlarms.mergeForPersonalSettingsUpdate(
+          formAlarms,
+          currentUser
+        )
 
-      // -15M should be preserved with original attendees
-      const keptAlarm = result.getAlarms().find(a => a.trigger === '-PT15M')
-      expect(keptAlarm?.attendees).toHaveLength(2)
-      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
-        'mailto:current@example.com'
-      )
-      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
-        'mailto:other@example.com'
-      )
-
-      // -10M should have current user removed (now single attendee = other)
-      const removedAlarm = result.getAlarms().find(a => a.trigger === '-PT10M')
-      expect(removedAlarm?.attendees).toHaveLength(1)
-      expect(removedAlarm?.attendees?.[0]?.cal_address).toBe(
-        'mailto:other@example.com'
-      )
+        expectAlarmAttendees(result.getAlarm(0), [
+          'mailto:current@example.com',
+          'mailto:other@example.com'
+        ])
+      })
     })
 
-    it('drops alarm when user is the only attendee and deselects it', () => {
-      const currentUser = createAttendee('current@example.com')
+    describe('when alarm is deselected', () => {
+      it('removes user from global alarm', () => {
+        const currentUser = createAttendee('current@example.com')
+        const otherUser = createAttendee('other@example.com')
 
-      // Original has a personal alarm for current user
-      const originalAlarms = new Valarms([
-        createAlarm('-PT15M', [currentUser]),
-        createAlarm('-PT10M', [currentUser])
-      ])
+        const originalAlarms = new Valarms([
+          createAlarm('-PT15M', [currentUser, otherUser])
+        ])
 
-      // Form only has -15M selected
-      const formAlarms = new Valarms([
-        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
-      ])
+        const formAlarms = new Valarms([])
 
-      const result = originalAlarms.mergeForPersonalSettingsUpdate(
-        formAlarms,
-        currentUser
-      )
+        const result = originalAlarms.mergeForPersonalSettingsUpdate(
+          formAlarms,
+          currentUser
+        )
 
-      // Only -15M should remain
-      expect(result.getAlarms()).toHaveLength(1)
-      expect(result.getAlarm(0)?.trigger).toBe('-PT15M')
+        expectAlarmAttendees(result.getAlarm(0), ['mailto:other@example.com'])
+      })
+
+      it('drops personal alarm when user deselects it', () => {
+        const currentUser = createAttendee('current@example.com')
+
+        const originalAlarms = new Valarms([
+          createAlarm('-PT15M', [currentUser]),
+          createAlarm('-PT10M', [currentUser])
+        ])
+
+        const formAlarms = new Valarms([
+          new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
+        ])
+
+        const result = originalAlarms.mergeForPersonalSettingsUpdate(
+          formAlarms,
+          currentUser
+        )
+
+        expect(result.getAlarms()).toHaveLength(1)
+        expect(result.getAlarm(0)?.trigger).toBe('-PT15M')
+      })
     })
 
     it('preserves alarms user was never part of', () => {
@@ -202,13 +185,11 @@ describe('Valarms', () => {
       const otherUser1 = createAttendee('other1@example.com')
       const otherUser2 = createAttendee('other2@example.com')
 
-      // Original has an alarm for other users only
       const originalAlarms = new Valarms([
         createAlarm('-PT15M', [currentUser]),
-        createAlarm('-PT10M', [otherUser1, otherUser2]) // current user not here
+        createAlarm('-PT10M', [otherUser1, otherUser2])
       ])
 
-      // Form has -15M selected
       const formAlarms = new Valarms([
         new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
       ])
@@ -218,14 +199,7 @@ describe('Valarms', () => {
         currentUser
       )
 
-      // Both should be in result
       expect(result.getAlarms()).toHaveLength(2)
-      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT15M')
-      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT10M')
-
-      // -10M should still have original attendees
-      const otherAlarm = result.getAlarms().find(a => a.trigger === '-PT10M')
-      expect(otherAlarm?.attendees).toHaveLength(2)
     })
 
     it('handles adding new alarms from form', () => {
@@ -233,7 +207,6 @@ describe('Valarms', () => {
 
       const originalAlarms = new Valarms([createAlarm('-PT15M', [currentUser])])
 
-      // Form adds a new alarm
       const formAlarms = new Valarms([
         createAlarm('-PT15M', [currentUser]),
         new VAlarm({ trigger: '-PT5M', action: 'EMAIL' })
@@ -245,80 +218,6 @@ describe('Valarms', () => {
       )
 
       expect(result.getAlarms()).toHaveLength(2)
-      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT15M')
-      expect(result.getAlarms().map(a => a.trigger)).toContain('-PT5M')
-    })
-
-    it('removes user from global alarm when deselected (2 attendees)', () => {
-      const currentUser = createAttendee('current@example.com')
-      const otherUser = createAttendee('other@example.com')
-
-      // Original has 2 global alarms with both attendees
-      const originalAlarms = new Valarms([
-        createAlarm('-PT15M', [currentUser, otherUser]),
-        createAlarm('-PT10M', [currentUser, otherUser])
-      ])
-
-      // Form only has -15M selected (current user deselected -10M)
-      const formAlarms = new Valarms([
-        new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })
-      ])
-
-      const result = originalAlarms.mergeForPersonalSettingsUpdate(
-        formAlarms,
-        currentUser
-      )
-
-      // -15M should be preserved with original attendees
-      const keptAlarm = result.getAlarms().find(a => a.trigger === '-PT15M')
-      expect(keptAlarm?.attendees).toHaveLength(2)
-      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
-        'mailto:current@example.com'
-      )
-      expect(keptAlarm?.attendees?.map(a => a.cal_address)).toContain(
-        'mailto:other@example.com'
-      )
-
-      // -10M should have current user removed (now single attendee = other)
-      const removedAlarm = result.getAlarms().find(a => a.trigger === '-PT10M')
-      expect(removedAlarm?.attendees).toHaveLength(1)
-      expect(removedAlarm?.attendees?.[0]?.cal_address).toBe(
-        'mailto:other@example.com'
-      )
-    })
-
-    it('drops global alarm entirely when user is the only attendee left', () => {
-      const currentUser = createAttendee('current@example.com')
-      const otherUser = createAttendee('other@example.com')
-
-      // Original has a global alarm with both attendees
-      const originalAlarms = new Valarms([
-        createAlarm('-PT15M', [currentUser, otherUser]),
-        createAlarm('-PT10M', [currentUser, otherUser])
-      ])
-
-      // Form has no alarms selected (user removed all)
-      const formAlarms = new Valarms([])
-
-      const result = originalAlarms.mergeForPersonalSettingsUpdate(
-        formAlarms,
-        currentUser
-      )
-
-      // Both alarms should have current user removed, leaving only other user
-      expect(result.getAlarms()).toHaveLength(2)
-
-      const alarm15m = result.getAlarms().find(a => a.trigger === '-PT15M')
-      expect(alarm15m?.attendees).toHaveLength(1)
-      expect(alarm15m?.attendees?.[0]?.cal_address).toBe(
-        'mailto:other@example.com'
-      )
-
-      const alarm10m = result.getAlarms().find(a => a.trigger === '-PT10M')
-      expect(alarm10m?.attendees).toHaveLength(1)
-      expect(alarm10m?.attendees?.[0]?.cal_address).toBe(
-        'mailto:other@example.com'
-      )
     })
   })
 })

--- a/common/src/features/Events/EventUpdateModal.tsx
+++ b/common/src/features/Events/EventUpdateModal.tsx
@@ -3,13 +3,12 @@ import { dialogPaddingStyles } from '@common/theme/dialogPaddingStyles'
 import { ResponsiveDialog } from '@common/components/Dialog'
 import EventFormFields from '@common/components/Event/EventFormFields'
 import { CalendarEvent } from '@common/types/EventsTypes'
-import { Valarms } from '@common/types/Valarms'
-import { userAttendee } from '@common/features/User/models/attendee'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { useI18n } from 'twake-i18n'
 import { EventActions } from './EventActions'
 import { useEventUpdateModal } from './useEventUpdateModal'
+import { useEditableInitialValues } from './hooks/useEditableInitialValues'
 
 export interface EventUpdateModalProps {
   eventId: string
@@ -27,7 +26,6 @@ const EventUpdateModalInternal: React.FC<
   const { open, event, typeOfAction } = props
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
-  const user = useAppSelector(state => state.user)
 
   const {
     userPersonalCalendars,
@@ -43,45 +41,7 @@ const EventUpdateModalInternal: React.FC<
     tempContext
   } = useEventUpdateModal(props)
 
-  // Determine if this is a single-user event (only the current user as attendee/organizer)
-  const isSingleUserEvent = useMemo(() => {
-    const attendees = initialValues.attendees || []
-    const currentUserEmail = user.userData?.email?.toLowerCase()
-    if (!currentUserEmail) return false
-    // Single user if only current user is in attendees (or no attendees at all)
-    if (attendees.length === 0) return true
-    if (attendees.length > 1) return false
-    // Check if the single attendee is the current user
-    const attendeeEmail = attendees[0]?.cal_address
-      ?.toLowerCase()
-      .replace('mailto:', '')
-    return attendeeEmail === currentUserEmail
-  }, [initialValues.attendees, user.userData?.email])
-
-  // Filter initial values: for single-user events show global + personal alarms,
-  // for multi-user events show only global alarms
-  const editableInitialValues = useMemo(() => {
-    if (!initialValues.alarms) return initialValues
-    if (isSingleUserEvent) {
-      const currentUserAttendee = user.userData?.email
-        ? new userAttendee({
-            cal_address: `mailto:${user.userData.email}`,
-            cn: user.userData.name || user.userData.email
-          })
-        : undefined
-      return {
-        ...initialValues,
-        alarms: Valarms.fromList(
-          initialValues.alarms.getEditableAlarms(currentUserAttendee)
-        )
-      }
-    }
-    // Multi-user event: show only global alarms
-    return {
-      ...initialValues,
-      alarms: Valarms.fromList(initialValues.alarms.getGlobalAlarms())
-    }
-  }, [initialValues, user.userData, isSingleUserEvent])
+  const editableInitialValues = useEditableInitialValues(initialValues)
 
   const actions = (
     <EventActions

--- a/common/src/features/Events/EventUpdateModal.tsx
+++ b/common/src/features/Events/EventUpdateModal.tsx
@@ -4,6 +4,7 @@ import { ResponsiveDialog } from '@common/components/Dialog'
 import EventFormFields from '@common/components/Event/EventFormFields'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { Valarms } from '@common/types/Valarms'
+import { userAttendee } from '@common/features/User/models/attendee'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 import React, { useMemo } from 'react'
 import { useI18n } from 'twake-i18n'
@@ -26,6 +27,7 @@ const EventUpdateModalInternal: React.FC<
   const { open, event, typeOfAction } = props
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const user = useAppSelector(state => state.user)
 
   const {
     userPersonalCalendars,
@@ -41,14 +43,45 @@ const EventUpdateModalInternal: React.FC<
     tempContext
   } = useEventUpdateModal(props)
 
-  // Filter initial values to only include global alarms (alarms with multiple attendees or no attendees)
-  const globalInitialValues = useMemo(() => {
+  // Determine if this is a single-user event (only the current user as attendee/organizer)
+  const isSingleUserEvent = useMemo(() => {
+    const attendees = initialValues.attendees || []
+    const currentUserEmail = user.userData?.email?.toLowerCase()
+    if (!currentUserEmail) return false
+    // Single user if only current user is in attendees (or no attendees at all)
+    if (attendees.length === 0) return true
+    if (attendees.length > 1) return false
+    // Check if the single attendee is the current user
+    const attendeeEmail = attendees[0]?.cal_address
+      ?.toLowerCase()
+      .replace('mailto:', '')
+    return attendeeEmail === currentUserEmail
+  }, [initialValues.attendees, user.userData?.email])
+
+  // Filter initial values: for single-user events show global + personal alarms,
+  // for multi-user events show only global alarms
+  const editableInitialValues = useMemo(() => {
     if (!initialValues.alarms) return initialValues
+    if (isSingleUserEvent) {
+      const currentUserAttendee = user.userData?.email
+        ? new userAttendee({
+            cal_address: `mailto:${user.userData.email}`,
+            cn: user.userData.name || user.userData.email
+          })
+        : undefined
+      return {
+        ...initialValues,
+        alarms: Valarms.fromList(
+          initialValues.alarms.getEditableAlarms(currentUserAttendee)
+        )
+      }
+    }
+    // Multi-user event: show only global alarms
     return {
       ...initialValues,
       alarms: Valarms.fromList(initialValues.alarms.getGlobalAlarms())
     }
-  }, [initialValues])
+  }, [initialValues, user.userData, isSingleUserEvent])
 
   const actions = (
     <EventActions
@@ -73,7 +106,7 @@ const EventUpdateModalInternal: React.FC<
       <EventFormFields
         key={effectiveEvent?.uid || 'no-event'}
         ref={formRef}
-        initialValues={globalInitialValues}
+        initialValues={editableInitialValues}
         showMore={showMore}
         isOpen={open}
         isSpecific={false}

--- a/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -88,31 +88,24 @@ export function prepareUpdatedEvent({
     color: targetCalendar?.color,
     alarms: (() => {
       const alarmAttendees = getAlarmAttendees(values, targetCalendar)
-      const isMultiUser = (alarmAttendees?.length ?? 0) > 1
 
-      // If event has multiple attendees, convert personal alarms (single attendee)
-      // to global alarms by stripping their personal attendee so fromFormValues
-      // assigns all attendees. Keep global alarms as-is.
-      const alarmsForFormValues = isMultiUser
-        ? Valarms.fromList(
-            values.alarms.getAlarms().map(alarm =>
-              alarm.attendees && alarm.attendees.length === 1
-                ? new VAlarm({
-                    trigger: alarm.trigger,
-                    action: alarm.action,
-                    summary: alarm.summary,
-                    description: alarm.description
-                    // attendees omitted → will use defaults (all attendees)
-                  })
-                : alarm
-            )
-          )
-        : values.alarms
-
-      return Valarms.fromFormValues(alarmsForFormValues, {
-        attendees: alarmAttendees,
-        summary: values.title
-      })
+      // If alarms already have attendees (from handleSave merge), preserve them.
+      // Only use fromFormValues for alarms without attendees (new alarms from UI).
+      return Valarms.fromList(
+        values.alarms.getAlarms().map(alarm => {
+          if (alarm.attendees && alarm.attendees.length > 0) {
+            return alarm // Preserve existing attendees from merge
+          }
+          // New alarm without attendees - add defaults
+          return new VAlarm({
+            trigger: alarm.trigger,
+            action: alarm.action,
+            attendees: alarmAttendees,
+            summary: values.title,
+            description: alarm.description
+          })
+        })
+      )
     })(),
     x_openpass_videoconference: values.meetingLink || undefined,
     attach: values.attachments?.length ? values.attachments : undefined

--- a/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -4,6 +4,7 @@ import { resolveEventISORange } from '@common/components/Event/utils/dateRangeUt
 import { updateAttendeesAfterTimeChange } from '@common/features/Events/updateEventHelpers/updateAttendeesAfterTimeChange'
 import { userAttendee } from '@common/features/User/models/attendee'
 import { Calendar } from '@common/types/CalendarTypes'
+import { VAlarm } from '@common/types/VAlarm'
 import { Valarms } from '@common/types/Valarms'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { RepetitionObject } from '@common/types/Repetition'
@@ -85,10 +86,34 @@ export function prepareUpdatedEvent({
     transp: values.busy,
     sequence: nextSequence,
     color: targetCalendar?.color,
-    alarms: Valarms.fromFormValues(values.alarms, {
-      attendees: getAlarmAttendees(values, targetCalendar),
-      summary: values.title
-    }),
+    alarms: (() => {
+      const alarmAttendees = getAlarmAttendees(values, targetCalendar)
+      const isMultiUser = (alarmAttendees?.length ?? 0) > 1
+
+      // If event has multiple attendees, convert personal alarms (single attendee)
+      // to global alarms by stripping their personal attendee so fromFormValues
+      // assigns all attendees. Keep global alarms as-is.
+      const alarmsForFormValues = isMultiUser
+        ? Valarms.fromList(
+            values.alarms.getAlarms().map(alarm =>
+              alarm.attendees && alarm.attendees.length === 1
+                ? new VAlarm({
+                    trigger: alarm.trigger,
+                    action: alarm.action,
+                    summary: alarm.summary,
+                    description: alarm.description
+                    // attendees omitted → will use defaults (all attendees)
+                  })
+                : alarm
+            )
+          )
+        : values.alarms
+
+      return Valarms.fromFormValues(alarmsForFormValues, {
+        attendees: alarmAttendees,
+        summary: values.title
+      })
+    })(),
     x_openpass_videoconference: values.meetingLink || undefined,
     attach: values.attachments?.length ? values.attachments : undefined
   }

--- a/common/src/features/Events/hooks/useEditableInitialValues.ts
+++ b/common/src/features/Events/hooks/useEditableInitialValues.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+import { useAppSelector } from '@common/app/hooks'
+import { userAttendee } from '@common/features/User/models/attendee'
+import { Valarms } from '@common/types/Valarms'
+import { EventFormValues } from '@common/components/Event/EventFormFields.types'
+import { userData } from '@common/features/User/userDataTypes'
+
+function getSingleAttendeeEmail(
+  attendees: EventFormValues['attendees']
+): string | undefined {
+  if (attendees.length !== 1) return undefined
+  return attendees[0]?.cal_address?.toLowerCase().replace('mailto:', '')
+}
+
+function isSingleUserEvent(
+  attendees: EventFormValues['attendees'],
+  currentUserEmail: string | undefined
+): boolean {
+  if (!currentUserEmail) return false
+  if (attendees.length === 0) return true
+  if (attendees.length > 1) return false
+  return getSingleAttendeeEmail(attendees) === currentUserEmail
+}
+
+function createCurrentUserAttendee(
+  userData: userData | undefined
+): userAttendee | undefined {
+  if (!userData?.email) return undefined
+  return new userAttendee({
+    cal_address: `mailto:${userData.email}`,
+    cn: userData.name || userData.email
+  })
+}
+
+function filterAlarmsForEdit(
+  alarms: Valarms,
+  isSingleUser: boolean,
+  currentUserAttendee: userAttendee | undefined
+): Valarms {
+  if (isSingleUser) {
+    return Valarms.fromList(alarms.getEditableAlarms(currentUserAttendee))
+  }
+  return Valarms.fromList(alarms.getGlobalAlarms())
+}
+
+interface UseEditableInitialValuesParams {
+  initialValues: Partial<EventFormValues>
+  userData: userData | undefined
+}
+
+function useEditableAlarms({
+  initialValues,
+  userData
+}: UseEditableInitialValuesParams) {
+  return useMemo(() => {
+    if (!initialValues.alarms) return initialValues
+
+    const currentUserEmail = userData?.email?.toLowerCase()
+    const singleUser = isSingleUserEvent(
+      initialValues.attendees || [],
+      currentUserEmail
+    )
+    const currentUserAttendee = createCurrentUserAttendee(userData)
+
+    return {
+      ...initialValues,
+      alarms: filterAlarmsForEdit(
+        initialValues.alarms,
+        singleUser,
+        currentUserAttendee
+      )
+    }
+  }, [initialValues, userData])
+}
+
+export function useEditableInitialValues(
+  initialValues: Partial<EventFormValues>
+) {
+  const userData = useAppSelector(state => state.user.userData)
+  return useEditableAlarms({ initialValues, userData })
+}

--- a/common/src/features/Events/useEventUpdateModal.tsx
+++ b/common/src/features/Events/useEventUpdateModal.tsx
@@ -95,17 +95,20 @@ export function useEventUpdateModal(
     const originalEvent = effectiveEvent || event
     const originalAlarms = originalEvent?.alarms
 
-    // Strip current user's personal alarms from form values before merging,
-    // since those are being edited. We only want to preserve OTHER users'
-    // personal alarms from the original event.
-    const globalAlarmsFromForm = Valarms.fromList(
-      values.alarms.getGlobalAlarms()
-    )
+    const isMultiUser = (values.attendees?.length ?? 0) > 1
 
-    // Merge global alarms from form with personal alarms from original event
-    const mergedAlarms = originalAlarms
-      ? globalAlarmsFromForm.withPersonalAlarmsFrom(originalAlarms)
-      : globalAlarmsFromForm
+    let mergedAlarms: Valarms
+    if (isMultiUser && originalAlarms) {
+      // Multi-user event: edit global alarms only, preserve personal alarms
+      // from other users that aren't shown in the form
+      const globalAlarmsFromForm = Valarms.fromList(
+        values.alarms.getGlobalAlarms()
+      )
+      mergedAlarms = globalAlarmsFromForm.withPersonalAlarmsFrom(originalAlarms)
+    } else {
+      // Single-user event: use form alarms directly
+      mergedAlarms = values.alarms
+    }
 
     const valuesWithMergedAlarms = {
       ...values,

--- a/common/src/features/Events/useEventUpdateModal.tsx
+++ b/common/src/features/Events/useEventUpdateModal.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Calendar } from '@common/types/CalendarTypes'
 import { useUserPersonalCalendars } from '@common/features/Calendars/hooks/useUserPersonalCalendars'
 import { CalendarEvent } from '@common/types/EventsTypes'
+import { Valarms } from '@common/types/Valarms'
 import { EventUpdateModalProps } from './EventUpdateModal'
 import { useMasterEvent } from './hooks/useMasterEvent'
 import { useSubmitUpdateEvent } from './hooks/useSubmitUpdateEvent'
@@ -94,10 +95,17 @@ export function useEventUpdateModal(
     const originalEvent = effectiveEvent || event
     const originalAlarms = originalEvent?.alarms
 
+    // Strip current user's personal alarms from form values before merging,
+    // since those are being edited. We only want to preserve OTHER users'
+    // personal alarms from the original event.
+    const globalAlarmsFromForm = Valarms.fromList(
+      values.alarms.getGlobalAlarms()
+    )
+
     // Merge global alarms from form with personal alarms from original event
     const mergedAlarms = originalAlarms
-      ? values.alarms.withPersonalAlarmsFrom(originalAlarms)
-      : values.alarms
+      ? globalAlarmsFromForm.withPersonalAlarmsFrom(originalAlarms)
+      : globalAlarmsFromForm
 
     const valuesWithMergedAlarms = {
       ...values,

--- a/common/src/types/Valarms.ts
+++ b/common/src/types/Valarms.ts
@@ -97,6 +97,25 @@ export class Valarms {
   }
 
   /**
+   * Get alarms that should be shown in the edit form for a specific attendee.
+   * Includes global alarms (no attendees or multiple attendees) AND
+   * the attendee's personal alarms (single attendee matching the user).
+   */
+  getEditableAlarms(attendee: userAttendee | undefined): VAlarm[] {
+    if (!attendee) return this.getGlobalAlarms()
+    const attendeeEmail = attendee.cal_address.toLowerCase()
+
+    const globalAlarms = this.getGlobalAlarms()
+    const personalAlarms = this._alarms.filter(
+      alarm =>
+        alarm.attendees?.length === 1 &&
+        alarm.attendees[0].cal_address.toLowerCase() === attendeeEmail
+    )
+
+    return [...globalAlarms, ...personalAlarms]
+  }
+
+  /**
    * Merge personal alarms from newPersonalAlarms with this Valarms.
    * Replaces existing personal alarms for the given attendee with new ones.
    * Keeps all other alarms (global alarms and other attendees' personal alarms).

--- a/common/src/types/Valarms.ts
+++ b/common/src/types/Valarms.ts
@@ -74,12 +74,12 @@ export class Valarms {
 
   getAllAlarmsForAttendee(attendee: userAttendee | undefined): VAlarm[] {
     if (!attendee) return []
-    const attendeeEmail = attendee.cal_address.toLowerCase()
+    const attendeeEmail = this.normalizeEmail(attendee.cal_address)
     return this._alarms.filter(
       alarm =>
         alarm?.attendees?.length &&
         alarm.attendees.some(
-          attendee => attendee.cal_address.toLowerCase() === attendeeEmail
+          a => this.normalizeEmail(a.cal_address) === attendeeEmail
         )
     )
   }
@@ -103,13 +103,13 @@ export class Valarms {
    */
   getEditableAlarms(attendee: userAttendee | undefined): VAlarm[] {
     if (!attendee) return this.getGlobalAlarms()
-    const attendeeEmail = attendee.cal_address.toLowerCase()
+    const attendeeEmail = this.normalizeEmail(attendee.cal_address)
 
     const globalAlarms = this.getGlobalAlarms()
     const personalAlarms = this._alarms.filter(
       alarm =>
         alarm.attendees?.length === 1 &&
-        alarm.attendees[0].cal_address.toLowerCase() === attendeeEmail
+        this.normalizeEmail(alarm.attendees[0].cal_address) === attendeeEmail
     )
 
     return [...globalAlarms, ...personalAlarms]
@@ -126,14 +126,14 @@ export class Valarms {
   ): Valarms {
     if (!attendee) return newPersonalAlarms
 
-    const attendeeEmail = attendee.cal_address.toLowerCase()
+    const attendeeEmail = this.normalizeEmail(attendee.cal_address)
 
     // Keep all alarms that are NOT for this attendee (global + other personal)
     const otherAlarms = this._alarms.filter(alarm => {
       // Keep global alarms (no attendees or multiple attendees)
       if (!alarm.attendees || alarm.attendees.length !== 1) return true
       // Keep other attendees' personal alarms
-      const alarmEmail = alarm.attendees[0].cal_address.toLowerCase()
+      const alarmEmail = this.normalizeEmail(alarm.attendees[0].cal_address)
       return alarmEmail !== attendeeEmail
     })
 
@@ -186,63 +186,76 @@ export class Valarms {
   ): Valarms {
     if (!attendee) return formAlarms
 
-    const attendeeEmail = attendee.cal_address
-      .toLowerCase()
-      .replace('mailto:', '')
-    const result: VAlarm[] = []
-    const processedTriggers = new Set<string>()
+    const attendeeEmail = this.normalizeEmail(attendee.cal_address)
+    const selectedTriggers = new Set(formAlarms.getAlarms().map(a => a.trigger))
 
-    // Helper to check if an alarm attendee matches the current user
-    const hasAttendee = (
-      alarmAttendees: userAttendee[] | undefined
-    ): boolean => {
-      if (!alarmAttendees) return false
-      return alarmAttendees.some(
-        a =>
-          a.cal_address.toLowerCase().replace('mailto:', '') === attendeeEmail
-      )
-    }
+    const selectedAlarms = this.processSelectedAlarms(formAlarms)
+    const deselectedAlarms = this.processDeselectedAlarms(
+      selectedTriggers,
+      attendeeEmail
+    )
 
-    // Process selected alarms: use original alarm data (preserves attendees)
-    for (const formAlarm of formAlarms.getAlarms()) {
+    return Valarms.fromList([...selectedAlarms, ...deselectedAlarms])
+  }
+
+  private normalizeEmail(email: string): string {
+    return email.toLowerCase().replace('mailto:', '')
+  }
+
+  private alarmHasAttendee(
+    alarmAttendees: userAttendee[] | undefined,
+    targetEmail: string
+  ): boolean {
+    if (!alarmAttendees) return false
+    return alarmAttendees.some(
+      a => this.normalizeEmail(a.cal_address) === targetEmail
+    )
+  }
+
+  private processSelectedAlarms(formAlarms: Valarms): VAlarm[] {
+    return formAlarms.getAlarms().map(formAlarm => {
       const originalAlarm = this._alarms.find(
         a => a.trigger === formAlarm.trigger
       )
-      if (originalAlarm) {
-        result.push(originalAlarm)
-      } else {
-        // New alarm added in form - use form data
-        result.push(formAlarm)
-      }
-      processedTriggers.add(formAlarm.trigger)
-    }
+      return originalAlarm ?? formAlarm
+    })
+  }
 
-    // Process deselected alarms from original
+  private processDeselectedAlarms(
+    selectedTriggers: Set<string>,
+    attendeeEmail: string
+  ): VAlarm[] {
+    const result: VAlarm[] = []
+
     for (const alarm of this._alarms) {
-      if (processedTriggers.has(alarm.trigger)) continue
+      if (selectedTriggers.has(alarm.trigger)) continue
 
-      const isPersonalForAttendee =
-        alarm.attendees?.length === 1 && hasAttendee(alarm.attendees)
-      if (isPersonalForAttendee) continue
-
-      const isGlobalWithAttendee =
-        alarm.attendees &&
-        alarm.attendees.length > 1 &&
-        hasAttendee(alarm.attendees)
-
-      if (isGlobalWithAttendee) {
-        const stripped = this.withUserRemovedFromGlobalAlarm(
-          alarm,
-          attendeeEmail
-        )
-        if (stripped) result.push(stripped)
-        continue
+      const processedAlarm = this.processDeselectedAlarm(alarm, attendeeEmail)
+      if (processedAlarm) {
+        result.push(processedAlarm)
       }
-
-      result.push(alarm)
     }
 
-    return Valarms.fromList(result)
+    return result
+  }
+
+  private processDeselectedAlarm(
+    alarm: VAlarm,
+    attendeeEmail: string
+  ): VAlarm | null {
+    const hasAttendee = this.alarmHasAttendee(alarm.attendees, attendeeEmail)
+
+    const isPersonalForAttendee = alarm.attendees?.length === 1 && hasAttendee
+    if (isPersonalForAttendee) return null
+
+    const isGlobalWithAttendee =
+      alarm.attendees && alarm.attendees.length > 1 && hasAttendee
+
+    if (isGlobalWithAttendee) {
+      return this.withUserRemovedFromGlobalAlarm(alarm, attendeeEmail)
+    }
+
+    return alarm
   }
 
   firstAlarmTrigger(): string {

--- a/common/src/types/Valarms.ts
+++ b/common/src/types/Valarms.ts
@@ -161,7 +161,7 @@ export class Valarms {
     attendeeEmail: string
   ): VAlarm | null {
     const remaining = (alarm.attendees ?? []).filter(
-      a => a.cal_address.toLowerCase() !== attendeeEmail
+      a => a.cal_address.toLowerCase().replace('mailto:', '') !== attendeeEmail
     )
     if (!remaining.length) return null
     return new VAlarm({
@@ -175,8 +175,8 @@ export class Valarms {
 
   /**
    * Merge form alarms back with original event alarms for a personal settings update.
-   * - Keeps form alarms (user's current selections)
-   * - For global alarms the user deselected: removes user from attendees
+   * - For selected alarms: uses the original alarm data (preserving attendees)
+   * - For deselected global alarms: removes user from attendees
    * - If a global alarm has no attendees left after removal, drops it
    * - Preserves other attendees' personal alarms and global alarms the user was never part of
    */
@@ -186,23 +186,49 @@ export class Valarms {
   ): Valarms {
     if (!attendee) return formAlarms
 
-    const attendeeEmail = attendee.cal_address.toLowerCase()
-    const selectedTriggers = new Set(formAlarms.getAlarms().map(a => a.trigger))
-    const result: VAlarm[] = [...formAlarms.getAlarms()]
+    const attendeeEmail = attendee.cal_address
+      .toLowerCase()
+      .replace('mailto:', '')
+    const result: VAlarm[] = []
+    const processedTriggers = new Set<string>()
 
+    // Helper to check if an alarm attendee matches the current user
+    const hasAttendee = (
+      alarmAttendees: userAttendee[] | undefined
+    ): boolean => {
+      if (!alarmAttendees) return false
+      return alarmAttendees.some(
+        a =>
+          a.cal_address.toLowerCase().replace('mailto:', '') === attendeeEmail
+      )
+    }
+
+    // Process selected alarms: use original alarm data (preserves attendees)
+    for (const formAlarm of formAlarms.getAlarms()) {
+      const originalAlarm = this._alarms.find(
+        a => a.trigger === formAlarm.trigger
+      )
+      if (originalAlarm) {
+        result.push(originalAlarm)
+      } else {
+        // New alarm added in form - use form data
+        result.push(formAlarm)
+      }
+      processedTriggers.add(formAlarm.trigger)
+    }
+
+    // Process deselected alarms from original
     for (const alarm of this._alarms) {
-      // Already in result (same trigger) — skip
-      if (selectedTriggers.has(alarm.trigger)) continue
+      if (processedTriggers.has(alarm.trigger)) continue
 
       const isPersonalForAttendee =
-        alarm.attendees?.length === 1 &&
-        alarm.attendees[0].cal_address.toLowerCase() === attendeeEmail
+        alarm.attendees?.length === 1 && hasAttendee(alarm.attendees)
       if (isPersonalForAttendee) continue
 
       const isGlobalWithAttendee =
         alarm.attendees &&
         alarm.attendees.length > 1 &&
-        alarm.attendees.some(a => a.cal_address.toLowerCase() === attendeeEmail)
+        hasAttendee(alarm.attendees)
 
       if (isGlobalWithAttendee) {
         const stripped = this.withUserRemovedFromGlobalAlarm(


### PR DESCRIPTION
resolves #1115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event editing now uses smarter initial alarm values, showing attendee-specific (personal) alarms for single-attendee scenarios.
* **Bug Fixes**
  * Updating events preserves the correct personal alarms when attendees change.
  * Improved alarm selection/merge behavior with case-insensitive email matching and normalized attendee identifiers.
  * Multi-attendee updates now rebuild global alarms from the form while reattaching personal alarms appropriately.
* **Tests**
  * Added/expanded coverage for editable alarm selection and updated-event alarm attendee handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->