### PR TITLE
[#1118] added calendarColor to booking link

### DIFF
--- a/__test__/components/CalendarSelection.test.tsx
+++ b/__test__/components/CalendarSelection.test.tsx
@@ -140,7 +140,9 @@ describe('CalendarSelection', () => {
         }
       )
 
-      expect(screen.queryByText('calendar.bookingLinks')).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('calendar.bookingLinks')
+      ).not.toBeInTheDocument()
       expect(listBookingLinks).not.toHaveBeenCalled()
     }
   )

--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -4,6 +4,7 @@ import {
   listBookingLinks
 } from '@common/features/booking/BookingLinksSlice'
 import { BookingLink } from '@common/features/booking/types/BookingTypes'
+import { calendarIdFromEventHref } from '@common/features/Calendars/CalendarDAO'
 import {
   addCalendarResource,
   addSharedCalendar,
@@ -220,7 +221,9 @@ const BookingLinkChip: React.FC<{
   const [copySnackbarOpen, setCopySnackbarOpen] = useState(false)
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
   const menuOpen = Boolean(menuAnchorEl)
-
+  const calendars = useAppSelector(state => state.calendars.list)
+  const calendarId = calendarIdFromEventHref(link.calendarUrl)
+  const calendarColor = calendars?.[calendarId]?.color?.light
   const getBookingLinkUrl = (publicId: string): string => {
     const prefix = window.PUBLIC_PAGE_BASE
       ? `${window.PUBLIC_PAGE_BASE}/booking`
@@ -280,7 +283,10 @@ const BookingLinkChip: React.FC<{
               marginRight: '4px'
             }}
           >
-            <EventIcon sx={{ color: defaultColors[4].dark }} fontSize="small" />
+            <EventIcon
+              sx={{ color: calendarColor ?? defaultColors[4].dark }}
+              fontSize="small"
+            />
           </div>
 
           <div


### PR DESCRIPTION
resolves #1118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Booking links now display the correct calendar icon color by matching the link’s calendar URL to the available calendars.
  * Calendar icons now fall back to a default color when no matching calendar is found.
* **Tests**
  * Updated a calendar-selection test assertion formatting (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->