### PR TITLE
[#1126] Gate booking link section behind BOOKING_LINK_ENABLED

### DIFF
--- a/__test__/components/CalendarSelection.test.tsx
+++ b/__test__/components/CalendarSelection.test.tsx
@@ -1,4 +1,5 @@
 import CalendarSelection from '../../apps/private/src/components/Calendar/CalendarSelection'
+import { listBookingLinks } from '@common/features/booking/BookingDao'
 import * as calendarThunks from '@common/features/Calendars/CalendarSlice'
 import '@testing-library/jest-dom'
 import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
@@ -18,11 +19,14 @@ jest.mock('@common/features/booking/BookingDao', () => ({
 
 describe('CalendarSelection', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     window.HIDE_RESOURCES = undefined
+    window.BOOKING_LINK_ENABLED = true
     localStorage.clear()
   })
   afterEach(() => {
     window.HIDE_RESOURCES = undefined
+    window.BOOKING_LINK_ENABLED = undefined
   })
   const baseUser = {
     userData: {
@@ -103,6 +107,43 @@ describe('CalendarSelection', () => {
 
     expect(screen.queryByText('calendar.resources')).not.toBeInTheDocument()
   })
+
+  it('renders booking links when BOOKING_LINK_ENABLED is true', () => {
+    renderWithProviders(
+      <CalendarSelection
+        selectedCalendars={[]}
+        setSelectedCalendars={jest.fn()}
+      />,
+      {
+        user: baseUser,
+        calendars: { list: calendarsMock, pending: false }
+      }
+    )
+
+    expect(screen.getByText('calendar.bookingLinks')).toBeInTheDocument()
+    expect(listBookingLinks).toHaveBeenCalled()
+  })
+
+  it.each([[undefined], [false]])(
+    'does not render booking links when BOOKING_LINK_ENABLED is %s',
+    value => {
+      window.BOOKING_LINK_ENABLED = value
+
+      renderWithProviders(
+        <CalendarSelection
+          selectedCalendars={[]}
+          setSelectedCalendars={jest.fn()}
+        />,
+        {
+          user: baseUser,
+          calendars: { list: calendarsMock, pending: false }
+        }
+      )
+
+      expect(screen.queryByText('calendar.bookingLinks')).not.toBeInTheDocument()
+      expect(listBookingLinks).not.toHaveBeenCalled()
+    }
+  )
 
   it('toggles a calendar selection on click', () => {
     const setSelectedCalendars = jest.fn()

--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -432,14 +432,17 @@ const CalendarSelection: React.FC<{
 
   // Booking links from Redux
   const bookingLinks = useAppSelector(state => state.bookingLinks.list)
+  const bookingLinkEnabled = window.BOOKING_LINK_ENABLED === true
 
   const [isCreateAppointmentModalOpen, setIsCreateAppointmentModalOpen] =
     useState(false)
 
   // Fetch booking links on mount
   useEffect(() => {
-    dispatch(listBookingLinks())
-  }, [dispatch])
+    if (bookingLinkEnabled) {
+      dispatch(listBookingLinks())
+    }
+  }, [dispatch, bookingLinkEnabled])
 
   const handleDeleteBookingLink = (publicId: string): void => {
     dispatch(deleteBookingLink(publicId))
@@ -448,14 +451,16 @@ const CalendarSelection: React.FC<{
   return (
     <>
       <div>
-        <BookingLinksAccordion
-          title={t('calendar.bookingLinks')}
-          bookingLinks={bookingLinks}
-          defaultExpanded
-          onDelete={handleDeleteBookingLink}
-          onAddClick={() => setIsCreateAppointmentModalOpen(true)}
-          addBtnTooltip={t('tooltip.createAppointment')}
-        />
+        {bookingLinkEnabled && (
+          <BookingLinksAccordion
+            title={t('calendar.bookingLinks')}
+            bookingLinks={bookingLinks}
+            defaultExpanded
+            onDelete={handleDeleteBookingLink}
+            onAddClick={() => setIsCreateAppointmentModalOpen(true)}
+            addBtnTooltip={t('tooltip.createAppointment')}
+          />
+        )}
 
         <CalendarAccordion
           title={t('calendar.personal')}

--- a/common/src/window.d.ts
+++ b/common/src/window.d.ts
@@ -47,6 +47,8 @@ declare global {
 
     ENABLE_CREATE_BOOKING: boolean
 
+    BOOKING_LINK_ENABLED: boolean | undefined
+
     ASK_FOR_TZ_UPDATE: boolean
 
     TOOLTIP_DELAY_MS: number

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -39,3 +39,5 @@ var DISABLE_PUBLIC_VISIBILITY = false
 var ASK_FOR_TZ_UPDATE = true
 var TOOLTIP_DELAY_MS = 2000
 var HIDE_LANGUAGE_SELECTOR = false
+// Exposes the booking link section in the left bar. Defaults to false.
+var BOOKING_LINK_ENABLED = false


### PR DESCRIPTION
Closes #1126

Exposes the booking link section in the left bar if and only if `.env.js` sets `var BOOKING_LINK_ENABLED = true;`. Defaults to `false`, so booking link CRUD stays hidden on prod while remaining available on preprod.

## Changes

- `apps/private/src/components/Calendar/CalendarSelection.tsx`: the `BookingLinksAccordion` is only rendered when the flag is on, and the `listBookingLinks()` fetch is skipped when it is off (no wasted API call on prod).
- `common/src/window.d.ts`: declares `BOOKING_LINK_ENABLED: boolean | undefined`.
- `public/.env.example.js`: documents the flag, defaulting to `false`.

The gate follows the existing `HIDE_RESOURCES` convention. It is strictly opt-in: an absent or non-`true` value hides the section.

`CreateAppointmentModal` is left mounted unconditionally — it is unreachable once the accordion (its only trigger) is hidden, and it has no mount-time side effects, so gating it too would be dead code.

## Tests

`__test__/components/CalendarSelection.test.tsx` gains coverage for the flag being on, absent, and `false` — asserting both that the section is hidden and that `listBookingLinks` is not called.

The pre-existing cases now set the flag to `true` in `beforeEach`, because several of them locate buttons by index (`getAllByRole('button')[3]`, `getAllByTestId('AddIcon')[2]`) and the booking accordion contributes one add button ahead of them. Those cases are about calendars, not about the flag, so keeping the section visible preserves their intent.

Note: I was unable to execute the suite locally (this checkout has no `node_modules` and only Node 12 is available), so the tests are verified by reading, not by running. Worth a CI confirmation.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a booking links section in the calendar sidebar, controlled by a new app setting.

* **Bug Fixes**
  * Booking links now only load and display when the feature is enabled, preventing the section from appearing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->