### PR TITLE
[#1130] reformat CalendarSelection.test.tsx with prettier

### DIFF
--- a/__test__/components/CalendarSelection.test.tsx
+++ b/__test__/components/CalendarSelection.test.tsx
@@ -140,7 +140,9 @@ describe('CalendarSelection', () => {
         }
       )
 
-      expect(screen.queryByText('calendar.bookingLinks')).not.toBeInTheDocument()
+      expect(
+        screen.queryByText('calendar.bookingLinks')
+      ).not.toBeInTheDocument()
       expect(listBookingLinks).not.toHaveBeenCalled()
     }
   )


### PR DESCRIPTION
Closes #1130

`__test__/components/CalendarSelection.test.tsx` did not satisfy `prettier --check`: the `calendar.bookingLinks` assertion introduced in #1127 was a single line of 81 characters, one over the `printWidth: 80` set in `.prettierrc`.

Reformatted the file with the repo`s pinned Prettier (3.8.1) using the project config. The only change is that assertion wrapped across three lines; no test logic was touched. `prettier --check` now passes on the file.

---
*Generated automatically*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted an existing calendar selection test assertion without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->