### PR TITLE
#1143 send working days in ISO-8601 format for availability

### DIFF
--- a/__test__/features/Settings/WorkingDays.test.tsx
+++ b/__test__/features/Settings/WorkingDays.test.tsx
@@ -296,11 +296,13 @@ describe('Working Days and Business Hours Settings', () => {
         )
       })
 
-      const patchedDays = (api.patch as jest.Mock).mock.calls[0][1].json
-        .find((m: { name: string }) => m.name === 'core')
-        .configurations.find(
-          (c: { name: string }) => c.name === 'businessHours'
-        ).value[0].daysOfWeek
+      const coreModule = (api.patch as jest.Mock).mock.calls[0][1].json.find(
+        (m: { name: string }) => m.name === 'core'
+      )
+      const businessHoursConfig = coreModule.configurations.find(
+        (c: { name: string }) => c.name === 'businessHours'
+      )
+      const patchedDays = businessHoursConfig.value[0].daysOfWeek
       expect(patchedDays).not.toContain(0)
 
       jest.useRealTimers()

--- a/__test__/features/Settings/WorkingDays.test.tsx
+++ b/__test__/features/Settings/WorkingDays.test.tsx
@@ -259,7 +259,7 @@ describe('Working Days and Business Hours Settings', () => {
       jest.useRealTimers()
     })
 
-    it('sends businessHours as array to API', async () => {
+    it('sends businessHours as array to API with Sunday in ISO-8601 format (7)', async () => {
       jest.useFakeTimers()
 
       renderWithProviders(<SettingsPage />, basePreloadedState)
@@ -283,7 +283,9 @@ describe('Working Days and Business Hours Settings', () => {
                       expect.objectContaining({
                         start: '8:0',
                         end: '19:0',
-                        daysOfWeek: expect.arrayContaining([0])
+                        // FullCalendar Sunday (0) must be sent as ISO-8601 (7),
+                        // otherwise the backend rejects DayOfWeek.of(0).
+                        daysOfWeek: expect.arrayContaining([7])
                       })
                     ])
                   })
@@ -293,6 +295,13 @@ describe('Working Days and Business Hours Settings', () => {
           })
         )
       })
+
+      const patchedDays = (api.patch as jest.Mock).mock.calls[0][1].json
+        .find((m: { name: string }) => m.name === 'core')
+        .configurations.find(
+          (c: { name: string }) => c.name === 'businessHours'
+        ).value[0].daysOfWeek
+      expect(patchedDays).not.toContain(0)
 
       jest.useRealTimers()
     })
@@ -399,6 +408,64 @@ describe('Working Days and Business Hours Settings', () => {
         daysOfWeek: [1, 2, 3, 4, 5]
       })
       expect(state.settings.workingDays).toBe(true)
+    })
+
+    it('converts ISO-8601 Sunday (7) from API back to FullCalendar Sunday (0)', async () => {
+      const store = configureStore({
+        reducer: { user: userReducer, settings: settingsReducer },
+        preloadedState: {
+          user: {
+            userData: {
+              sub: 'test',
+              email: 'test@test.com',
+              family_name: 'Doe',
+              name: 'John',
+              sid: 'mockSid',
+              openpaasId: '667037022b752d0026472254'
+            },
+            organiserData: null,
+            tokens: null,
+            coreConfig: { language: 'en', datetime: { timeZone: 'UTC' } },
+            alarmEmailsEnabled: null,
+            loading: false,
+            error: null
+          },
+          settings: {
+            language: 'en',
+            timeZone: 'UTC',
+            isBrowserDefaultTimeZone: false,
+            view: 'calendar',
+            businessHours: null,
+            workingDays: null
+          }
+        }
+      })
+
+      const mockResponse = {
+        id: '667037022b752d0026472254',
+        firstname: 'John',
+        lastname: 'Doe',
+        preferredEmail: 'test@test.com',
+        configurations: {
+          modules: [
+            {
+              name: 'core',
+              configurations: [
+                {
+                  name: 'businessHours',
+                  value: [{ start: '8:0', end: '19:0', daysOfWeek: [1, 7] }]
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      await store.dispatch(
+        getOpenPaasUserData.fulfilled(mockResponse, '', undefined)
+      )
+
+      expect(store.getState().settings.businessHours?.daysOfWeek).toEqual([1, 0])
     })
 
     it('sets businessHours to null when not present in API response', async () => {

--- a/__test__/features/Settings/WorkingDays.test.tsx
+++ b/__test__/features/Settings/WorkingDays.test.tsx
@@ -467,7 +467,9 @@ describe('Working Days and Business Hours Settings', () => {
         getOpenPaasUserData.fulfilled(mockResponse, '', undefined)
       )
 
-      expect(store.getState().settings.businessHours?.daysOfWeek).toEqual([1, 0])
+      expect(store.getState().settings.businessHours?.daysOfWeek).toEqual([
+        1, 0
+      ])
     })
 
     it('sets businessHours to null when not present in API response', async () => {

--- a/__test__/features/user/userAPI.test.tsx
+++ b/__test__/features/user/userAPI.test.tsx
@@ -64,6 +64,45 @@ describe('makeConfigurationBody', () => {
 
     expect(result).toEqual({ modules: [] })
   })
+
+  it('should send businessHours days in ISO-8601 format (Sunday 0 -> 7)', () => {
+    const result = makeConfigurationBody({
+      businessHours: {
+        start: '9:0',
+        end: '18:0',
+        daysOfWeek: [1, 2, 3, 4, 5, 6, 0]
+      }
+    })
+
+    expect(result).toEqual({
+      modules: [
+        {
+          name: 'core',
+          configurations: [
+            {
+              name: 'businessHours',
+              value: [
+                { start: '9:0', end: '18:0', daysOfWeek: [1, 2, 3, 4, 5, 6, 7] }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('should forward businessHours null to clear the config', () => {
+    const result = makeConfigurationBody({ businessHours: null })
+
+    expect(result).toEqual({
+      modules: [
+        {
+          name: 'core',
+          configurations: [{ name: 'businessHours', value: null }]
+        }
+      ]
+    })
+  })
 })
 
 describe('patchConfigurations', () => {

--- a/common/src/features/Settings/SettingsSlice.ts
+++ b/common/src/features/Settings/SettingsSlice.ts
@@ -6,6 +6,7 @@ import {
 import { getOpenPaasUserData } from '@common/features/User/UserSlice'
 import { browserDefaultTimeZone } from '@common/utils/timezone'
 import { PayloadAction } from '@reduxjs/toolkit'
+import { businessHoursFromIso } from './businessHoursDays'
 
 export interface BusinessHour {
   start: string
@@ -123,7 +124,7 @@ const SettingsSlice = createAppSlice({
       state.businessHours =
         Array.isArray(businessHoursConfig?.value) &&
         businessHoursConfig?.value?.[0]
-          ? businessHoursConfig.value[0]
+          ? businessHoursFromIso(businessHoursConfig.value[0])
           : null
 
       // From esnCalendarModule (alongside hideDeclinedEvents)

--- a/common/src/features/Settings/businessHoursDays.ts
+++ b/common/src/features/Settings/businessHoursDays.ts
@@ -1,0 +1,36 @@
+import { BusinessHour } from './SettingsSlice'
+
+/**
+ * Working days are handled internally in FullCalendar convention
+ * (0=Sunday, 1=Monday ... 6=Saturday), while the backend expects the
+ * ISO-8601 day-of-week numbering (1=Monday ... 7=Sunday). Only Sunday
+ * differs between the two conventions, the other days share the same value.
+ *
+ * These helpers convert `businessHours.daysOfWeek` at the API boundary so that
+ * Sunday can be persisted (and read back) correctly. Sending Sunday as `0`
+ * makes the backend reject the value (`DayOfWeek.of(0)` is invalid), which
+ * previously prevented creating a booking link when Sunday was a working day.
+ */
+
+const fcToIso = (day: number): number => (day === 0 ? 7 : day)
+const isoToFc = (day: number): number => (day === 7 ? 0 : day)
+
+export function businessHoursToIso(
+  businessHours: BusinessHour | null
+): BusinessHour | null {
+  if (!businessHours) return businessHours
+  return {
+    ...businessHours,
+    daysOfWeek: businessHours.daysOfWeek.map(fcToIso)
+  }
+}
+
+export function businessHoursFromIso(
+  businessHours: BusinessHour | null
+): BusinessHour | null {
+  if (!businessHours) return businessHours
+  return {
+    ...businessHours,
+    daysOfWeek: businessHours.daysOfWeek.map(isoToFc)
+  }
+}

--- a/common/src/features/Settings/businessHoursDays.ts
+++ b/common/src/features/Settings/businessHoursDays.ts
@@ -21,7 +21,9 @@ export function businessHoursToIso(
   if (!businessHours) return businessHours
   return {
     ...businessHours,
-    daysOfWeek: businessHours.daysOfWeek.map(fcToIso)
+    daysOfWeek: Array.isArray(businessHours.daysOfWeek)
+      ? businessHours.daysOfWeek.map(fcToIso)
+      : []
   }
 }
 
@@ -31,6 +33,8 @@ export function businessHoursFromIso(
   if (!businessHours) return businessHours
   return {
     ...businessHours,
-    daysOfWeek: businessHours.daysOfWeek.map(isoToFc)
+    daysOfWeek: Array.isArray(businessHours.daysOfWeek)
+      ? businessHours.daysOfWeek.map(isoToFc)
+      : []
   }
 }

--- a/common/src/features/User/transformers/makeConfigurationBody.ts
+++ b/common/src/features/User/transformers/makeConfigurationBody.ts
@@ -1,4 +1,5 @@
 import { BusinessHour } from '@common/features/Settings/SettingsSlice'
+import { businessHoursToIso } from '@common/features/Settings/businessHoursDays'
 import { ConfigurationItem, ModuleConfiguration } from '../userDataTypes'
 
 export interface ConfigurationUpdatesInput {
@@ -36,7 +37,9 @@ function buildCoreConfigs(
   pushIfDefined(
     configs,
     'businessHours',
-    updates.businessHours ? [updates.businessHours] : updates.businessHours
+    updates.businessHours
+      ? [businessHoursToIso(updates.businessHours)]
+      : updates.businessHours
   )
 
   if (updates.timezone !== undefined) {


### PR DESCRIPTION
Closes #1143

## Problem

Working days are handled internally in FullCalendar convention (`0`=Sunday, `1`=Monday … `6`=Saturday) and were persisted **as-is** to the backend `core / businessHours` configuration.

The backend derives default booking availability from those days:

```java
// BookingLinkCreateRoute#toAvailabilityRuleList
dto.daysOfWeek().stream()
   .map(DayOfWeek::of)   // requires ISO-8601: 1=Monday … 7=Sunday
   ...
```

`DayOfWeek.of(int)` only accepts `1..7`, so a Sunday stored as `0` makes `DayOfWeek.of(0)` throw. Monday–Saturday happen to coincide between the two conventions (`1..6`), but **Sunday breaks**: creating a booking link failed whenever Sunday was ticked as a working day.

## Fix

Convert `businessHours.daysOfWeek` at the API boundary only, keeping the internal FullCalendar representation used by the day selector and `useHiddenDays` untouched:

- **write** (`makeConfigurationBody`): FullCalendar → ISO-8601 (`0` → `7`)
- **read** (`SettingsSlice` on `getOpenPaasUserData`): ISO-8601 → FullCalendar (`7` → `0`)

Only Sunday changes value, so both freshly written ISO configs and any legacy config (Sunday stored as `0`, which `isoToFc` leaves as `0` = Sunday) read back correctly.

## Tests

- `makeConfigurationBody` sends `daysOfWeek` in ISO-8601 (Sunday `0` → `7`) and forwards `null` to clear the config.
- `SettingsSlice` converts ISO-8601 Sunday (`7`) from the API back to FullCalendar Sunday (`0`).
- Updated the existing "sends businessHours as array to API" test to assert the Sunday payload is `7`, not `0`.

> Note: local build/test run was not possible in this environment (Node 12, dependencies not installable); relying on CI to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed business-hours day-of-week synchronization so Sunday uses ISO-8601 numbering consistently between the settings UI and backend payloads.
  * Ensured backend-provided business-hours data displays correctly in the settings interface.
  * Improved configuration updates so setting business-hours to `null` clears the value reliably.
* **Tests**
  * Extended tests to verify ISO normalization (FullCalendar vs ISO Sunday) and correct `null` clearing behavior, including payload inspection and response conversion checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->