### PR TITLE
[#1140] data is validated as soon a proper value is typed

### DIFF
--- a/__test__/components/DateTimeField.test.tsx
+++ b/__test__/components/DateTimeField.test.tsx
@@ -31,8 +31,13 @@ describe('DateTimeFields', () => {
     hasEndDateChanged: false,
     showEndDate: false,
     validation: {
+      isValid: true,
       errors: {
-        dateTime: ''
+        date: { start: '', end: '' },
+        time: { start: '', end: '' }
+      },
+      warnings: {
+        date: { start: '' }
       }
     },
     ...mockHandlers
@@ -89,6 +94,24 @@ describe('DateTimeFields', () => {
 
     await waitFor(() =>
       expect(mockHandlers.onEndDateChange).toHaveBeenCalledWith('2025-01-03')
+    )
+  })
+
+  it('updates the end time as soon as a complete value is typed', async () => {
+    await renderField({
+      startDate: '2025-01-01',
+      startTime: '10:00',
+      endDate: '2025-01-01',
+      endTime: '10:00',
+      showMore: true
+    })
+
+    fireEvent.change(screen.getByTestId('end-time-input'), {
+      target: { value: '11:00' }
+    })
+
+    await waitFor(() =>
+      expect(mockHandlers.onEndTimeChange).toHaveBeenCalledWith('11:00')
     )
   })
 

--- a/common/src/components/Event/components/EditableTimeField.tsx
+++ b/common/src/components/Event/components/EditableTimeField.tsx
@@ -256,7 +256,17 @@ function EditableTimePickerField(props: GenericPickerFieldProps) {
   }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value)
+    const value = e.target.value
+    setInputValue(value)
+
+    // Keep partial and shorthand input editable, but immediately propagate a
+    // complete time so form validation is refreshed while the user is typing.
+    if (/^\d{2}:\d{2}$/.test(value.trim())) {
+      const newValue = parseTimeInput(value, pickerValue as Dayjs | null)
+      if (newValue) {
+        pickerActions.setValue(newValue, { changeImportance: 'accept' })
+      }
+    }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
resolves #1140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Time values are now recognized and applied immediately after a complete `HH:mm` value is entered, without requiring the field to lose focus.
  * Improved validation handling for date and time fields, including date-specific errors and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->