### PR TITLE
#1086 display contact card of attendee

### DIFF
--- a/apps/public/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/apps/public/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -105,9 +105,24 @@ export function EventPreviewAttendees({
         mt: 2
       }}
     >
-      {organizer && renderAttendeeBadge(organizer, 'organizer', t, true, true)}
+      {organizer &&
+        renderAttendeeBadge({
+          a: organizer,
+          key: 'organizer',
+          t,
+          isFull: true,
+          isOrganizer: true,
+          isPublic: true
+        })}
       {attendeesWithoutOrganizer.map((a, idx) =>
-        renderAttendeeBadge(a, `participant-${idx}`, t, true, false)
+        renderAttendeeBadge({
+          a,
+          key: `participant-${idx}`,
+          t,
+          isFull: true,
+          isOrganizer: false,
+          isPublic: true
+        })
       )}
     </Box>
   )
@@ -124,7 +139,14 @@ export function EventPreviewAttendees({
       }}
     >
       {resources.map((r, idx) =>
-        renderAttendeeBadge(r, `resource-${idx}`, t, true, false)
+        renderAttendeeBadge({
+          a: r,
+          key: `resource-${idx}`,
+          t,
+          isFull: true,
+          isOrganizer: false,
+          isPublic: true
+        })
       )}
     </Box>
   )

--- a/apps/public/src/components/EventPreview/EventPreviewDetails.tsx
+++ b/apps/public/src/components/EventPreview/EventPreviewDetails.tsx
@@ -58,7 +58,14 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
 
       {isResourceEventPreview &&
         organizer &&
-        renderAttendeeBadge(organizer, 'org', t, true, true)}
+        renderAttendeeBadge({
+          a: organizer,
+          key: 'org',
+          t,
+          isFull: true,
+          isOrganizer: true,
+          isPublic: true
+        })}
 
       {shouldShowAttendeesSection && (
         <EventPreviewAttendees

--- a/common/package.json
+++ b/common/package.json
@@ -13,6 +13,7 @@
     "@fullcalendar/moment-timezone": "^6.1.19",
     "@fullcalendar/react": "^6.1.17",
     "@fullcalendar/timegrid": "^6.1.17",
+    "@linagora/twake-icons": "^2.7.0",
     "@linagora/twake-mui": "^2.0.0",
     "@lottiefiles/dotlottie-react": "^0.17.13",
     "@mui/icons-material": "^9.0.1",

--- a/common/src/components/Attendees/AttendeePopover.tsx
+++ b/common/src/components/Attendees/AttendeePopover.tsx
@@ -1,0 +1,247 @@
+import { userAttendee } from '@common/features/User/models/attendee'
+import {
+  Avatar,
+  Box,
+  Button,
+  IconButton,
+  Typography,
+  Popper,
+  Paper,
+  useTheme,
+  alpha
+} from '@linagora/twake-mui'
+import { ClickAwayListener } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined'
+import { Icon, CalendarToday, EmailOpen } from '@linagora/twake-icons'
+import React, { useState } from 'react'
+import { useI18n } from 'twake-i18n'
+import { useAppSelector } from '@common/app/hooks'
+import { resolveMailSpaUrl } from '@common/utils/mailUrlUtils'
+import { Tooltip } from '../Tooltip'
+import { stringAvatar } from '../Event/utils/eventUtils'
+import { SnackbarAlert } from '../Loading/SnackBarAlert'
+
+interface AttendeePopoverProps {
+  attendee: userAttendee
+  children: React.ReactElement
+  isPublic?: boolean
+}
+
+function AttendeeInfo({ attendee }: { attendee: userAttendee }): JSX.Element {
+  const { t } = useI18n()
+  const theme = useTheme()
+  const [snackbarOpen, setSnackbarOpen] = useState(false)
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Avatar
+          {...stringAvatar(attendee.cn || attendee.cal_address)}
+          sx={{ width: 48, height: 48, fontSize: '1.25rem' }}
+        />
+        <Box sx={{ minWidth: 0 }}>
+          {attendee.cn ? (
+            <Typography variant="body1" sx={{ fontWeight: 500 }} noWrap>
+              {attendee.cn}
+            </Typography>
+          ) : null}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="body2" color="text.secondary" noWrap>
+              {attendee.cal_address}
+            </Typography>
+            <Tooltip title={t('tooltip.copyEmail')}>
+              <IconButton
+                size="small"
+                onClick={() => {
+                  void navigator.clipboard.writeText(attendee.cal_address)
+                  setSnackbarOpen(true)
+                }}
+                sx={{ p: 0.5, color: alpha(theme.palette.grey[900], 0.9) }}
+              >
+                <ContentCopyOutlinedIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      </Box>
+      <SnackbarAlert
+        open={snackbarOpen}
+        setOpen={setSnackbarOpen}
+        message={t('tooltip.emailCopied')}
+        sx={{ whiteSpace: 'nowrap' }}
+      />
+    </>
+  )
+}
+
+function AttendeeActions({
+  attendee,
+  isPublic
+}: {
+  attendee: userAttendee
+  isPublic?: boolean
+}): JSX.Element {
+  const { t } = useI18n()
+  const theme = useTheme()
+
+  const workplaceFqdn = useAppSelector(
+    state => state.user.userData?.workplaceFqdn
+  )
+  const userEmail = useAppSelector(state => state.user.userData?.email)
+  const mailSpaUrl = resolveMailSpaUrl({
+    localpart: userEmail?.split('@')[0],
+    workplaceFqdn
+  })
+
+  const handleSendMail = (): void => {
+    if (!mailSpaUrl) return
+    window.open(
+      `${mailSpaUrl}/mailto/?uri=${encodeURIComponent(
+        `mailto:${attendee.cal_address}`
+      )}`,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        mt: 1,
+        alignItems: 'center'
+      }}
+    >
+      {mailSpaUrl && (
+        <Button
+          variant="outlined"
+          startIcon={<Icon icon={EmailOpen} size={18} />}
+          onClick={handleSendMail}
+          sx={{
+            borderRadius: 6,
+            textTransform: 'none',
+            borderColor: 'divider',
+            color: alpha(theme.palette.grey[900], 0.9)
+          }}
+        >
+          {t('attendees.sendMail')}
+        </Button>
+      )}
+      {!isPublic && (
+        <Tooltip title={t('tooltip.createEvent')}>
+          <IconButton
+            onClick={() => {
+              window.open(
+                `/newEvent?attendee=${encodeURIComponent(attendee.cal_address)}`,
+                '_self'
+              )
+            }}
+            sx={{
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: '50%',
+              padding: 1,
+              color: alpha(theme.palette.grey[900], 0.9)
+            }}
+            size="small"
+          >
+            <Icon icon={CalendarToday} size={20} />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  )
+}
+
+export function AttendeePopover({
+  attendee,
+  children,
+  isPublic
+}: AttendeePopoverProps): React.ReactElement {
+  const theme = useTheme()
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
+    setAnchorEl(anchorEl ? null : event.currentTarget)
+  }
+
+  const handleClose = (): void => {
+    setAnchorEl(null)
+  }
+
+  const open = Boolean(anchorEl)
+
+  if (attendee.role === 'CHAIR' || attendee.cutype === 'RESOURCE') {
+    return <>{children}</>
+  }
+
+  return (
+    <ClickAwayListener onClickAway={handleClose}>
+      <div>
+        <div
+          onClick={handleClick}
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              handleClick(event as unknown as React.MouseEvent<HTMLElement>)
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          style={{
+            display: 'inline-block',
+            width: 'fit-content',
+            cursor: 'pointer'
+          }}
+        >
+          {children}
+        </div>
+        <Popper
+          open={open}
+          anchorEl={anchorEl}
+          placement="right"
+          style={{ zIndex: 1300 }}
+          modifiers={[
+            {
+              name: 'offset',
+              options: {
+                offset: [0, 8]
+              }
+            }
+          ]}
+        >
+          <Paper
+            elevation={4}
+            sx={{
+              p: 3,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+              position: 'relative',
+              minWidth: 320,
+              borderRadius: 2
+            }}
+          >
+            <IconButton
+              size="small"
+              onClick={handleClose}
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                color: alpha(theme.palette.grey[900], 0.9)
+              }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+
+            <AttendeeInfo attendee={attendee} />
+            <AttendeeActions attendee={attendee} isPublic={isPublic} />
+          </Paper>
+        </Popper>
+      </div>
+    </ClickAwayListener>
+  )
+}

--- a/common/src/components/Event/utils/eventUtils.tsx
+++ b/common/src/components/Event/utils/eventUtils.tsx
@@ -13,9 +13,10 @@ import { formatDateToYYYYMMDDTHHMMSS } from '@common/utils/dateUtils'
 import { Avatar, Badge, Box, Typography } from '@linagora/twake-mui'
 import CancelIcon from '@mui/icons-material/Cancel'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { AttendeePopover } from '@common/components/Attendees/AttendeePopover'
 import { PartStat } from '@common/features/User/models/attendee'
 
-export const classIcon = (partStat?: PartStat) => {
+export const classIcon = (partStat?: PartStat): JSX.Element | null => {
   switch (partStat) {
     case 'ACCEPTED':
       return (
@@ -38,36 +39,54 @@ export const classIcon = (partStat?: PartStat) => {
   }
 }
 
-export function renderAttendeeBadge(
+function renderSimpleAttendeeBadge(
   a: userAttendee,
   key: string,
-  t: (key: string) => string,
-  isFull?: boolean,
-  isOrganizer?: boolean,
+  isPublic?: boolean
+): JSX.Element {
+  return (
+    <AttendeePopover key={key} attendee={a} isPublic={isPublic}>
+      <Avatar {...stringAvatar(a?.cn || a?.cal_address)} />
+    </AttendeePopover>
+  )
+}
+
+function renderFullAttendeeBadge({
+  a,
+  key,
+  t,
+  isOrganizer,
+  caption,
+  isPublic
+}: {
+  a: userAttendee
+  key: string
+  t: (key: string) => string
+  isOrganizer?: boolean
   caption?: string
-) {
+  isPublic?: boolean
+}): JSX.Element {
   const icon = classIcon(a.partstat)
-  if (!isFull) {
-    return <Avatar key={key} {...stringAvatar(a.cn || a.cal_address)} />
-  } else {
-    return (
-      <Box
-        key={key}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1.5,
-          marginBottom: 0.5,
-          padding: 0.5,
-          borderRadius: 1
-        }}
-      >
-        {a.cutype === 'RESOURCE' && (
-          <Box sx={{ marginRight: 2 }}>
-            <ResourceIcon />
-          </Box>
-        )}
-        {a.cutype !== 'RESOURCE' && (
+  const displayName = a.cn || a.cal_address
+
+  return (
+    <Box
+      key={key}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        marginBottom: 0.5,
+        padding: 0.5,
+        borderRadius: 1
+      }}
+    >
+      {a.cutype === 'RESOURCE' ? (
+        <Box sx={{ marginRight: 2 }}>
+          <ResourceIcon />
+        </Box>
+      ) : (
+        <AttendeePopover attendee={a} isPublic={isPublic}>
           <Badge
             overlap="circular"
             sx={{ marginRight: 2 }}
@@ -88,30 +107,57 @@ export function renderAttendeeBadge(
               )
             }
           >
-            <Avatar {...stringAvatar(a.cn || a.cal_address)} />
+            <Avatar {...stringAvatar(displayName)} />
           </Badge>
-        )}
-        <Box style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        </AttendeePopover>
+      )}
+      <Box style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        <AttendeePopover attendee={a} isPublic={isPublic}>
           <Typography variant="body2" noWrap>
-            {a.cn || a.cal_address}
+            {displayName}
           </Typography>
-          {isOrganizer && (
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {t('event.organizer')}
-            </Typography>
-          )}
-          {caption && (
-            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              {caption}
-            </Typography>
-          )}
-        </Box>
+        </AttendeePopover>
+        {isOrganizer && (
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            {t('event.organizer')}
+          </Typography>
+        )}
+        {caption && (
+          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+            {caption}
+          </Typography>
+        )}
       </Box>
-    )
-  }
+    </Box>
+  )
 }
 
-export function stringToColor(string: string) {
+export function renderAttendeeBadge({
+  a,
+  key,
+  t,
+  isFull,
+  isOrganizer,
+  caption,
+  isPublic
+}: {
+  a: userAttendee
+  key: string
+  t: (key: string) => string
+  isFull?: boolean
+  isOrganizer?: boolean
+  caption?: string
+  isPublic?: boolean
+}): JSX.Element {
+  if (!a) return <></>
+
+  if (!isFull) {
+    return renderSimpleAttendeeBadge(a, key, isPublic)
+  }
+  return renderFullAttendeeBadge({ a, key, t, isOrganizer, caption, isPublic })
+}
+
+export function stringToColor(string: string): string {
   let hash = 0
   for (let i = 0; i < string.length; i++) {
     hash = string.charCodeAt(i) + ((hash << 5) - hash)
@@ -126,7 +172,10 @@ export function stringToColor(string: string) {
   return color
 }
 
-export function stringAvatar(name: string) {
+export function stringAvatar(name: string): {
+  color?: string
+  children: string
+} {
   return {
     color: stringToGradient(name),
     children: getInitials(name)
@@ -141,7 +190,7 @@ export async function refreshCalendars(
     end: Date
   },
   calType?: 'temp'
-) {
+): Promise<void> {
   if (process.env.NODE_ENV === 'test') return
 
   if (!calType) {
@@ -171,7 +220,7 @@ export async function refreshSingularCalendar(
   calendar: Calendar,
   calendarRange: { start: Date; end: Date },
   calType?: 'temp'
-) {
+): Promise<void> {
   const isTestEnv = process.env.NODE_ENV === 'test'
   dispatch(emptyEventsCal({ calId: calendar.id, calType }))
 

--- a/common/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/common/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -137,15 +137,20 @@ export function EventPreviewAttendees({
             >
               <AvatarGroup max={ATTENDEE_DISPLAY_LIMIT}>
                 {organizer &&
-                  renderAttendeeBadge(
-                    organizer,
-                    'org',
+                  renderAttendeeBadge({
+                    a: organizer,
+                    key: 'org',
                     t,
-                    showAllAttendees,
-                    true
-                  )}
+                    isFull: showAllAttendees,
+                    isOrganizer: true
+                  })}
                 {attendees.map((a, idx) =>
-                  renderAttendeeBadge(a, idx.toString(), t, showAllAttendees)
+                  renderAttendeeBadge({
+                    a,
+                    key: idx.toString(),
+                    t,
+                    isFull: showAllAttendees
+                  })
                 )}
               </AvatarGroup>
               <Button
@@ -182,17 +187,23 @@ export function EventPreviewAttendees({
 
       {showAllAttendees &&
         organizer &&
-        renderAttendeeBadge(organizer, 'org', t, showAllAttendees, true)}
+        renderAttendeeBadge({
+          a: organizer,
+          key: 'org',
+          t,
+          isFull: showAllAttendees,
+          isOrganizer: true
+        })}
       {showAllAttendees &&
         attendees.map((a, idx) =>
-          renderAttendeeBadge(
+          renderAttendeeBadge({
             a,
-            idx.toString(),
+            key: idx.toString(),
             t,
-            showAllAttendees,
-            false,
-            busyCaption(a)
-          )
+            isFull: showAllAttendees,
+            isOrganizer: false,
+            caption: busyCaption(a)
+          })
         )}
     </>
   )

--- a/common/src/components/EventPreview/EventPreviewDetails.tsx
+++ b/common/src/components/EventPreview/EventPreviewDetails.tsx
@@ -73,7 +73,13 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
 
       {isResourceEventPreview &&
         organizer &&
-        renderAttendeeBadge(organizer, 'org', t, true, true)}
+        renderAttendeeBadge({
+          a: organizer,
+          key: 'org',
+          t,
+          isFull: true,
+          isOrganizer: true
+        })}
 
       {shouldShowAttendeesSection && (
         <EventPreviewAttendees

--- a/common/src/components/EventPreview/utils/makeAttendeePreview.ts
+++ b/common/src/components/EventPreview/utils/makeAttendeePreview.ts
@@ -2,7 +2,7 @@ import { userAttendee } from '@common/features/User/models/attendee'
 
 export function makeAttendeePreview(
   attendees: userAttendee[] | undefined,
-  t: (k: string, p?: string | object) => string
+  t: (k: string, p?: Record<string, unknown>) => string
 ) {
   const attendeePreview = []
   const counts = (attendees ?? []).reduce(

--- a/common/src/components/Loading/SnackBarAlert.tsx
+++ b/common/src/components/Loading/SnackBarAlert.tsx
@@ -5,13 +5,15 @@ export function SnackbarAlert({
   open,
   setOpen,
   message,
-  severity = 'success'
+  severity = 'success',
+  sx
 }: {
   open: boolean
   setOpen: (o: boolean) => void
   message: string
   severity?: AlertColor
-}) {
+  sx?: object
+}): JSX.Element {
   return (
     <Snackbar
       open={open}
@@ -22,7 +24,7 @@ export function SnackbarAlert({
       <Alert
         severity={severity}
         onClose={() => setOpen(false)}
-        sx={{ width: '100%' }}
+        sx={{ width: '100%', ...sx }}
       >
         {message}
       </Alert>

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -478,7 +478,10 @@
     "nextMonth": "Next month",
     "previousMonth": "Previous month",
     "copyBookingLink": "Copy booking link",
-    "createAppointment": "Create appointment schedule"
+    "createAppointment": "Create appointment schedule",
+    "chat": "Chat",
+    "copyEmail": "Copy email address",
+    "emailCopied": "Email copied"
   },
   "booking": {
     "addSlot": "Add slot",
@@ -561,5 +564,8 @@
     "and": "and",
     "termsOfService": "Terms of Service",
     "dot": "."
+  },
+  "attendees": {
+    "sendMail": "Send mail"
   }
 }

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -478,7 +478,10 @@
     "nextMonth": "Mois suivant",
     "previousMonth": "Mois précédent",
     "copyBookingLink": "Copier le lien de réservation",
-    "createAppointment": "Créer un planning de rendez-vous"
+    "createAppointment": "Créer un planning de rendez-vous",
+    "chat": "Discuter",
+    "copyEmail": "Copier l'adresse e-mail",
+    "emailCopied": "Email copié"
   },
   "booking": {
     "addSlot": "Ajouter un créneau",
@@ -561,5 +564,8 @@
     "and": "et aux",
     "termsOfService": "Conditions d'utilisation",
     "dot": "."
+  },
+  "attendees": {
+    "sendMail": "Envoyer un e-mail"
   }
 }

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -478,7 +478,9 @@
     "nextMonth": "Следующий месяц",
     "previousMonth": "Предыдущий месяц",
     "copyBookingLink": "Копировать ссылку для бронирования",
-    "createAppointment": "Создать расписание встреч"
+    "createAppointment": "Создать расписание встреч",
+    "copyEmail": "Копировать адрес электронной почты",
+    "emailCopied": "Email скопирован"
   },
   "booking": {
     "addSlot": "Добавить слот",
@@ -561,5 +563,10 @@
     "and": "и",
     "termsOfService": "Условиями использования Twake",
     "dot": "."
+  },
+  "attendees": {
+    "sendMail": "Отправить письмо",
+    "chat": "Чат",
+    "createEvent": "Создать событие"
   }
 }

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -478,7 +478,9 @@
     "nextMonth": "Tháng sau",
     "previousMonth": "Tháng trước",
     "copyBookingLink": "Sao chép liên kết đặt lịch",
-    "createAppointment": "Create appointment schedule"
+    "createAppointment": "Tạo lịch hẹn",
+    "copyEmail": "Sao chép địa chỉ email",
+    "emailCopied": "Email đã được sao chép"
   },
   "booking": {
     "addSlot": "Thêm khung giờ",
@@ -561,5 +563,10 @@
     "and": "và",
     "termsOfService": "Điều khoản dịch vụ",
     "dot": "."
+  },
+  "attendees": {
+    "sendMail": "Gửi thư",
+    "chat": "Trò chuyện",
+    "createEvent": "Tạo sự kiện"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@fullcalendar/moment-timezone": "^6.1.19",
         "@fullcalendar/react": "^6.1.17",
         "@fullcalendar/timegrid": "^6.1.17",
-        "@linagora/twake-icons": "^2.6.7",
+        "@linagora/twake-icons": "^2.7.0",
         "@linagora/twake-mui": "^2.0.0",
         "@lottiefiles/dotlottie-react": "^0.17.13",
         "@mui/icons-material": "^9.0.1",
@@ -150,6 +150,7 @@
         "@fullcalendar/moment-timezone": "^6.1.19",
         "@fullcalendar/react": "^6.1.17",
         "@fullcalendar/timegrid": "^6.1.17",
+        "@linagora/twake-icons": "^2.7.0",
         "@linagora/twake-mui": "^2.0.0",
         "@lottiefiles/dotlottie-react": "^0.17.13",
         "@mui/icons-material": "^9.0.1",
@@ -2800,9 +2801,9 @@
       }
     },
     "node_modules/@linagora/twake-icons": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@linagora/twake-icons/-/twake-icons-2.6.7.tgz",
-      "integrity": "sha512-UseMFLN7EWVR0DkCADgjhZwHal6nBFPWVjGfFvocV5W2K7hf9EITQIrXwhHxwd6J7Jm3wpNOfue4dL6aI+j7eA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@linagora/twake-icons/-/twake-icons-2.7.0.tgz",
+      "integrity": "sha512-t2o0Zg83xIqjieLBlZmE7nO1EAiixyW5gbqYtYYcUEhHHVNL5FSaZXSQa1qPD3o3kjIkUk3EgDTwB8MV+H4Gww==",
       "license": "MIT",
       "dependencies": {
         "mime": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fullcalendar/moment-timezone": "^6.1.19",
     "@fullcalendar/react": "^6.1.17",
     "@fullcalendar/timegrid": "^6.1.17",
-    "@linagora/twake-icons": "^2.6.7",
+    "@linagora/twake-icons": "^2.7.0",
     "@linagora/twake-mui": "^2.0.0",
     "@lottiefiles/dotlottie-react": "^0.17.13",
     "@mui/icons-material": "^9.0.1",


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1086

### Need:

This PR is only merged after merging https://github.com/linagora/twake-ui/pull/50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added attendee popovers displaying avatar and attendee identity, with quick actions (copy email with confirmation, send mail, start chat, and create an event).
  - Popovers are dismissible via click-away and support keyboard activation.
- **Improvements**
  - Refined attendee badge rendering for clearer organizer/availability/resource indicators and consistent captions.
  - Enhanced snackbar alerts to support optional style overrides.
- **Localization**
  - Extended attendee action tooltips/labels in English, French, Russian, and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->