### PR TITLE
[#1135] added backend color support

### DIFF
--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -240,7 +240,7 @@ const BookingLinkChip: React.FC<{
   const calendarId = calendarIdFromEventHref(link.calendarUrl)
   const calendarColor = calendars?.[calendarId]?.color?.light
   const iconColor = isVisible
-    ? (calendarColor ?? defaultColors[4].dark)
+    ? (link.color ?? calendarColor ?? defaultColors[4].dark)
     : theme.palette.grey[400]
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>): void => {

--- a/apps/private/src/features/booking/CreateAppointmentModal.tsx
+++ b/apps/private/src/features/booking/CreateAppointmentModal.tsx
@@ -29,6 +29,8 @@ export const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
     setTimezone,
     calendarid,
     setCalendarid,
+    color,
+    setColor,
     error,
     setError,
     loading,
@@ -71,7 +73,8 @@ export const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
               timeZone: timezone
             }))
           ),
-        description
+        description,
+        color
       })
       const currentLinks = getVisibleBookingLinks()
       if (!currentLinks.includes(response.bookingLinkPublicId)) {
@@ -103,6 +106,8 @@ export const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
       setTimezone={setTimezone}
       calendarid={calendarid}
       setCalendarid={setCalendarid}
+      color={color}
+      setColor={setColor}
       userPersonalCalendars={userPersonalCalendars}
       availabilityRules={availabilityRules}
       setAvailabilityRules={setAvailabilityRules}

--- a/apps/private/src/features/booking/EditAppointmentModal.tsx
+++ b/apps/private/src/features/booking/EditAppointmentModal.tsx
@@ -32,6 +32,8 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
     setTimezone,
     calendarid,
     setCalendarid,
+    color,
+    setColor,
     error,
     setError,
     loading,
@@ -69,7 +71,8 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
                   timeZone: timezone
                 }))
               ),
-            description: description || null
+            description: description || null,
+            color
           }
         })
       ).unwrap()
@@ -101,6 +104,8 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
       setTimezone={setTimezone}
       calendarid={calendarid}
       setCalendarid={setCalendarid}
+      color={color}
+      setColor={setColor}
       userPersonalCalendars={userPersonalCalendars}
       availabilityRules={availabilityRules}
       setAvailabilityRules={setAvailabilityRules}

--- a/apps/private/src/features/booking/components/AppointmentModalForm.tsx
+++ b/apps/private/src/features/booking/components/AppointmentModalForm.tsx
@@ -1,16 +1,24 @@
 import React from 'react'
-import { Button, TextField, Typography } from '@linagora/twake-mui'
+import {
+  Button,
+  TextField,
+  Box,
+  Typography,
+  useTheme
+} from '@linagora/twake-mui'
 import { ResponsiveDialog } from '@common/components/Dialog'
 import { useI18n } from 'twake-i18n'
 import { AddDescButton } from '@common/components/Event/AddDescButton'
 import { TimeSlotSelectField } from './TimeSlotSelectField'
 import { TimezoneSelectField } from './TimezoneSelectField'
 import { CalendarSelectField } from '@common/components/Event/fields/CalendarSelectField'
+import { ColorPicker } from '@common/components/Calendar/CalendarColorPicker'
 import type { Calendar } from '@common/types/CalendarTypes'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 import { RegularHoursField } from './RegularHoursField'
 import { DayAvailability } from './RegularHoursField/RegularHoursTypes'
 import { useAppSelector } from '@common/app/hooks'
+import { getAccessiblePair } from '@common/utils/getAccessiblePair'
 
 interface AppointmentModalFormProps {
   open: boolean
@@ -28,6 +36,8 @@ interface AppointmentModalFormProps {
   setTimezone: (value: string) => void
   calendarid: string
   setCalendarid: (value: string) => void
+  color: string
+  setColor: (value: string) => void
   userPersonalCalendars: Calendar[]
   availabilityRules?: DayAvailability[]
   setAvailabilityRules?: React.Dispatch<React.SetStateAction<DayAvailability[]>>
@@ -54,6 +64,8 @@ export const AppointmentModalForm: React.FC<AppointmentModalFormProps> = ({
   setTimezone,
   calendarid,
   setCalendarid,
+  color,
+  setColor,
   userPersonalCalendars,
   availabilityRules,
   setAvailabilityRules,
@@ -65,6 +77,7 @@ export const AppointmentModalForm: React.FC<AppointmentModalFormProps> = ({
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const theme = useTheme()
 
   const businessHours = useAppSelector(state => state.settings.businessHours)
   const workingDays = businessHours?.daysOfWeek
@@ -118,6 +131,19 @@ export const AppointmentModalForm: React.FC<AppointmentModalFormProps> = ({
       />
 
       <TimezoneSelectField timezone={timezone} setTimezone={setTimezone} />
+
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="body2" sx={{ mb: 1, color: 'text.secondary' }}>
+          {t('booking.color', { defaultValue: 'Color' })}
+        </Typography>
+        <ColorPicker
+          selectedColor={{
+            light: color,
+            dark: getAccessiblePair(color, theme)
+          }}
+          onChange={c => setColor(c.light)}
+        />
+      </Box>
 
       <CalendarSelectField
         calendarid={calendarid}

--- a/apps/private/src/features/booking/hooks/useAppointmentForm.ts
+++ b/apps/private/src/features/booking/hooks/useAppointmentForm.ts
@@ -13,6 +13,7 @@ import {
   DayAvailability,
   DAYS
 } from '../components/RegularHoursField/RegularHoursTypes'
+import { defaultColors } from '@common/utils/defaultColors'
 
 interface UseAppointmentFormOptions {
   bookingLink?: BookingLink
@@ -80,7 +81,7 @@ const formStateFromBookingLink = (
         })) || []
     }
   }),
-  color: bookingLink.color ?? calendarColor ?? '#0B57D0'
+  color: bookingLink.color ?? calendarColor ?? defaultColors[4].dark
 })
 
 const defaultFormState = (
@@ -104,7 +105,7 @@ const defaultFormState = (
       slots: [{ start: '09:00', end: '18:00' }]
     }
   }),
-  color: defaultCalendarColor ?? '#0B57D0'
+  color: defaultCalendarColor ?? defaultColors[4].dark
 })
 
 interface FormSetters {

--- a/apps/private/src/features/booking/hooks/useAppointmentForm.ts
+++ b/apps/private/src/features/booking/hooks/useAppointmentForm.ts
@@ -4,6 +4,7 @@ import type {
   BookingLink,
   WeeklyAvailabilityRule
 } from '@common/features/booking/types/BookingTypes'
+import type { Calendar } from '@common/types/CalendarTypes'
 import { calendarIdFromEventHref } from '@common/features/Calendars/CalendarDAO'
 import { useUserPersonalCalendars } from '@common/features/Calendars/hooks/useUserPersonalCalendars'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -26,6 +27,7 @@ interface FormState {
   timezone: string
   calendarid: string
   availabilityRules: DayAvailability[]
+  color: string
 }
 
 interface UseAppointmentFormReturn extends FormState {
@@ -36,6 +38,7 @@ interface UseAppointmentFormReturn extends FormState {
   setTimezone: (value: string) => void
   setCalendarid: (value: string) => void
   setAvailabilityRules: React.Dispatch<React.SetStateAction<DayAvailability[]>>
+  setColor: (value: string) => void
   error: string | null
   setError: (value: string | null) => void
   loading: boolean
@@ -52,7 +55,10 @@ const bookingTimezone = (bookingLink: BookingLink): string =>
     (rule: AvailabilityRule) => rule.type === 'weekly'
   )?.timeZone ?? localTimezone()
 
-const formStateFromBookingLink = (bookingLink: BookingLink): FormState => ({
+const formStateFromBookingLink = (
+  bookingLink: BookingLink,
+  calendarColor?: string
+): FormState => ({
   name: bookingLink.name ?? '',
   duration: bookingLink.durationMinutes,
   description: bookingLink.description ?? '',
@@ -73,12 +79,14 @@ const formStateFromBookingLink = (bookingLink: BookingLink): FormState => ({
           end: r.end
         })) || []
     }
-  })
+  }),
+  color: bookingLink.color ?? calendarColor ?? '#0B57D0'
 })
 
 const defaultFormState = (
   defaultCalendarId: string,
-  workingDays?: number[]
+  workingDays?: number[],
+  defaultCalendarColor?: string
 ): FormState => ({
   name: '',
   duration: 30,
@@ -95,7 +103,8 @@ const defaultFormState = (
       enabled: isWorkingDay,
       slots: [{ start: '09:00', end: '18:00' }]
     }
-  })
+  }),
+  color: defaultCalendarColor ?? '#0B57D0'
 })
 
 interface FormSetters {
@@ -106,10 +115,12 @@ interface FormSetters {
   setTimezone: (value: string) => void
   setCalendarid: (value: string) => void
   setAvailabilityRules: React.Dispatch<React.SetStateAction<DayAvailability[]>>
+  setColor: (value: string) => void
 }
 
 const makeSetters = (
-  setForm: React.Dispatch<React.SetStateAction<FormState>>
+  setForm: React.Dispatch<React.SetStateAction<FormState>>,
+  calendars: Calendar[]
 ): FormSetters => ({
   setName: (value: string): void => setForm(prev => ({ ...prev, name: value })),
   setDuration: (value: number): void =>
@@ -121,7 +132,14 @@ const makeSetters = (
   setTimezone: (value: string): void =>
     setForm(prev => ({ ...prev, timezone: value })),
   setCalendarid: (value: string): void =>
-    setForm(prev => ({ ...prev, calendarid: value })),
+    setForm(prev => {
+      const calendar = calendars.find(c => c.id === value)
+      return {
+        ...prev,
+        calendarid: value,
+        color: calendar?.color?.light ?? prev.color
+      }
+    }),
   setAvailabilityRules: (
     value: React.SetStateAction<DayAvailability[]>
   ): void =>
@@ -129,19 +147,22 @@ const makeSetters = (
       ...prev,
       availabilityRules:
         typeof value === 'function' ? value(prev.availabilityRules) : value
-    }))
+    })),
+  setColor: (value: string): void =>
+    setForm(prev => ({ ...prev, color: value }))
 })
 
 const computeInitialFormState = (
   isOpen: boolean,
   bookingLink: BookingLink | undefined,
   workingDays: number[] | undefined,
-  firstCalendarId?: string
+  firstCalendarId?: string,
+  firstCalendarColor?: string
 ): FormState => {
-  if (!isOpen) return defaultFormState('', workingDays)
+  if (!isOpen) return defaultFormState('', workingDays, firstCalendarColor)
   return bookingLink
-    ? formStateFromBookingLink(bookingLink)
-    : defaultFormState(firstCalendarId ?? '', workingDays)
+    ? formStateFromBookingLink(bookingLink, firstCalendarColor)
+    : defaultFormState(firstCalendarId ?? '', workingDays, firstCalendarColor)
 }
 
 const checkFormValid = (form: FormState): boolean =>
@@ -164,7 +185,8 @@ export const useAppointmentForm = ({
         isOpen,
         bookingLink,
         workingDays,
-        userPersonalCalendars[0]?.id
+        userPersonalCalendars[0]?.id,
+        userPersonalCalendars[0]?.color?.light
       ),
     [isOpen, bookingLink, userPersonalCalendars, workingDays]
   )
@@ -187,7 +209,7 @@ export const useAppointmentForm = ({
 
   return {
     ...form,
-    ...makeSetters(setForm),
+    ...makeSetters(setForm, userPersonalCalendars),
     error,
     setError,
     loading,

--- a/common/src/features/booking/types/BookingTypes.ts
+++ b/common/src/features/booking/types/BookingTypes.ts
@@ -30,6 +30,7 @@ export interface BookingLink {
   availabilityRules?: AvailabilityRule[]
   name?: string
   description?: string
+  color?: string
 }
 
 export interface Slot {
@@ -77,6 +78,7 @@ export interface CreateBookingLinkRequest {
   name?: string
   description?: string
   timeZone?: string
+  color?: string
 }
 
 export interface CreateBookingLinkResponse {
@@ -103,6 +105,11 @@ export interface UpdateBookingLinkRequest {
    * Omit to leave unchanged.
    */
   description?: string | null
+  /**
+   * Set to null or blank to clear this field.
+   * Omit to leave unchanged.
+   */
+  color?: string | null
 }
 
 export interface CreateBookingResponse {

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -516,6 +516,7 @@
     "createAppointmentTitle": "Create appointment schedule",
     "editAppointmentTitle": "Edit appointment schedule",
     "scheduleName": "Schedule name",
+    "color": "Color",
     "chooseTimeSlot": "Choose time slot",
     "15minutes": "15 minutes",
     "30minutes": "30 minutes",

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -516,6 +516,7 @@
     "createAppointmentTitle": "Créer un lien de prise de rendez-vous",
     "editAppointmentTitle": "Modifier le lien de prise de rendez-vous",
     "scheduleName": "Nom du planning",
+    "color": "Couleur",
     "chooseTimeSlot": "Choisir un créneau",
     "15minutes": "15 minutes",
     "30minutes": "30 minutes",

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -516,6 +516,7 @@
     "createAppointmentTitle": "Создать расписание встреч",
     "editAppointmentTitle": "Редактировать расписание встреч",
     "scheduleName": "Название расписания",
+    "color": "Цвет",
     "chooseTimeSlot": "Выберите время",
     "15minutes": "15 минут",
     "30minutes": "30 минут",

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -516,6 +516,7 @@
     "createAppointmentTitle": "Tạo lịch hẹn",
     "editAppointmentTitle": "Chỉnh sửa lịch hẹn",
     "scheduleName": "Tên lịch trình",
+    "color": "Màu sắc",
     "chooseTimeSlot": "Chọn khung giờ",
     "15minutes": "15 phút",
     "30minutes": "30 phút",


### PR DESCRIPTION
resolves #1135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added color selection when creating or editing booking links.
  * Booking link colors are saved and reflected on calendar chips for visible links.
  * Selected calendar colors are now used as defaults when a custom color isn’t provided.
* **Localization**
  * Added translations for the color field in English, French, Russian, and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->