### PR TITLE
#1063 update twake-icons to 2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@fullcalendar/moment-timezone": "^6.1.19",
         "@fullcalendar/react": "^6.1.17",
         "@fullcalendar/timegrid": "^6.1.17",
-        "@linagora/twake-icons": "^2.4.1",
+        "@linagora/twake-icons": "^2.6.7",
         "@linagora/twake-mui": "^2.0.0",
         "@lottiefiles/dotlottie-react": "^0.17.13",
         "@mui/icons-material": "^9.0.1",
@@ -2799,9 +2799,9 @@
       }
     },
     "node_modules/@linagora/twake-icons": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@linagora/twake-icons/-/twake-icons-2.4.1.tgz",
-      "integrity": "sha512-DsMhkNG1UTN9gqXB7TzjxzIRfVayexruasAQIQpCSbXXjkyGowJdAyfAU1FUna14wu6psLNZIb9+RFiFR//6KA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@linagora/twake-icons/-/twake-icons-2.6.7.tgz",
+      "integrity": "sha512-UseMFLN7EWVR0DkCADgjhZwHal6nBFPWVjGfFvocV5W2K7hf9EITQIrXwhHxwd6J7Jm3wpNOfue4dL6aI+j7eA==",
       "license": "MIT",
       "dependencies": {
         "mime": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@fullcalendar/moment-timezone": "^6.1.19",
     "@fullcalendar/react": "^6.1.17",
     "@fullcalendar/timegrid": "^6.1.17",
-    "@linagora/twake-icons": "^2.4.1",
+    "@linagora/twake-icons": "^2.6.7",
     "@linagora/twake-mui": "^2.0.0",
     "@lottiefiles/dotlottie-react": "^0.17.13",
     "@mui/icons-material": "^9.0.1",


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1063