### PR TITLE
[#1170] fix edit booking regular hours

### DIFF
--- a/apps/private/src/features/booking/components/RegularHoursField/index.tsx
+++ b/apps/private/src/features/booking/components/RegularHoursField/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Stack } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { DayAvailability, DAYS, DAY_TO_FC } from './RegularHoursTypes'
-import { useRegularHours } from '../../hooks/useRegularHours'
+import { DEFAULT_SLOT, useRegularHours } from '../../hooks/useRegularHours'
 import { RegularHoursRow } from './RegularHoursRow'
 import { FieldWithLabel } from '@common/components/Event/components/FieldWithLabel'
 import { TwakeLocalizationProvider } from '@common/components/DateTimePicker'
@@ -48,7 +48,7 @@ export const RegularHoursField: React.FC<RegularHoursFieldProps> = ({
               ? workingDays.includes(DAY_TO_FC[day])
               : true
             const isEnabled = rule ? rule.enabled : isWorkingDay
-            const slots = rule?.slots || [{ start: '09:00', end: '18:00' }]
+            const slots = rule?.slots?.length ? rule.slots : [DEFAULT_SLOT]
 
             return (
               <RegularHoursRow

--- a/apps/private/src/features/booking/hooks/useAppointmentForm.ts
+++ b/apps/private/src/features/booking/hooks/useAppointmentForm.ts
@@ -14,6 +14,7 @@ import {
   DAYS
 } from '../components/RegularHoursField/RegularHoursTypes'
 import { defaultColors } from '@common/utils/defaultColors'
+import { DEFAULT_SLOT } from './useRegularHours'
 
 interface UseAppointmentFormOptions {
   bookingLink?: BookingLink
@@ -74,11 +75,10 @@ const formStateFromBookingLink = (
     return {
       dayOfWeek: day,
       enabled: !!rules?.length,
-      slots:
-        rules?.map((r: WeeklyAvailabilityRule) => ({
-          start: r.start,
-          end: r.end
-        })) || []
+      slots: rules?.map((r: WeeklyAvailabilityRule) => ({
+        start: r.start,
+        end: r.end
+      })) || [DEFAULT_SLOT]
     }
   }),
   color: bookingLink.color ?? calendarColor ?? defaultColors[4].dark
@@ -102,7 +102,7 @@ const defaultFormState = (
     return {
       dayOfWeek: day,
       enabled: isWorkingDay,
-      slots: [{ start: '09:00', end: '18:00' }]
+      slots: [DEFAULT_SLOT]
     }
   }),
   color: defaultCalendarColor ?? defaultColors[4].dark

--- a/apps/private/src/features/booking/hooks/useRegularHours.ts
+++ b/apps/private/src/features/booking/hooks/useRegularHours.ts
@@ -28,7 +28,7 @@ interface UseRegularHoursReturn {
   getDayLabel: (day: DayOfWeek) => string
 }
 
-const DEFAULT_SLOT: TimeSlot = { start: '09:00', end: '18:00' }
+export const DEFAULT_SLOT: TimeSlot = { start: '09:00', end: '18:00' }
 const DEFAULT_SLOTS: TimeSlot[] = [DEFAULT_SLOT]
 
 const updateRule = (
@@ -62,7 +62,11 @@ export const useRegularHours = ({
   const handleToggleDay = (day: DayOfWeek): void => {
     updateAvailability(
       day,
-      rule => ({ ...rule, enabled: !rule.enabled }),
+      rule => ({
+        ...rule,
+        enabled: !rule.enabled,
+        slots: rule.slots?.length ? rule.slots : [...DEFAULT_SLOTS]
+      }),
       () => {
         const isWorkingDay = workingDays
           ? workingDays.includes(DAY_TO_FC[day])


### PR DESCRIPTION
resolves #1170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default availability handling when no time slots are configured.
  * Days with missing or empty schedules now display a standard time slot instead of appearing blank.
  * Enabling or toggling a day now preserves existing time slots and automatically adds a default slot when none are present.
  * Booking forms now consistently apply the standard availability slot across all default and imported schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->