### PR TITLE
[#1180] ellisped booking link name

### DIFF
--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -297,7 +297,7 @@ const BookingLinkChip: React.FC<{
               style={{
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
-                overflowWrap: 'break-word',
+                whiteSpace: 'nowrap',
                 fontSize: '0.875rem',
                 color: alpha(theme.palette.grey[900], 0.9)
               }}


### PR DESCRIPTION
resolves #1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented booking link names from wrapping onto multiple lines in the calendar selection view.
  * Improved readability of long booking link labels by keeping them on a single line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->