### PR TITLE
#1069 hide visio link in description to avoid from editing

### DIFF
--- a/common/src/components/Event/hooks/useVideoConference.ts
+++ b/common/src/components/Event/hooks/useVideoConference.ts
@@ -1,9 +1,5 @@
 import { useAppSelector } from '@common/app/hooks'
-import {
-  addVideoConferenceToDescription,
-  generateMeetingLink,
-  removeVideoConferenceFromDescription
-} from '@common/utils/videoConferenceUtils'
+import { generateMeetingLink } from '@common/utils/videoConferenceUtils'
 
 interface UseVideoConferenceProps {
   description: string
@@ -20,8 +16,6 @@ interface UseVideoConferenceReturn {
 }
 
 export const useVideoConference = ({
-  description,
-  setDescription,
   setHasVideoConference,
   setMeetingLink,
   showMore,
@@ -37,11 +31,6 @@ export const useVideoConference = ({
       localpart: email?.split('@')[0],
       workplaceFqdn
     })
-    const updatedDescription = addVideoConferenceToDescription(
-      description,
-      newMeetingLink
-    )
-    setDescription(updatedDescription)
     setHasVideoConference(true)
     setMeetingLink(newMeetingLink)
     if (showMore) {
@@ -50,7 +39,6 @@ export const useVideoConference = ({
   }
 
   const handleDeleteVideoConference = (): void => {
-    setDescription(removeVideoConferenceFromDescription(description))
     setHasVideoConference(false)
     setMeetingLink(null)
   }

--- a/common/src/components/Event/utils/eventInitialValuesHelpers.ts
+++ b/common/src/components/Event/utils/eventInitialValuesHelpers.ts
@@ -5,7 +5,7 @@ import { Calendar } from '@common/types/CalendarTypes'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { Valarms } from '@common/types/Valarms'
 import { resolveTimezone } from '@common/utils/timezone'
-import { addVideoConferenceToDescription } from '@common/utils/videoConferenceUtils'
+import { removeVideoConferenceFromDescription } from '@common/utils/videoConferenceUtils'
 
 import {
   resolveAttendeesAndResources,
@@ -23,17 +23,7 @@ export { buildDefaultNewEvent, buildFromSelectedRange }
 
 function resolveDescription(event: CalendarEvent): string {
   const description = event.description ?? ''
-  const meetingLink = event.x_openpass_videoconference
-
-  if (!meetingLink || !description) {
-    return description
-  }
-
-  if (description.includes('Visio:')) {
-    return description
-  }
-
-  return addVideoConferenceToDescription(description, meetingLink)
+  return removeVideoConferenceFromDescription(description)
 }
 
 export interface BuildFromExistingEventParams {

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -4,6 +4,7 @@ import { userAttendee } from '@common/features/User/models/attendee'
 import { Attachment } from '@common/types/Attachment'
 import { RepetitionObject } from '@common/types/Repetition'
 import { Valarms } from '@common/types/Valarms'
+import { removeVideoConferenceFromDescription } from '@common/utils/videoConferenceUtils'
 import { Box, Typography, useTheme } from '@linagora/twake-mui'
 import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined'
 import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined'
@@ -140,13 +141,17 @@ export const EventDescriptionRow: React.FC<{
   description?: string
   attach?: Attachment[]
 }> = ({ description, attach }) => {
-  if (!(description || !!attach?.length)) return null
+  const displayedDescription = removeVideoConferenceFromDescription(
+    description ?? ''
+  )
+  if (!(displayedDescription || !!attach?.length)) return null
+
   return (
     <BaseEventRow
       alignItems="flex-start"
       alignSelf="flex-start"
       icon={<SubjectIcon />}
-      text={description}
+      text={displayedDescription}
       content={
         attach &&
         attach.length > 0 && <AttachementPreview attachments={attach} />

--- a/common/src/features/Events/formHelpers.ts
+++ b/common/src/features/Events/formHelpers.ts
@@ -3,7 +3,7 @@ import { formatDateTimeInTimezone } from '@common/components/Event/utils/dateTim
 import { extractEventBaseUuid } from '@common/utils/extractEventBaseUuid'
 import { browserDefaultTimeZone } from '@common/utils/timezone'
 import { TIMEZONES } from '@common/utils/timezone-data'
-import { addVideoConferenceToDescription } from '@common/utils/videoConferenceUtils'
+import { removeVideoConferenceFromDescription } from '@common/utils/videoConferenceUtils'
 import { userAttendee } from '@common/features/User/models/attendee'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { RepetitionObject } from '@common/types/Repetition'
@@ -178,18 +178,10 @@ export function populateFormFromEvent(
   setHasVideoConference(event.x_openpass_videoconference ? true : false)
   setMeetingLink(event.x_openpass_videoconference || null)
 
-  // Update description to include video conference footer if exists
-  if (event.x_openpass_videoconference && event.description) {
-    const hasVideoFooter = event.description.includes('Visio:')
-    if (!hasVideoFooter) {
-      setDescription(
-        addVideoConferenceToDescription(
-          event.description,
-          event.x_openpass_videoconference
-        )
-      )
-    } else {
-      setDescription(event.description)
-    }
+  // Always strip video conference footer from description for UI form
+  if (event.description) {
+    setDescription(removeVideoConferenceFromDescription(event.description))
+  } else {
+    setDescription('')
   }
 }

--- a/common/src/features/Events/hooks/submitCreateHelpers/createAction.ts
+++ b/common/src/features/Events/hooks/submitCreateHelpers/createAction.ts
@@ -15,6 +15,7 @@ import {
   saveEventFormDataToTemp,
   showErrorNotification
 } from '@common/utils/eventFormTempStorage'
+import { addVideoConferenceToDescription } from '@common/utils/videoConferenceUtils'
 import { getAlarmAttendees } from '../submitUpdateHelpers/utils'
 import { userOrganiser } from '@common/features/User/userDataTypes'
 
@@ -39,13 +40,15 @@ function buildNewEvent({
   targetCalendar,
   showMore,
   organizer,
-  newEventUID
+  newEventUID,
+  t
 }: {
   values: EventFormValues
   targetCalendar: Calendar
   showMore: boolean
   organizer?: userOrganiser
   newEventUID: string
+  t?: (key: string) => string
 }): CalendarEvent {
   const newEventURL = `/calendars/${targetCalendar.id}/${newEventUID}.ics`
   const { startISO, endISO } = resolveEventISORange({
@@ -67,7 +70,13 @@ function buildNewEvent({
     end: endISO,
     allday: values.allday,
     uid: newEventUID,
-    description: values.description,
+    description: values.meetingLink
+      ? addVideoConferenceToDescription(
+          values.description,
+          values.meetingLink,
+          t
+        )
+      : values.description,
     location: values.location,
     class: values.eventClass,
     repetition: RepetitionObject.fromFormValues(values.repetition, {
@@ -113,7 +122,8 @@ export async function handleCreateEvent({
   targetCalendar,
   showMore,
   organizer,
-  onClose
+  onClose,
+  t
 }: {
   dispatch: AppDispatch
   values: EventFormValues
@@ -121,13 +131,15 @@ export async function handleCreateEvent({
   showMore: boolean
   organizer?: userOrganiser
   onClose: (refresh?: boolean) => void
+  t?: (key: string) => string
 }): Promise<void> {
   const newEvent = buildNewEvent({
     values,
     targetCalendar,
     showMore,
     organizer,
-    newEventUID: crypto.randomUUID()
+    newEventUID: crypto.randomUUID(),
+    t
   })
 
   onClose(true)

--- a/common/src/features/Events/hooks/submitUpdateHelpers/types.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/types.ts
@@ -50,6 +50,7 @@ export interface PrepareUpdateDataParams {
   eventId: string
   typeOfAction?: 'all' | 'solo'
   masterEvent?: CalendarEvent | null
+  t?: (key: string) => string
 }
 
 export interface HandleUpdateSubmitParams extends PrepareUpdateDataParams {
@@ -67,6 +68,7 @@ export interface PrepareUpdatedEventParams {
   targetCalendar: Calendar
   calId: string
   newCalId: string
+  t?: (key: string) => string
 }
 
 export interface HandleUpdateErrorParams {

--- a/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -9,6 +9,7 @@ import { Valarms } from '@common/types/Valarms'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { RepetitionObject } from '@common/types/Repetition'
 import { extractEventBaseUuid } from '@common/utils/extractEventBaseUuid'
+import { addVideoConferenceToDescription } from '@common/utils/videoConferenceUtils'
 import { PrepareUpdateDataParams, PrepareUpdateDataResult } from './types'
 
 export function getAlarmAttendees(
@@ -42,6 +43,54 @@ export function getSeriesInstances(
   return instances
 }
 
+export function buildUpdatedAlarms(
+  values: EventFormValues,
+  targetCalendar: Calendar
+): Valarms {
+  const alarmAttendees = getAlarmAttendees(values, targetCalendar)
+
+  return Valarms.fromList(
+    values.alarms.getAlarms().map(alarm => {
+      if (alarm.attendees && alarm.attendees.length > 0) {
+        return alarm // Preserve existing attendees from merge
+      }
+      // New alarm without attendees - add defaults
+      return new VAlarm({
+        trigger: alarm.trigger,
+        action: alarm.action,
+        attendees: alarmAttendees,
+        summary: values.title,
+        description: alarm.description
+      })
+    })
+  )
+}
+
+function getUpdatedDescription(
+  values: EventFormValues,
+  t?: (key: string) => string
+): string {
+  return values.meetingLink
+    ? addVideoConferenceToDescription(values.description, values.meetingLink, t)
+    : values.description
+}
+
+function getNextSequence(sequence?: number): number {
+  return (sequence ?? 1) + 1
+}
+
+function getEventURL(
+  url: string | undefined,
+  calId: string,
+  uid: string
+): string {
+  return url ?? `/calendars/${calId}/${uid}.ics`
+}
+
+function getEventAttachments<T>(attachments?: T[]): T[] | undefined {
+  return attachments && attachments.length > 0 ? attachments : undefined
+}
+
 export function prepareUpdatedEvent({
   event,
   values,
@@ -50,7 +99,8 @@ export function prepareUpdatedEvent({
   timeChanged,
   targetCalendar,
   calId,
-  newCalId
+  newCalId,
+  t
 }: {
   event: CalendarEvent
   values: EventFormValues
@@ -60,21 +110,20 @@ export function prepareUpdatedEvent({
   targetCalendar: Calendar
   calId: string
   newCalId: string
+  t?: (key: string) => string
 }): CalendarEvent {
   const currentCalId = newCalId || calId
-  const nextSequence = (event.sequence ?? 1) + 1
-  const fallbackURL = `/calendars/${currentCalId}/${event.uid}.ics`
 
   const newEvent: CalendarEvent = {
     ...updateAttendeesAfterTimeChange(event, timeChanged, values.attendees),
     calId: currentCalId,
     title: values.title,
-    URL: event.URL ?? fallbackURL,
+    URL: getEventURL(event.URL, currentCalId, event.uid),
     start: startISO,
     end: endISO,
     allday: values.allday,
     uid: event.uid,
-    description: values.description,
+    description: getUpdatedDescription(values, t),
     location: values.location,
     repetition: RepetitionObject.fromFormValues(values.repetition, {
       allday: values.allday,
@@ -84,34 +133,14 @@ export function prepareUpdatedEvent({
     organizer: event.organizer,
     timezone: values.timezone,
     transp: values.busy,
-    sequence: nextSequence,
+    sequence: getNextSequence(event.sequence),
     color: targetCalendar?.color,
-    alarms: (() => {
-      const alarmAttendees = getAlarmAttendees(values, targetCalendar)
-
-      // If alarms already have attendees (from handleSave merge), preserve them.
-      // Only use fromFormValues for alarms without attendees (new alarms from UI).
-      return Valarms.fromList(
-        values.alarms.getAlarms().map(alarm => {
-          if (alarm.attendees && alarm.attendees.length > 0) {
-            return alarm // Preserve existing attendees from merge
-          }
-          // New alarm without attendees - add defaults
-          return new VAlarm({
-            trigger: alarm.trigger,
-            action: alarm.action,
-            attendees: alarmAttendees,
-            summary: values.title,
-            description: alarm.description
-          })
-        })
-      )
-    })(),
+    alarms: buildUpdatedAlarms(values, targetCalendar),
     x_openpass_videoconference: values.meetingLink || undefined,
-    attach: values.attachments?.length ? values.attachments : undefined
+    attach: getEventAttachments(values.attachments)
   }
 
-  if (values.selectedResources?.length) {
+  if (values.selectedResources && values.selectedResources.length > 0) {
     const resourceAttendees = mapResourcesToAttendees(
       values.selectedResources,
       event.attendee || []
@@ -145,7 +174,8 @@ export function prepareUpdateData({
   calId,
   eventId,
   typeOfAction,
-  masterEvent
+  masterEvent,
+  t
 }: PrepareUpdateDataParams): PrepareUpdateDataResult | null {
   const targetCalendar = calList[values.calendarid]
   if (!targetCalendar) return null
@@ -174,7 +204,8 @@ export function prepareUpdateData({
     timeChanged,
     targetCalendar,
     calId,
-    newCalId
+    newCalId,
+    t
   })
 
   return {

--- a/common/src/features/Events/hooks/useSubmitCreateEvent.ts
+++ b/common/src/features/Events/hooks/useSubmitCreateEvent.ts
@@ -4,6 +4,7 @@ import { Calendar } from '@common/types/CalendarTypes'
 import { EventFormValues } from '@common/components/Event/EventFormFields.types'
 import { handleCreateEvent } from './submitCreateHelpers/createAction'
 import { userOrganiser } from '@common/features/User/userDataTypes'
+import { useI18n } from 'twake-i18n'
 
 export interface UseSubmitCreateEventProps {
   showMore: boolean
@@ -21,6 +22,7 @@ export function useSubmitCreateEvent({
     organizer?: userOrganiser
   ) => Promise<void>
 } {
+  const { t } = useI18n()
   const dispatch = useAppDispatch()
   const calList = useAppSelector(state => state.calendars.list)
 
@@ -45,10 +47,11 @@ export function useSubmitCreateEvent({
         targetCalendar,
         showMore,
         organizer,
-        onClose
+        onClose,
+        t
       })
     },
-    [showMore, onClose, userPersonalCalendars, dispatch, calList]
+    [showMore, onClose, userPersonalCalendars, dispatch, calList, t]
   )
 
   return { handleSubmit }

--- a/common/src/features/Events/hooks/useSubmitUpdateEvent.ts
+++ b/common/src/features/Events/hooks/useSubmitUpdateEvent.ts
@@ -3,6 +3,7 @@ import { useAppDispatch, useAppSelector } from '@common/app/hooks'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { EventFormValues } from '@common/components/Event/EventFormFields.types'
 import { handleUpdateSubmit } from './submitUpdateHelpers/performUpdateAction'
+import { useI18n } from 'twake-i18n'
 
 export interface UseSubmitUpdateEventProps {
   event: CalendarEvent
@@ -25,6 +26,7 @@ export const useSubmitUpdateEvent = ({
 }: UseSubmitUpdateEventProps): {
   handleSubmit: (values: EventFormValues) => Promise<void>
 } => {
+  const { t } = useI18n()
   const dispatch = useAppDispatch()
   const calList = useAppSelector(state => state.calendars.list)
 
@@ -40,7 +42,8 @@ export const useSubmitUpdateEvent = ({
         typeOfAction,
         onClose,
         dispatch,
-        masterEvent
+        masterEvent,
+        t
       })
     },
     [
@@ -52,7 +55,8 @@ export const useSubmitUpdateEvent = ({
       showMore,
       onClose,
       dispatch,
-      calList
+      calList,
+      t
     ]
   )
 

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -181,6 +181,8 @@
       "meetCopied": "Meeting link copied!",
       "addVisioConference": "Add Visio conference",
       "joinVisioConference": "Join Visio conference",
+      "joinVisio": "Join Visio",
+      "doNotEditSection": "Please do not edit this section.",
       "copyMeetingLink": "Copy meeting link",
       "removeVideoConference": "Remove video conference",
       "location": "Location",

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -181,6 +181,8 @@
       "meetCopied": "Lien de la visio copié!",
       "addVisioConference": "Ajouter une visioconférence",
       "joinVisioConference": "Rejoindre la visioconférence",
+      "joinVisio": "Participer via Visio",
+      "doNotEditSection": "Veuillez ne pas modifier cette section.",
       "copyMeetingLink": "Copier le lien de la réunion",
       "removeVideoConference": "Supprimer la visioconférence",
       "location": "Lieu",

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -181,6 +181,8 @@
       "meetCopied": "Ссылка на встречу скопирована",
       "addVisioConference": "Добавить видеоконференцию",
       "joinVisioConference": "Подключиться сейчас",
+      "joinVisio": "Подключиться к Visio",
+      "doNotEditSection": "Пожалуйста, не редактируйте этот раздел.",
       "copyMeetingLink": "Скопировать ссылку на встречу",
       "removeVideoConference": "Удалить видеоконференцию",
       "location": "Место",

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -181,6 +181,8 @@
       "meetCopied": "Đã sao chép liên kết họp!",
       "addVisioConference": "Thêm cuộc họp trực tuyến",
       "joinVisioConference": "Tham gia cuộc họp",
+      "joinVisio": "Tham gia Visio",
+      "doNotEditSection": "Vui lòng không chỉnh sửa phần này.",
       "copyMeetingLink": "Sao chép liên kết họp",
       "removeVideoConference": "Xóa cuộc họp",
       "location": "Địa điểm",

--- a/common/src/utils/__test__/videoConferenceUtils.test.ts
+++ b/common/src/utils/__test__/videoConferenceUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  VISIO_BLOCK_SEPARATOR,
   addVideoConferenceToDescription,
   extractVideoConferenceFromDescription,
   generateMeetingId,
@@ -133,7 +134,9 @@ describe('videoConferenceUtils', () => {
       const description = ''
       const meetingLink = 'https://meet.linagora.com/abc-defg-hij'
       const result = addVideoConferenceToDescription(description, meetingLink)
-      expect(result).toBe('Visio: https://meet.linagora.com/abc-defg-hij')
+      expect(result).toBe(
+        `${VISIO_BLOCK_SEPARATOR}\nJoin Visio : ${meetingLink}\n\nPlease do not edit this section.\n${VISIO_BLOCK_SEPARATOR}`
+      )
     })
 
     it('should add video conference footer to existing description', () => {
@@ -141,7 +144,7 @@ describe('videoConferenceUtils', () => {
       const meetingLink = 'https://meet.linagora.com/abc-defg-hij'
       const result = addVideoConferenceToDescription(description, meetingLink)
       expect(result).toBe(
-        'This is a meeting description.\nVisio: https://meet.linagora.com/abc-defg-hij'
+        `This is a meeting description.\n\n${VISIO_BLOCK_SEPARATOR}\nJoin Visio : ${meetingLink}\n\nPlease do not edit this section.\n${VISIO_BLOCK_SEPARATOR}`
       )
     })
   })

--- a/common/src/utils/videoConferenceUtils.ts
+++ b/common/src/utils/videoConferenceUtils.ts
@@ -55,17 +55,25 @@ export function generateMeetingLink(
   return `${base}/${meetingId}`
 }
 
+export const VISIO_BLOCK_SEPARATOR =
+  '-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-'
+
 /**
  * Add video conference footer to event description.
  * If description is empty, adds on first line; otherwise adds on the line below existing content.
  */
 export function addVideoConferenceToDescription(
   description: string,
-  meetingLink: string
+  meetingLink: string,
+  t?: (key: string) => string
 ): string {
-  const line = `Visio: ${meetingLink}`
+  const joinText = t ? t('event.form.joinVisio') : 'Join Visio'
+  const doNotEditText = t
+    ? t('event.form.doNotEditSection')
+    : 'Please do not edit this section.'
+  const line = `${VISIO_BLOCK_SEPARATOR}\n${joinText} : ${meetingLink}\n\n${doNotEditText}\n${VISIO_BLOCK_SEPARATOR}`
   const trimmed = description.trimEnd()
-  return trimmed ? `${trimmed}\n${line}` : line
+  return trimmed ? `${trimmed}\n\n${line}` : line
 }
 
 /**
@@ -74,6 +82,18 @@ export function addVideoConferenceToDescription(
 export function extractVideoConferenceFromDescription(
   description: string
 ): string | null {
+  if (description.includes(VISIO_BLOCK_SEPARATOR)) {
+    const escapedSeparator = VISIO_BLOCK_SEPARATOR.replace(
+      /[-/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    )
+    const blockRegex = new RegExp(
+      `${escapedSeparator}[\\s\\S]*?(https?:\\/\\/[^\\s]+)[\\s\\S]*?${escapedSeparator}`
+    )
+    const match = description.match(blockRegex)
+    if (match) return match[1]
+  }
+
   const match = description.match(/Visio:\s*(https?:\/\/[^\s]+)/)
   return match ? match[1] : null
 }
@@ -87,7 +107,23 @@ const VISIO_LINE_REGEX = /^Visio:\s*https?:\/\/\S+$/
 export function removeVideoConferenceFromDescription(
   description: string
 ): string {
-  const lines = description.split('\n')
-  const filtered = lines.filter(line => !VISIO_LINE_REGEX.test(line.trim()))
-  return filtered.join('\n').trimEnd()
+  if (description.includes(VISIO_BLOCK_SEPARATOR)) {
+    const escapedSeparator = VISIO_BLOCK_SEPARATOR.replace(
+      /[-/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    )
+    const regex = new RegExp(
+      `\\n*${escapedSeparator}[\\s\\S]*?${escapedSeparator}\\n*`,
+      'g'
+    )
+    const result = description.replace(regex, '\n').trimEnd()
+    // Fallback old format just in case
+    const lines = result.split('\n')
+    const filtered = lines.filter(line => !VISIO_LINE_REGEX.test(line.trim()))
+    return filtered.join('\n').trimEnd()
+  } else {
+    const lines = description.split('\n')
+    const filtered = lines.filter(line => !VISIO_LINE_REGEX.test(line.trim()))
+    return filtered.join('\n').trimEnd()
+  }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1069

### Result:

#### In Twake Calendar:

<img width="570" height="401" alt="image" src="https://github.com/user-attachments/assets/59de7084-e383-4487-8b31-19abdf39f7a1" />

#### In other calendar app:

<img width="554" height="499" alt="image" src="https://github.com/user-attachments/assets/b537eb6c-6e86-4024-b869-4b80802dccff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video-conference details now appear in a structured, localized section when creating or updating events.
  * Added localized “Join Visio” and editing guidance in English, French, Russian, and Vietnamese.

* **Improvements**
  * Event descriptions no longer display video-conference details in previews or editing forms.
  * Existing and legacy video-conference sections are handled consistently when events are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->