### PR TITLE
#1187 change translation in ru of public calendar footer

### DIFF
--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -539,11 +539,11 @@
   },
   "publicLayout": {
     "logoAlt": "Twake Calendar",
-    "title": "Публичный календарь от Twake Calendar.",
-    "useSubjectTo": "Использование вами регулируется",
-    "privacyPolicy": "Политикой конфиденциальности Twake",
+    "title": "Публичный календарь Twake Calendar.",
+    "useSubjectTo": "Используя этот календарь, вы соглашаетесь с",
+    "privacyPolicy": "Политикой конфиденциальности",
     "and": "и",
-    "termsOfService": "Условиями обслуживания",
+    "termsOfService": "Условиями использования Twake",
     "dot": "."
   }
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Russian text on the public calendar page.
  * Improved wording for privacy policy and terms of use references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->