### PR TITLE
[#1190] Gate attachment section in event display modal

### DIFF
--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -144,7 +144,9 @@ export const EventDescriptionRow: React.FC<{
   const displayedDescription = removeVideoConferenceFromDescription(
     description ?? ''
   )
-  if (!(displayedDescription || !!attach?.length)) return null
+  const showAttachments =
+    window.ENABLE_EVENT_ATTACHMENTS === true && !!attach?.length
+  if (!(displayedDescription || showAttachments)) return null
 
   return (
     <BaseEventRow
@@ -153,8 +155,8 @@ export const EventDescriptionRow: React.FC<{
       icon={<SubjectIcon />}
       text={displayedDescription}
       content={
-        attach &&
-        attach.length > 0 && <AttachementPreview attachments={attach} />
+        showAttachments &&
+        attach && <AttachementPreview attachments={attach} />
       }
     />
   )

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -155,8 +155,7 @@ export const EventDescriptionRow: React.FC<{
       icon={<SubjectIcon />}
       text={displayedDescription}
       content={
-        showAttachments &&
-        attach && <AttachementPreview attachments={attach} />
+        showAttachments && attach && <AttachementPreview attachments={attach} />
       }
     />
   )

--- a/common/src/window.d.ts
+++ b/common/src/window.d.ts
@@ -49,6 +49,8 @@ declare global {
 
     BOOKING_LINK_ENABLED: boolean | undefined
 
+    ENABLE_EVENT_ATTACHMENTS: boolean | undefined
+
     ASK_FOR_TZ_UPDATE: boolean
 
     TOOLTIP_DELAY_MS: number

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -41,3 +41,5 @@ var TOOLTIP_DELAY_MS = 2000
 var HIDE_LANGUAGE_SELECTOR = false
 // Exposes the booking link section in the left bar. Defaults to false.
 var BOOKING_LINK_ENABLED = false
+// Displays the attachments section in the event display modal. Defaults to false.
+var ENABLE_EVENT_ATTACHMENTS = false


### PR DESCRIPTION
Closes #1190

## Problem

The attachments section in the event display modal was always rendered. It should be gated behind an `env.js` flag that defaults to `false`, so the section only shows when explicitly enabled.

## Change

- Added a new runtime flag `ENABLE_EVENT_ATTACHMENTS` (typed in `window.d.ts`, documented in `.env.example.js`), defaulting to `false`.
- `EventDescriptionRow` now only renders the `AttachementPreview` when `window.ENABLE_EVENT_ATTACHMENTS === true`. The row is still shown when there is a description; attachments alone no longer force it to appear unless the flag is enabled.

This follows the existing pattern used for other opt-in flags such as `BOOKING_LINK_ENABLED`.

---
*Generated automatically*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control whether event attachments appear in the event details view.
  * Attachments are displayed only when enabled and available.
* **Bug Fixes**
  * Improved event detail rendering so descriptions remain visible independently of attachment settings.
* **Documentation**
  * Documented the new attachment display setting and its default disabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->