### PR TITLE
[#1191] Filter out attachments rendered without a filename

### DIFF
--- a/__test__/components/AttachementPreview.test.tsx
+++ b/__test__/components/AttachementPreview.test.tsx
@@ -16,7 +16,9 @@ jest.mock(
       attachment
     }: {
       attachment: { x_filename?: string; uri: string }
-    }) => <div data-testid="chip">{attachment.x_filename ?? attachment.uri}</div>
+    }) => (
+      <div data-testid="chip">{attachment.x_filename ?? attachment.uri}</div>
+    )
   })
 )
 

--- a/__test__/components/AttachementPreview.test.tsx
+++ b/__test__/components/AttachementPreview.test.tsx
@@ -1,0 +1,51 @@
+import { AttachementPreview } from '@common/components/EventPreview/AttachementPreview'
+import { Attachment } from '@common/types/Attachment'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+jest.mock('twake-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+jest.mock(
+  '@common/components/EventPreview/AttachementPreview/AttachementChip',
+  () => ({
+    AttachementChip: ({
+      attachment
+    }: {
+      attachment: { x_filename?: string; uri: string }
+    }) => <div data-testid="chip">{attachment.x_filename ?? attachment.uri}</div>
+  })
+)
+
+describe('AttachementPreview', () => {
+  it('filters out attachments rendered without a filename', () => {
+    render(
+      <AttachementPreview
+        attachments={[
+          new Attachment('https://example.com/doc.pdf', undefined, 'doc.pdf'),
+          new Attachment('CID:664DD99135B2AF428B97493A660B458C@ugap.fr')
+        ]}
+      />
+    )
+
+    const chips = screen.getAllByTestId('chip')
+    expect(chips).toHaveLength(1)
+    expect(chips[0]).toHaveTextContent('doc.pdf')
+  })
+
+  it('renders nothing when no attachment has a filename', () => {
+    const { container } = render(
+      <AttachementPreview
+        attachments={[
+          new Attachment('CID:664DD99135B2AF428B97493A660B458C@ugap.fr'),
+          new Attachment('CID:other@ugap.fr', undefined, '   ')
+        ]}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/common/src/components/EventPreview/AttachementPreview/index.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/index.tsx
@@ -16,7 +16,13 @@ export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
   const { t } = useI18n()
   const [showAllAttachments, setShowAllAttachments] = useState(false)
 
-  if (!attachments?.length) {
+  // Attachments positioned by third party clients (e.g. inline CID references)
+  // carry no filename and would render as an empty, broken chip: filter them out.
+  const displayableAttachments = attachments?.filter(attachment =>
+    attachment.hasDisplayableFilename()
+  )
+
+  if (!displayableAttachments?.length) {
     return null
   }
 
@@ -24,8 +30,11 @@ export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
     <Box
       sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, alignItems: 'center' }}
     >
-      {renderAttachments({ attachments, slice: 'first' })}
-      {attachments.length > ATTACHMENT_DISPLAY_LIMIT && (
+      {renderAttachments({
+        attachments: displayableAttachments,
+        slice: 'first'
+      })}
+      {displayableAttachments.length > ATTACHMENT_DISPLAY_LIMIT && (
         <Button
           variant="text"
           size="small"
@@ -37,7 +46,11 @@ export const AttachementPreview: React.FC<AttachementPreviewProps> = ({
             : t('eventPreview.showMore')}
         </Button>
       )}
-      {showAllAttachments && renderAttachments({ attachments, slice: 'rest' })}
+      {showAllAttachments &&
+        renderAttachments({
+          attachments: displayableAttachments,
+          slice: 'rest'
+        })}
     </Box>
   )
 }

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -144,8 +144,11 @@ export const EventDescriptionRow: React.FC<{
   const displayedDescription = removeVideoConferenceFromDescription(
     description ?? ''
   )
+  const displayableAttach = attach?.filter(attachment =>
+    attachment.hasDisplayableFilename()
+  )
   const showAttachments =
-    window.ENABLE_EVENT_ATTACHMENTS === true && !!attach?.length
+    window.ENABLE_EVENT_ATTACHMENTS === true && !!displayableAttach?.length
   if (!(displayedDescription || showAttachments)) return null
 
   return (
@@ -155,7 +158,9 @@ export const EventDescriptionRow: React.FC<{
       icon={<SubjectIcon />}
       text={displayedDescription}
       content={
-        showAttachments && attach && <AttachementPreview attachments={attach} />
+        showAttachments && displayableAttach && (
+          <AttachementPreview attachments={displayableAttach} />
+        )
       }
     />
   )

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -158,7 +158,8 @@ export const EventDescriptionRow: React.FC<{
       icon={<SubjectIcon />}
       text={displayedDescription}
       content={
-        showAttachments && displayableAttach && (
+        showAttachments &&
+        displayableAttach && (
           <AttachementPreview attachments={displayableAttach} />
         )
       }

--- a/common/src/types/Attachment.ts
+++ b/common/src/types/Attachment.ts
@@ -7,6 +7,10 @@ export class Attachment {
     public x_filename?: string
   ) {}
 
+  hasDisplayableFilename(): boolean {
+    return !!this.x_filename?.trim()
+  }
+
   asJcal(): VObjectProperty {
     const params: Record<string, string> = {}
     if (this.fmttype) params['fmttype'] = this.fmttype


### PR DESCRIPTION
Closes #1191

## Problem

Some external events carry attachments positioned by third party clients as inline `CID` references, e.g.:

```
ATTACH:CID:664DD99135B2AF428B97493A660B458C@ugap.fr
```

These attachments have no `x-filename` parameter (and no HTTP-fetchable URI), so the event preview rendered them as an empty, broken chip — an icon with no label and no working link.

## Fix

Filter out attachments that would be rendered without a filename before displaying them in the event preview:

- Added `Attachment.hasDisplayableFilename()` which returns `true` only when a non-blank `x-filename` is present.
- `AttachementPreview` now skips non-displayable attachments (and renders nothing when none remain).
- `EventDescriptionRow` uses the same predicate so the description/attachment row is not shown for an event whose only attachments are non-displayable.

Attachments are only filtered from the *rendering*; the underlying event data is untouched, so nothing is lost on round-trip. The edit form already filtered non-HTTP URIs via `isSafeHttpUrl`, so this aligns the preview with that behaviour.

## Tests

Added `__test__/components/AttachementPreview.test.tsx` covering:
- an event with one named attachment and one CID attachment renders only the named one,
- an event whose attachments all lack a filename renders nothing.

---
*Generated automatically*
1190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Attachments without a usable filename are no longer displayed in event previews.
  * Empty attachment previews are now hidden when no displayable attachments remain.
  * “Show more/less” behavior now counts and displays only valid attachments.

* **Tests**
  * Added coverage for filtering unnamed attachments and rendering empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->