### PR TITLE
[#1191] Filter out broken attachments rendered without a filename

### DIFF
--- a/__test__/types/Attachment.test.ts
+++ b/__test__/types/Attachment.test.ts
@@ -1,0 +1,27 @@
+import { Attachment } from '@common/types/Attachment'
+
+describe('Attachment', () => {
+  describe('isDisplayable', () => {
+    it('is displayable when a filename is present', () => {
+      expect(
+        new Attachment(
+          'https://example.com/file',
+          'application/pdf',
+          'report.pdf'
+        ).isDisplayable()
+      ).toBe(true)
+    })
+
+    it('is not displayable without a filename', () => {
+      expect(
+        new Attachment('CID:664DD99135B2AF428B97493A660B458C@ugap.fr').isDisplayable()
+      ).toBe(false)
+    })
+
+    it('is not displayable with an empty filename', () => {
+      expect(
+        new Attachment('https://example.com/file', undefined, '   ').isDisplayable()
+      ).toBe(false)
+    })
+  })
+})

--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -144,7 +144,9 @@ export const EventDescriptionRow: React.FC<{
   const displayedDescription = removeVideoConferenceFromDescription(
     description ?? ''
   )
-  if (!(displayedDescription || !!attach?.length)) return null
+  const displayableAttach =
+    attach?.filter(attachment => attachment.isDisplayable()) ?? []
+  if (!(displayedDescription || displayableAttach.length > 0)) return null
 
   return (
     <BaseEventRow
@@ -153,8 +155,9 @@ export const EventDescriptionRow: React.FC<{
       icon={<SubjectIcon />}
       text={displayedDescription}
       content={
-        attach &&
-        attach.length > 0 && <AttachementPreview attachments={attach} />
+        displayableAttach.length > 0 && (
+          <AttachementPreview attachments={displayableAttach} />
+        )
       }
     />
   )

--- a/common/src/types/Attachment.ts
+++ b/common/src/types/Attachment.ts
@@ -7,6 +7,10 @@ export class Attachment {
     public x_filename?: string
   ) {}
 
+  isDisplayable(): boolean {
+    return Boolean(this.x_filename?.trim())
+  }
+
   asJcal(): VObjectProperty {
     const params: Record<string, string> = {}
     if (this.fmttype) params['fmttype'] = this.fmttype


### PR DESCRIPTION
Closes #1191

## Problem

Third-party clients sometimes positionned `ATTACH` properties on events that only carry a `CID` reference with no filename, e.g.:

```
ATTACH:CID:664DD99135B2AF428B97493A660B458C@ugap.fr
```

In the event preview these were rendered as empty, broken attachment chips (no name, no working link).

## Fix

Only display attachments that actually have a filename. This mirrors the filtering already performed in the edit form (`AttachmentField`, which drops non-safe-URL attachments).

- Added `Attachment.isDisplayable()` (true when a non-empty `x_filename` is present).
- `EventDescriptionRow` now filters attachments through `isDisplayable()` before rendering, and no longer shows the description row solely because of a non-displayable attachment.
- Added unit tests for `Attachment.isDisplayable()`.

---
*Generated automatically*
1190
