### PR TITLE
1189 long name in sidebar improvement

### DIFF
--- a/__test__/components/Calendar.test.tsx
+++ b/__test__/components/Calendar.test.tsx
@@ -148,9 +148,15 @@ describe('CalendarSelection', () => {
     expect(screen.getByText('calendar.delegated')).toBeInTheDocument()
     expect(screen.getByText('calendar.other')).toBeInTheDocument()
 
-    expect(screen.getByLabelText('Calendar personal')).toBeInTheDocument()
-    expect(screen.getByLabelText('Calendar delegated')).toBeInTheDocument()
-    expect(screen.getByLabelText('Calendar shared')).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar personal' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar delegated' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar shared' })
+    ).toBeInTheDocument()
   })
   it('open accordeon when clicking on button only', async () => {
     await act(async () => {
@@ -160,9 +166,15 @@ describe('CalendarSelection', () => {
     expect(screen.getByText('calendar.delegated')).toBeInTheDocument()
     expect(screen.getByText('calendar.other')).toBeInTheDocument()
 
-    expect(screen.getByLabelText('Calendar personal')).toBeInTheDocument()
-    expect(screen.getByLabelText('Calendar delegated')).toBeInTheDocument()
-    expect(screen.getByLabelText('Calendar shared')).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar personal' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar delegated' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar shared' })
+    ).toBeInTheDocument()
 
     const sharedAccordionSummary = screen
       .getByText('calendar.other')
@@ -188,22 +200,36 @@ describe('CalendarSelection', () => {
       renderWithProviders(<CalendarLayout />, preloadedState)
     })
 
-    expect(screen.getByLabelText('Calendar personal')).toBeChecked()
-    expect(screen.getByLabelText('Calendar delegated')).toBeChecked()
-    expect(screen.getByLabelText('Calendar shared')).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar personal' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar delegated' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar shared' })
+    ).toBeChecked()
   })
   it('persist selected calendars in local storage', async () => {
     await act(async () => {
       renderWithProviders(<CalendarLayout />, preloadedState)
     })
 
-    expect(screen.getByLabelText('Calendar personal')).toBeChecked()
-    expect(screen.getByLabelText('Calendar delegated')).not.toBeChecked()
-    expect(screen.getByLabelText('Calendar shared')).not.toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar personal' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar delegated' })
+    ).not.toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar shared' })
+    ).not.toBeChecked()
 
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Calendar personal'))
-      fireEvent.click(screen.getByLabelText('Calendar shared'))
+      fireEvent.click(
+        screen.getByRole('checkbox', { name: 'Calendar personal' })
+      )
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Calendar shared' }))
     })
 
     expect(localStorage.getItem('selectedCalendars')).toBe('["user3/cal1"]')
@@ -389,7 +415,7 @@ describe('calendar Availability search', () => {
       })
     )
 
-    const checkbox = screen.getByLabelText('Calendar personal')
+    const checkbox = screen.getByRole('checkbox', { name: 'Calendar personal' })
     expect(checkbox).toBeChecked()
 
     fireEvent.click(checkbox) // toggle off

--- a/__test__/components/CalendarSelection.test.tsx
+++ b/__test__/components/CalendarSelection.test.tsx
@@ -87,9 +87,15 @@ describe('CalendarSelection', () => {
     expect(screen.getByText('calendar.delegated')).toBeInTheDocument()
     expect(screen.getByText('calendar.other')).toBeInTheDocument()
 
-    expect(screen.getByLabelText('Calendar personal')).toBeChecked()
-    expect(screen.getByLabelText('Calendar delegated')).not.toBeChecked()
-    expect(screen.getByLabelText('Calendar shared')).not.toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar personal' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar delegated' })
+    ).not.toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Calendar shared' })
+    ).not.toBeChecked()
   })
 
   it('does not render resources when HIDE_RESOURCES is true', () => {
@@ -161,7 +167,7 @@ describe('CalendarSelection', () => {
       }
     )
 
-    const checkbox = screen.getByLabelText('Calendar personal')
+    const checkbox = screen.getByRole('checkbox', { name: 'Calendar personal' })
     fireEvent.click(checkbox)
 
     expect(setSelectedCalendars).toHaveBeenCalledWith(expect.any(Function))
@@ -184,7 +190,7 @@ describe('CalendarSelection', () => {
       }
     )
 
-    const checkbox = screen.getByLabelText('Calendar personal')
+    const checkbox = screen.getByRole('checkbox', { name: 'Calendar personal' })
     fireEvent.click(checkbox)
 
     const updater = setSelectedCalendars.mock.calls[0][0]

--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -243,6 +243,9 @@ const BookingLinkChip: React.FC<{
     ? (link.color ?? calendarColor ?? defaultColors[4].dark)
     : theme.palette.grey[400]
 
+  const linkName =
+    link.name || t('booking.durationMinutes', { count: link.durationMinutes })
+
   const handleMenuOpen = (event: React.MouseEvent<HTMLButtonElement>): void => {
     setMenuAnchorEl(event.currentTarget)
   }
@@ -279,32 +282,35 @@ const BookingLinkChip: React.FC<{
             display: 'flex',
             alignItems: 'center',
             maxWidth: 'calc(100% - 40px)',
-            overflow: 'hidden'
+            overflow: 'hidden',
+            cursor: 'pointer'
           }}
         >
           <div style={{ display: 'flex', padding: '9px', marginRight: '4px' }}>
             <EventIcon sx={{ color: iconColor }} fontSize="small" />
           </div>
 
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden'
-            }}
-          >
-            <span
+          <Tooltip title={linkName} enterDelay={500} placement="bottom-start">
+            <div
               style={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontSize: '0.875rem',
-                color: alpha(theme.palette.grey[900], 0.9)
+                display: 'flex',
+                flexDirection: 'column',
+                overflow: 'hidden'
               }}
             >
-              {link.name || `${link.durationMinutes}min`}
-            </span>
-          </div>
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: '0.875rem',
+                  color: alpha(theme.palette.grey[900], 0.9)
+                }}
+              >
+                {linkName}
+              </span>
+            </div>
+          </Tooltip>
         </div>
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <Tooltip title={t('tooltip.copyBookingLink')}>
@@ -752,47 +758,50 @@ const CalendarSelector: React.FC<{
           }
         }}
       >
-        <label
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            maxWidth: 'calc(100% - 40px)',
-            overflow: 'hidden'
-          }}
-        >
-          <Checkbox
-            sx={{
-              color: calendars[id].color?.light,
-              '&.Mui-checked': { color: calendars[id].color?.light }
-            }}
-            size="small"
-            checked={selectedCalendars.includes(id)}
-            onChange={() => handleCalendarToggle(id)}
-            slotProps={{ input: { 'aria-label': displayName } }}
-          />
-          <div
+        <Tooltip title={displayName} enterDelay={500} placement="bottom-start">
+          <label
             style={{
               display: 'flex',
-              flexDirection: 'column',
-              overflow: 'hidden',
-              padding: showCaption ? '6px' : undefined
+              alignItems: 'center',
+              maxWidth: 'calc(100% - 40px)',
+              overflow: 'hidden'
             }}
           >
-            <span
+            <Checkbox
+              sx={{
+                color: calendars[id].color?.light,
+                '&.Mui-checked': { color: calendars[id].color?.light }
+              }}
+              size="small"
+              checked={selectedCalendars.includes(id)}
+              onChange={() => handleCalendarToggle(id)}
+              slotProps={{ input: { 'aria-label': displayName } }}
+            />
+            <div
               style={{
+                display: 'flex',
+                flexDirection: 'column',
                 overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                overflowWrap: 'break-word'
+                padding: showCaption ? '6px' : undefined
               }}
             >
-              {displayName}
-            </span>
-            <OwnerCaption
-              showCaption={showCaption}
-              ownerDisplayName={ownerDisplayName ?? ''}
-            />
-          </div>
-        </label>
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  overflowWrap: 'break-word',
+                  whiteSpace: 'nowrap'
+                }}
+              >
+                {displayName}
+              </span>
+              <OwnerCaption
+                showCaption={showCaption}
+                ownerDisplayName={ownerDisplayName ?? ''}
+              />
+            </div>
+          </label>
+        </Tooltip>
         {!isMobile && (
           <IconButton className="MoreBtn" onClick={handleClick}>
             <MoreHorizIcon />

--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -285,6 +285,7 @@ const BookingLinkChip: React.FC<{
             overflow: 'hidden',
             cursor: 'pointer'
           }}
+          onClick={() => onEdit(link)}
         >
           <div style={{ display: 'flex', padding: '9px', marginRight: '4px' }}>
             <EventIcon sx={{ color: iconColor }} fontSize="small" />


### PR DESCRIPTION
resolves #1189 & triggers edit modal for booking on clicking on name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Booking link chips now prefer custom link names when available, falling back to duration text when needed.
  * Booking link tooltips and calendar selection tooltips provide clearer, full-name context.
  * Enhanced label layout with improved wrapping and ellipsis behavior for long names.
* **Tests**
  * Updated calendar selection tests to use checkbox role/name queries for more reliable accessibility-based assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->