### PR TITLE
#1186 remove double scrollbar in create event modal

### DIFF
--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -193,6 +193,7 @@ function ResponsiveDialog({
       transitionDuration={isExpanded ? 0 : 300}
       sx={
         [
+          { '& .MuiDialog-paper': { overflowY: 'hidden' } },
           ...(baseSx ? [baseSx] : []),
           ...(Array.isArray(sx) ? (sx as SxProps<Theme>[]) : sx ? [sx] : [])
         ] as SxProps<Theme>


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary vertical scrolling within responsive dialog content for a cleaner viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->