### PR TITLE
[#1201] Use RFC 5545 duration format for alarm triggers

### DIFF
--- a/__test__/utils/normalizeAlarmTrigger.test.ts
+++ b/__test__/utils/normalizeAlarmTrigger.test.ts
@@ -1,0 +1,52 @@
+import { VAlarm } from '@common/types/VAlarm'
+import { normalizeAlarmTrigger } from '@common/utils/normalizeAlarmTrigger'
+
+describe('normalizeAlarmTrigger', () => {
+  it('moves week durations out of the time part', () => {
+    expect(normalizeAlarmTrigger('-PT1W')).toBe('-P1W')
+  })
+
+  it('moves day durations out of the time part', () => {
+    expect(normalizeAlarmTrigger('-PT1D')).toBe('-P1D')
+    expect(normalizeAlarmTrigger('-PT2D')).toBe('-P2D')
+  })
+
+  it('keeps already standard durations', () => {
+    expect(normalizeAlarmTrigger('-P1W')).toBe('-P1W')
+    expect(normalizeAlarmTrigger('-P2D')).toBe('-P2D')
+  })
+
+  it('keeps time based durations', () => {
+    expect(normalizeAlarmTrigger('-PT15M')).toBe('-PT15M')
+    expect(normalizeAlarmTrigger('-PT12H')).toBe('-PT12H')
+    expect(normalizeAlarmTrigger('PT30S')).toBe('PT30S')
+  })
+
+  it('keeps absolute date-time triggers', () => {
+    expect(normalizeAlarmTrigger('20260723T100000Z')).toBe('20260723T100000Z')
+  })
+
+  it('keeps empty triggers', () => {
+    expect(normalizeAlarmTrigger('')).toBe('')
+  })
+})
+
+describe('VAlarm', () => {
+  it('normalizes the trigger it is built with', () => {
+    expect(new VAlarm({ trigger: '-PT1W', action: 'EMAIL' }).trigger).toBe(
+      '-P1W'
+    )
+  })
+
+  it('normalizes the trigger of a deserialized alarm', () => {
+    expect(VAlarm.fromJSON({ trigger: '-PT2D', action: 'EMAIL' }).trigger).toBe(
+      '-P2D'
+    )
+  })
+
+  it('serializes the normalized trigger to jCal', () => {
+    const [, props] = new VAlarm({ trigger: '-PT1W', action: 'EMAIL' }).asJcal()
+
+    expect(props).toContainEqual(['trigger', {}, 'duration', '-P1W'])
+  })
+})

--- a/common/src/components/Event/fields/NotificationField.tsx
+++ b/common/src/components/Event/fields/NotificationField.tsx
@@ -24,9 +24,9 @@ const PREDEFINED_VALUES = [
   '-PT2H',
   '-PT5H',
   '-PT12H',
-  '-PT1D',
-  '-PT2D',
-  '-PT1W'
+  '-P1D',
+  '-P2D',
+  '-P1W'
 ]
 
 export interface NotificationFieldProps {

--- a/common/src/types/VAlarm.ts
+++ b/common/src/types/VAlarm.ts
@@ -3,6 +3,7 @@ import {
   VObjectProperty
 } from '@common/features/Calendars/types/CalendarData'
 import { userAttendee } from '@common/features/User/models/attendee'
+import { normalizeAlarmTrigger } from '@common/utils/normalizeAlarmTrigger'
 
 export const DEFAULT_ALARM_DESCRIPTION =
   'This is an automatic alarm sent by Twake Calendar'
@@ -23,7 +24,7 @@ export class VAlarm implements AlarmData {
   description?: string
 
   constructor({ trigger, action, attendees, summary, description }: AlarmData) {
-    this.trigger = trigger
+    this.trigger = normalizeAlarmTrigger(trigger)
     this.action = action
     this.attendees = attendees
     this.summary = summary

--- a/common/src/utils/normalizeAlarmTrigger.ts
+++ b/common/src/utils/normalizeAlarmTrigger.ts
@@ -1,0 +1,14 @@
+/**
+ * In RFC 5545 durations, the `T` designator only introduces time components
+ * (hours, minutes, seconds). Weeks and days belong to the date part, so a one
+ * week reminder is `-P1W`, not `-PT1W`.
+ *
+ * Triggers stored with the misplaced designator are normalized back to the
+ * standard form. Anything else (absolute date-time triggers, time based
+ * durations) is returned untouched.
+ */
+const MISPLACED_TIME_DESIGNATOR = /^([+-]?)PT(\d+[WD])$/i
+
+export function normalizeAlarmTrigger(trigger: string): string {
+  return trigger.replace(MISPLACED_TIME_DESIGNATOR, '$1P$2')
+}


### PR DESCRIPTION
Closes #1201

## Problem

Creating an event with a "1 week" notification produced a `TRIGGER` of `-PT1W` in the PUT payload. In RFC 5545 (and ISO 8601) durations the `T` designator only introduces *time* components (hours, minutes, seconds); weeks and days belong to the date part. The correct value is `-P1W`.

The same mistake affected the "1 day" and "2 days" entries (`-PT1D`, `-PT2D`).

## Fix

- `NotificationField`: the predefined triggers now use `-P1D`, `-P2D`, `-P1W`. Time based values (`-PT15M`, `-PT12H`, ...) were already correct and are unchanged.
- New `normalizeAlarmTrigger` util, applied in the `VAlarm` constructor: a trigger of the form `-PTnW` / `-PTnD` is rewritten to `-PnW` / `-PnD`. Since every alarm (form input, jCal parsing, session storage deserialization) goes through that constructor, alarms already stored with the invalid format are displayed as the matching predefined value and corrected the next time the event is saved. Absolute date-time triggers and time based durations pass through untouched.

`translateDuration` already accepted both spellings, so the displayed labels are unchanged.

## Tests

Added `__test__/utils/normalizeAlarmTrigger.test.ts` covering the normalization cases and the `VAlarm` constructor / `fromJSON` / `asJcal` path.

Note: I could not run the suite in this environment (node v12, no `node_modules` installable here) — CI will exercise it.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected alarm trigger formatting for day- and week-based reminders.
  * Preserved existing time-based and date-time alarm triggers during serialization.
  * Ensured alarms consistently retain normalized trigger values when created or loaded.

* **New Features**
  * Added day- and week-based reminder options, including one-day, two-day, and one-week durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->