### PR TITLE
#1161 implement button open chat in contact card

### DIFF
--- a/__test__/components/AttendeePopover.public.test.tsx
+++ b/__test__/components/AttendeePopover.public.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../utils/Renderwithproviders'
+import { AttendeePopover } from '@common/components/Attendees/AttendeePopover'
+import { userAttendee } from '@common/features/User/models/attendee'
+
+describe('AttendeePopover (Public)', () => {
+  beforeEach(() => {
+    window.MAIL_SPA_URL = 'https://mail.example.com'
+  })
+
+  it('uses public mail-only AttendeeActions implementation', () => {
+    const attendee = new userAttendee({
+      cal_address: 'john@example.com',
+      cn: 'John Doe'
+    })
+
+    renderWithProviders(
+      <AttendeePopover attendee={attendee}>
+        <span>Open Popover</span>
+      </AttendeePopover>,
+      {
+        user: {
+          userData: {
+            email: 'user@example.com',
+            workplaceFqdn: 'example.com'
+          }
+        }
+      }
+    )
+
+    const trigger = screen.getByText('Open Popover')
+    fireEvent.click(trigger)
+
+    // Should render mail action button
+    expect(screen.getByText('attendees.sendMail')).toBeInTheDocument()
+
+    // Should NOT render chat or create event buttons present only in private AttendeeActions
+    expect(screen.queryByText(/tooltip\.openChat/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/tooltip\.createEventWithAttendee/)
+    ).not.toBeInTheDocument()
+  })
+})

--- a/__test__/components/AttendeePopover.test.tsx
+++ b/__test__/components/AttendeePopover.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../utils/Renderwithproviders'
+import { AttendeePopover } from '@common/components/Attendees/AttendeePopover'
+import { userAttendee } from '@common/features/User/models/attendee'
+
+describe('AttendeePopover (Private)', () => {
+  beforeEach(() => {
+    window.MAIL_SPA_URL = 'https://mail.example.com'
+  })
+
+  it('uses private AttendeeActions implementation with chat and create event actions', () => {
+    const attendee = new userAttendee({
+      cal_address: 'john@example.com',
+      cn: 'John Doe'
+    })
+
+    renderWithProviders(
+      <AttendeePopover attendee={attendee}>
+        <span>Open Popover</span>
+      </AttendeePopover>,
+      {
+        user: {
+          userData: {
+            email: 'user@example.com',
+            workplaceFqdn: 'example.com'
+          }
+        }
+      }
+    )
+
+    const trigger = screen.getByText('Open Popover')
+    fireEvent.click(trigger)
+
+    // Should render mail action button
+    expect(screen.getByText('attendees.sendMail')).toBeInTheDocument()
+
+    // Should render create event action button present in private AttendeeActions
+    expect(
+      screen.getByLabelText(
+        'tooltip.createEventWithAttendee(attendee=John Doe)'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/private/injectedAliases.ts
+++ b/apps/private/injectedAliases.ts
@@ -5,4 +5,6 @@
  * 1. Create your custom implementation under `src/` (e.g. `src/components/MyCustomComponent.tsx`).
  * 2. Add the path relative to `src/` into the array below (e.g. `'components/MyCustomComponent'`).
  */
-export const injectedAliases: string[] = []
+export const injectedAliases: string[] = [
+  'components/Attendees/AttendeeActions'
+]

--- a/apps/private/package.json
+++ b/apps/private/package.json
@@ -20,7 +20,8 @@
     "react-router-dom": "^6.23.1",
     "redux-first-history": "^5.2.0",
     "twake-i18n": "^0.3.0",
-    "@fullcalendar/core": "^6.1.17"
+    "@fullcalendar/core": "^6.1.17",
+    "@linagora/twake-icons": "^2.7.0"
   },
   "scripts": {
     "start": "PORT=5000 rsbuild dev",

--- a/apps/private/src/components/Attendees/AttendeeActions.tsx
+++ b/apps/private/src/components/Attendees/AttendeeActions.tsx
@@ -1,0 +1,134 @@
+import { Box, Button, IconButton, useTheme, alpha } from '@linagora/twake-mui'
+import { Icon, CalendarToday, EmailOpen, Discuss } from '@linagora/twake-icons'
+import { useI18n } from 'twake-i18n'
+import { useNavigate } from 'react-router-dom'
+import { useAppSelector } from '@common/app/hooks'
+import { resolveMailSpaUrl } from '@common/utils/mailUrlUtils'
+import { resolveChatSpaUrl } from '@common/utils/chatUrlUtils'
+import { Tooltip } from '@common/components/Tooltip'
+import { useCheckInternalUser } from './useCheckInternalUser'
+import { userAttendee } from '@common/features/User/models/attendee'
+
+const getUserNameFromEmail = (email: string | undefined): string => {
+  return email?.split('@')[0] || ''
+}
+
+export function AttendeeActions({
+  attendee
+}: {
+  attendee: userAttendee
+}): JSX.Element {
+  const { t } = useI18n()
+  const theme = useTheme()
+  const navigate = useNavigate()
+
+  const workplaceFqdn = useAppSelector(
+    state => state.user.userData?.workplaceFqdn
+  )
+  const userEmail = useAppSelector(state => state.user.userData?.email)
+
+  const mailSpaUrl = resolveMailSpaUrl({
+    localpart: getUserNameFromEmail(userEmail),
+    workplaceFqdn
+  })
+
+  const chatSpaUrl = resolveChatSpaUrl({
+    localpart: getUserNameFromEmail(userEmail),
+    workplaceFqdn,
+    target: getUserNameFromEmail(attendee.cal_address)
+  })
+
+  const { isInternalUser, loading } = useCheckInternalUser(
+    attendee.cal_address,
+    chatSpaUrl
+  )
+
+  const handleSendMail = (): void => {
+    if (!mailSpaUrl) return
+    window.open(
+      `${mailSpaUrl}/mailto/?uri=${encodeURIComponent(attendee.asMailto())}`,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  }
+
+  const handleOpenChat = (): void => {
+    if (!chatSpaUrl) return
+    window.open(chatSpaUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        mt: 1,
+        alignItems: 'center'
+      }}
+    >
+      {mailSpaUrl && (
+        <Button
+          variant="outlined"
+          startIcon={<Icon icon={EmailOpen} size={18} />}
+          onClick={handleSendMail}
+          sx={{
+            borderRadius: 6,
+            textTransform: 'none',
+            borderColor: 'divider',
+            color: alpha(theme.palette.grey[900], 0.9)
+          }}
+        >
+          {t('attendees.sendMail')}
+        </Button>
+      )}
+      {chatSpaUrl && (
+        <Tooltip
+          title={
+            !isInternalUser
+              ? t('tooltip.cannotOpenChatExternalUser')
+              : t('tooltip.openChat', { attendee: attendee.cn })
+          }
+        >
+          <Box component="span" sx={{ display: 'inline-flex' }}>
+            <IconButton
+              onClick={handleOpenChat}
+              sx={{
+                border: '1px solid',
+                borderColor: 'divider',
+                borderRadius: '50%',
+                padding: 1,
+                color: alpha(theme.palette.grey[900], 0.9)
+              }}
+              size="small"
+              disabled={!isInternalUser || loading}
+              loading={loading}
+            >
+              <Icon icon={Discuss} size={20} />
+            </IconButton>
+          </Box>
+        </Tooltip>
+      )}
+      <Tooltip
+        title={t('tooltip.createEventWithAttendee', { attendee: attendee.cn })}
+      >
+        <IconButton
+          onClick={() => {
+            navigate(
+              `/newEvent?attendee=${encodeURIComponent(attendee.cal_address)}`
+            )
+          }}
+          sx={{
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: '50%',
+            padding: 1,
+            color: alpha(theme.palette.grey[900], 0.9)
+          }}
+          size="small"
+        >
+          <Icon icon={CalendarToday} size={20} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  )
+}

--- a/apps/private/src/components/Attendees/useCheckInternalUser.ts
+++ b/apps/private/src/components/Attendees/useCheckInternalUser.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { searchPeople } from '@common/features/User/UserDao'
+
+export function useCheckInternalUser(
+  email: string | undefined,
+  chatSpaUrl: string | null
+): { isInternalUser: boolean; loading: boolean } {
+  const [isInternalUser, setIsInternalUser] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    let cancelled = false
+    const checkUser = async (): Promise<void> => {
+      if (!email || !chatSpaUrl) {
+        setIsInternalUser(false)
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+
+      let internalUser = false
+      try {
+        const res = await searchPeople(email, ['user'])
+        internalUser = res.length > 0
+      } catch (e) {
+        console.error('Error checking internal user:', e)
+      }
+
+      if (!cancelled) {
+        setIsInternalUser(internalUser)
+        setLoading(false)
+      }
+    }
+    void checkUser()
+
+    return (): void => {
+      cancelled = true
+    }
+  }, [email, chatSpaUrl])
+
+  return { isInternalUser, loading }
+}

--- a/apps/private/tsconfig.json
+++ b/apps/private/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@common/*": ["../../common/src/*"],
-      "@injected/*": ["../../common/src/*"]
+      "@injected/*": ["./src/*"]
     }
   },
   "include": ["src", "../../common/**/**.d.ts"],

--- a/apps/public/injectedAliases.ts
+++ b/apps/public/injectedAliases.ts
@@ -5,4 +5,6 @@
  * 1. Create your custom implementation under `src/` (e.g. `src/components/MyCustomComponent.tsx`).
  * 2. Add the path relative to `src/` into the array below (e.g. `'components/MyCustomComponent'`).
  */
-export const injectedAliases: string[] = []
+export const injectedAliases: string[] = [
+  'components/Attendees/AttendeeActions'
+]

--- a/apps/public/package.json
+++ b/apps/public/package.json
@@ -17,7 +17,8 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.23.1",
     "redux-first-history": "^5.2.0",
-    "twake-i18n": "^0.3.0"
+    "twake-i18n": "^0.3.0",
+    "@linagora/twake-icons": "^2.7.0"
   },
   "scripts": {
     "start": "PORT=5001 rsbuild dev",

--- a/apps/public/src/components/Attendees/AttendeeActions.tsx
+++ b/apps/public/src/components/Attendees/AttendeeActions.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, useTheme, alpha } from '@linagora/twake-mui'
+import { Icon, EmailOpen } from '@linagora/twake-icons'
+import { useI18n } from 'twake-i18n'
+import { useAppSelector } from '@common/app/hooks'
+import { resolveMailSpaUrl } from '@common/utils/mailUrlUtils'
+import { userAttendee } from '@common/features/User/models/attendee'
+
+const getUserNameFromEmail = (email: string | undefined): string => {
+  return email?.split('@')[0] || ''
+}
+
+export function AttendeeActions({
+  attendee
+}: {
+  attendee: userAttendee
+}): JSX.Element {
+  const { t } = useI18n()
+  const theme = useTheme()
+
+  const workplaceFqdn = useAppSelector(
+    state => state.user.userData?.workplaceFqdn
+  )
+  const userEmail = useAppSelector(state => state.user.userData?.email)
+
+  const mailSpaUrl = resolveMailSpaUrl({
+    localpart: getUserNameFromEmail(userEmail),
+    workplaceFqdn
+  })
+
+  const handleSendMail = (): void => {
+    if (!mailSpaUrl) return
+    window.open(
+      `${mailSpaUrl}/mailto/?uri=${encodeURIComponent(
+        `mailto:${attendee.cal_address}`
+      )}`,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        mt: 1,
+        alignItems: 'center'
+      }}
+    >
+      {mailSpaUrl && (
+        <Button
+          variant="outlined"
+          startIcon={<Icon icon={EmailOpen} size={18} />}
+          onClick={handleSendMail}
+          sx={{
+            borderRadius: 6,
+            textTransform: 'none',
+            borderColor: 'divider',
+            color: alpha(theme.palette.grey[900], 0.9)
+          }}
+        >
+          {t('attendees.sendMail')}
+        </Button>
+      )}
+    </Box>
+  )
+}

--- a/apps/public/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/apps/public/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -111,8 +111,7 @@ export function EventPreviewAttendees({
           key: 'organizer',
           t,
           isFull: true,
-          isOrganizer: true,
-          isPublic: true
+          isOrganizer: true
         })}
       {attendeesWithoutOrganizer.map((a, idx) =>
         renderAttendeeBadge({
@@ -120,8 +119,7 @@ export function EventPreviewAttendees({
           key: `participant-${idx}`,
           t,
           isFull: true,
-          isOrganizer: false,
-          isPublic: true
+          isOrganizer: false
         })
       )}
     </Box>
@@ -144,8 +142,7 @@ export function EventPreviewAttendees({
           key: `resource-${idx}`,
           t,
           isFull: true,
-          isOrganizer: false,
-          isPublic: true
+          isOrganizer: false
         })
       )}
     </Box>

--- a/apps/public/src/components/EventPreview/EventPreviewDetails.tsx
+++ b/apps/public/src/components/EventPreview/EventPreviewDetails.tsx
@@ -63,8 +63,7 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
           key: 'org',
           t,
           isFull: true,
-          isOrganizer: true,
-          isPublic: true
+          isOrganizer: true
         })}
 
       {shouldShowAttendeesSection && (

--- a/apps/public/tsconfig.json
+++ b/apps/public/tsconfig.json
@@ -7,7 +7,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@common/*": ["../../common/src/*"],
-      "@injected/*": ["../../common/src/*"]
+      "@injected/*": ["./src/*"]
     }
   },
   "include": ["src", "../../common/**/**.d.ts"],

--- a/common/src/components/Attendees/AttendeePopover.tsx
+++ b/common/src/components/Attendees/AttendeePopover.tsx
@@ -2,7 +2,6 @@ import { userAttendee } from '@common/features/User/models/attendee'
 import {
   Avatar,
   Box,
-  Button,
   IconButton,
   Typography,
   Popper,
@@ -13,19 +12,17 @@ import {
 import { ClickAwayListener } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined'
-import { Icon, CalendarToday, EmailOpen } from '@linagora/twake-icons'
 import React, { useState } from 'react'
 import { useI18n } from 'twake-i18n'
-import { useAppSelector } from '@common/app/hooks'
-import { resolveMailSpaUrl } from '@common/utils/mailUrlUtils'
 import { Tooltip } from '../Tooltip'
 import { stringAvatar } from '../Event/utils/eventUtils'
 import { SnackbarAlert } from '../Loading/SnackBarAlert'
+import { AttendeeActions } from '@injected/components/Attendees/AttendeeActions'
+import { useAppSelector } from '@common/app/hooks'
 
 interface AttendeePopoverProps {
   attendee: userAttendee
   children: React.ReactElement
-  isPublic?: boolean
 }
 
 function AttendeeInfo({ attendee }: { attendee: userAttendee }): JSX.Element {
@@ -75,90 +72,9 @@ function AttendeeInfo({ attendee }: { attendee: userAttendee }): JSX.Element {
   )
 }
 
-function AttendeeActions({
-  attendee,
-  isPublic
-}: {
-  attendee: userAttendee
-  isPublic?: boolean
-}): JSX.Element {
-  const { t } = useI18n()
-  const theme = useTheme()
-
-  const workplaceFqdn = useAppSelector(
-    state => state.user.userData?.workplaceFqdn
-  )
-  const userEmail = useAppSelector(state => state.user.userData?.email)
-  const mailSpaUrl = resolveMailSpaUrl({
-    localpart: userEmail?.split('@')[0],
-    workplaceFqdn
-  })
-
-  const handleSendMail = (): void => {
-    if (!mailSpaUrl) return
-    window.open(
-      `${mailSpaUrl}/mailto/?uri=${encodeURIComponent(
-        `mailto:${attendee.cal_address}`
-      )}`,
-      '_blank',
-      'noopener,noreferrer'
-    )
-  }
-
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        gap: 1,
-        mt: 1,
-        alignItems: 'center'
-      }}
-    >
-      {mailSpaUrl && (
-        <Button
-          variant="outlined"
-          startIcon={<Icon icon={EmailOpen} size={18} />}
-          onClick={handleSendMail}
-          sx={{
-            borderRadius: 6,
-            textTransform: 'none',
-            borderColor: 'divider',
-            color: alpha(theme.palette.grey[900], 0.9)
-          }}
-        >
-          {t('attendees.sendMail')}
-        </Button>
-      )}
-      {!isPublic && (
-        <Tooltip title={t('tooltip.createEvent')}>
-          <IconButton
-            onClick={() => {
-              window.open(
-                `/newEvent?attendee=${encodeURIComponent(attendee.cal_address)}`,
-                '_self'
-              )
-            }}
-            sx={{
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: '50%',
-              padding: 1,
-              color: alpha(theme.palette.grey[900], 0.9)
-            }}
-            size="small"
-          >
-            <Icon icon={CalendarToday} size={20} />
-          </IconButton>
-        </Tooltip>
-      )}
-    </Box>
-  )
-}
-
 export function AttendeePopover({
   attendee,
-  children,
-  isPublic
+  children
 }: AttendeePopoverProps): React.ReactElement {
   const theme = useTheme()
   const userEmail = useAppSelector(state => state.user.userData?.email)
@@ -245,7 +161,7 @@ export function AttendeePopover({
             </IconButton>
 
             <AttendeeInfo attendee={attendee} />
-            <AttendeeActions attendee={attendee} isPublic={isPublic} />
+            <AttendeeActions attendee={attendee} />
           </Paper>
         </Popper>
       </div>

--- a/common/src/components/Event/utils/eventUtils.tsx
+++ b/common/src/components/Event/utils/eventUtils.tsx
@@ -48,13 +48,9 @@ export const classIcon = (
   }
 }
 
-function renderSimpleAttendeeBadge(
-  a: userAttendee,
-  key: string,
-  isPublic?: boolean
-): JSX.Element {
+function renderSimpleAttendeeBadge(a: userAttendee, key: string): JSX.Element {
   return (
-    <AttendeePopover key={key} attendee={a} isPublic={isPublic}>
+    <AttendeePopover key={key} attendee={a}>
       <Avatar {...stringAvatar(a?.cn || a?.cal_address)} />
     </AttendeePopover>
   )
@@ -65,15 +61,13 @@ function renderFullAttendeeBadge({
   key,
   t,
   isOrganizer,
-  caption,
-  isPublic
+  caption
 }: {
   a: userAttendee
   key: string
   t: (key: string) => string
   isOrganizer?: boolean
   caption?: string
-  isPublic?: boolean
 }): JSX.Element {
   const icon = classIcon(a.partstat)
   const displayName = a.cn || a.cal_address
@@ -95,7 +89,7 @@ function renderFullAttendeeBadge({
           <ResourceIcon />
         </Box>
       ) : (
-        <AttendeePopover attendee={a} isPublic={isPublic}>
+        <AttendeePopover attendee={a}>
           <Badge
             overlap="circular"
             sx={{ marginRight: 2 }}
@@ -121,7 +115,7 @@ function renderFullAttendeeBadge({
         </AttendeePopover>
       )}
       <Box style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-        <AttendeePopover attendee={a} isPublic={isPublic}>
+        <AttendeePopover attendee={a}>
           <Typography variant="body2" noWrap>
             {displayName}
           </Typography>
@@ -147,8 +141,7 @@ export function renderAttendeeBadge({
   t,
   isFull,
   isOrganizer,
-  caption,
-  isPublic
+  caption
 }: {
   a: userAttendee
   key: string
@@ -156,14 +149,13 @@ export function renderAttendeeBadge({
   isFull?: boolean
   isOrganizer?: boolean
   caption?: string
-  isPublic?: boolean
 }): JSX.Element {
   if (!a) return <></>
 
   if (!isFull) {
-    return renderSimpleAttendeeBadge(a, key, isPublic)
+    return renderSimpleAttendeeBadge(a, key)
   }
-  return renderFullAttendeeBadge({ a, key, t, isOrganizer, caption, isPublic })
+  return renderFullAttendeeBadge({ a, key, t, isOrganizer, caption })
 }
 
 export function stringToColor(string: string): string {

--- a/common/src/injected.d.ts
+++ b/common/src/injected.d.ts
@@ -1,0 +1,8 @@
+declare module '@injected/components/Attendees/AttendeeActions' {
+  import React from 'react'
+  import { userAttendee } from '@common/features/User/models/attendee'
+
+  export function AttendeeActions(props: {
+    attendee: userAttendee
+  }): React.ReactElement | null
+}

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -460,6 +460,7 @@
   "tooltip": {
     "download": "Export event details to .ics file",
     "createEvent": "Create a new event",
+    "createEventWithAttendee": "Create a new event with %{attendee}",
     "editEvent": "Edit event",
     "deleteEvent": "Delete event",
     "ACCEPTED": "Accept invitation",
@@ -483,6 +484,8 @@
     "chat": "Chat",
     "copyEmail": "Copy email address",
     "emailCopied": "Email copied",
+    "cannotOpenChatExternalUser": "Cannot open chat with external user",
+    "openChat": "Open chat with %{attendee}",
     "printSchedule": "Print your schedule as a PDF"
   },
   "print": {

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -460,6 +460,7 @@
   "tooltip": {
     "download": "Exporter les détails de l'événement vers un fichier .ics",
     "createEvent": "Créer un nouvel événement",
+    "createEventWithAttendee": "Créer un nouvel événement avec %{attendee}",
     "editEvent": "Modifier l'événement",
     "deleteEvent": "Supprimer l'événement",
     "ACCEPTED": "Accepter l'invitation",
@@ -483,6 +484,8 @@
     "chat": "Discuter",
     "copyEmail": "Copier l'adresse e-mail",
     "emailCopied": "Email copié",
+    "cannotOpenChatExternalUser": "Impossible d'ouvrir le chat avec un utilisateur externe",
+    "openChat": "Ouvrir le chat avec %{attendee}",
     "printSchedule": "Imprimer votre agenda en PDF"
   },
   "print": {

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -460,6 +460,7 @@
   "tooltip": {
     "download": "Экспорт деталей события в файл .ics",
     "createEvent": "Создать новое событие",
+    "createEventWithAttendee": "Создать новое событие с %{attendee}",
     "editEvent": "Редактировать событие",
     "deleteEvent": "Удалить событие",
     "ACCEPTED": "Принять приглашение",
@@ -482,6 +483,8 @@
     "createAppointment": "Создать расписание встреч",
     "copyEmail": "Копировать адрес электронной почты",
     "emailCopied": "Email скопирован",
+    "cannotOpenChatExternalUser": "Невозможно открыть чат с внешним пользователем",
+    "openChat": "Открыть чат с %{attendee}",
     "printSchedule": "Распечатать расписание в PDF"
   },
   "print": {

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -460,6 +460,7 @@
   "tooltip": {
     "download": "Xuất chi tiết sự kiện sang file .ics",
     "createEvent": "Tạo sự kiện mới",
+    "createEventWithAttendee": "Tạo sự kiện mới với %{attendee}",
     "editEvent": "Chỉnh sửa sự kiện",
     "deleteEvent": "Xóa sự kiện",
     "ACCEPTED": "Chấp nhận lời mời",
@@ -482,7 +483,8 @@
     "createAppointment": "Tạo lịch hẹn",
     "copyEmail": "Sao chép địa chỉ email",
     "emailCopied": "Email đã được sao chép",
-    "createAppointment": "Create appointment schedule",
+    "cannotOpenChatExternalUser": "Không thể mở trò chuyện với người dùng bên ngoài",
+    "openChat": "Mở trò chuyện với %{attendee}",
     "printSchedule": "In lịch của bạn dưới dạng PDF"
   },
   "print": {

--- a/common/src/utils/chatUrlUtils.ts
+++ b/common/src/utils/chatUrlUtils.ts
@@ -1,0 +1,24 @@
+/**
+ * Utility functions for the chat application URL.
+ */
+
+import {
+  resolveUriTemplate,
+  UriTemplateContext
+} from '@common/utils/uriTemplateUtils'
+
+/**
+ * Resolve the CHAT_SPA_URL configuration entry.
+ *
+ * CHAT_SPA_URL is a URI template (RFC 6570 style).
+ *
+ * @returns the resolved base URL, or null when CHAT_SPA_URL is not configured.
+ */
+export function resolveChatSpaUrl(
+  context: UriTemplateContext = {}
+): string | null {
+  const template = window.CHAT_SPA_URL
+  if (!template) return null
+
+  return resolveUriTemplate(template, context)
+}

--- a/common/src/utils/uriTemplateUtils.ts
+++ b/common/src/utils/uriTemplateUtils.ts
@@ -9,6 +9,7 @@
 export interface UriTemplateContext {
   localpart?: string
   workplaceFqdn?: string
+  target?: string
 }
 
 /**
@@ -19,12 +20,13 @@ export interface UriTemplateContext {
  *  - {workplaceFqdn}           the full workplace FQDN (e.g. tmle.stg.lin-saas.com)
  *  - {workplaceFqdn.localpart} the first label of the FQDN (e.g. tmle)
  *  - {workplaceFqdn.domain}    the FQDN without its first label (e.g. stg.lin-saas.com)
+ *  - {target}                  the target username for chat url
  *
  * Unknown expressions are left untouched.
  */
 export function resolveUriTemplate(
   template: string,
-  { localpart = '', workplaceFqdn = '' }: UriTemplateContext
+  { localpart = '', workplaceFqdn = '', target = '' }: UriTemplateContext
 ): string {
   const [fqdnLocalpart = '', ...fqdnRest] = workplaceFqdn.split('.')
   const fqdnDomain = fqdnRest.join('.')
@@ -33,7 +35,8 @@ export function resolveUriTemplate(
     localpart,
     workplaceFqdn,
     'workplaceFqdn.localpart': fqdnLocalpart,
-    'workplaceFqdn.domain': fqdnDomain
+    'workplaceFqdn.domain': fqdnDomain,
+    target
   }
 
   return template.replace(/\{([^}]+)\}/g, (match, expression: string) => {

--- a/common/src/window.d.ts
+++ b/common/src/window.d.ts
@@ -18,6 +18,7 @@ declare global {
     DAV_BASE_URL: string
     CALDAV_PREFER_HANDLING?: 'strict'
     MAIL_SPA_URL: string
+    CHAT_SPA_URL: string
     VIDEO_CONFERENCE_BASE_URL: string
     SUPPORT_URL: string
     PRIVACY_URL: string

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -5,8 +5,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "paths": {
-      "@common/*": ["./src/*"],
-      "@injected/*": ["./src/*"]
+      "@common/*": ["./src/*"]
     }
   },
   "include": ["src", "../*.d.ts"]

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -28,6 +28,7 @@ const config: Config = {
       ],
       testEnvironment: 'jsdom',
       testMatch: ['**/*.test.tsx'],
+      testPathIgnorePatterns: ['\\.public\\.test\\.tsx$', '/apps/public/'],
       extensionsToTreatAsEsm: ['.ts', '.tsx'],
       testTimeout: 15000,
       transform: {
@@ -48,7 +49,53 @@ const config: Config = {
         '^preact(/(.*)|$)': 'preact$1',
         '^react$': '<rootDir>/node_modules/react',
         '^react-dom$': '<rootDir>/node_modules/react-dom',
-        '^@injected/(.*)$': '<rootDir>/common/src/$1',
+        '^@injected/(.*)$': '<rootDir>/apps/private/src/$1',
+        '^@/common/(.*)$': '<rootDir>/common/src/$1',
+        '^@common/(.*)$': '<rootDir>/common/src/$1',
+        '^@private/(.*)$': '<rootDir>/apps/private/src/$1',
+        '^@public/(.*)$': '<rootDir>/apps/public/src/$1',
+        '^@linagora/twake-mui$': '<rootDir>/node_modules/@linagora/twake-mui',
+        '^@linagora/twake-icons$':
+          '<rootDir>/node_modules/@linagora/twake-icons'
+      },
+      setupFilesAfterEnv: ['<rootDir>/common/src/setupTests.ts']
+    },
+    {
+      displayName: 'public-dom',
+      clearMocks: true,
+      moduleFileExtensions: [
+        'js',
+        'mjs',
+        'cjs',
+        'jsx',
+        'ts',
+        'tsx',
+        'json',
+        'node'
+      ],
+      testEnvironment: 'jsdom',
+      testMatch: ['**/*.public.test.tsx', '**/apps/public/**/*.test.tsx'],
+      extensionsToTreatAsEsm: ['.ts', '.tsx'],
+      testTimeout: 15000,
+      transform: {
+        '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.base.json' }],
+        '^.+\\.(js|jsx|mjs)$': 'babel-jest',
+        '^.+\\.(css|scss|sass|less|styl|stylus)$':
+          'jest-preview/transforms/css',
+        '^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)':
+          'jest-preview/transforms/file',
+        '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+          '<rootDir>/fileTransformer.ts'
+      },
+      transformIgnorePatterns: [
+        '/node_modules/(?!(preact|@fullcalendar|react-calendar|get-user-locale|memoize|mimic-function|@wojtekmaj|ky|cozy-ui|p-map|@linagora/twake-mui|@linagora/twake-icons|mime)/)'
+      ],
+
+      moduleNameMapper: {
+        '^preact(/(.*)|$)': 'preact$1',
+        '^react$': '<rootDir>/node_modules/react',
+        '^react-dom$': '<rootDir>/node_modules/react-dom',
+        '^@injected/(.*)$': '<rootDir>/apps/public/src/$1',
         '^@/common/(.*)$': '<rootDir>/common/src/$1',
         '^@common/(.*)$': '<rootDir>/common/src/$1',
         '^@private/(.*)$': '<rootDir>/apps/private/src/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
       "dependencies": {
         "@calendar/common": "*",
         "@fullcalendar/core": "^6.1.17",
+        "@linagora/twake-icons": "^2.7.0",
         "@linagora/twake-mui": "^2.0.0",
         "@mui/icons-material": "^9.0.1",
         "@mui/x-date-pickers": "^9",
@@ -121,6 +122,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@calendar/common": "*",
+        "@linagora/twake-icons": "^2.7.0",
         "@linagora/twake-mui": "^2.0.0",
         "@mui/icons-material": "^9.1.1",
         "@mui/x-date-pickers": "^9",

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -43,3 +43,10 @@ var HIDE_LANGUAGE_SELECTOR = false
 var BOOKING_LINK_ENABLED = false
 // Displays the attachments section in the event display modal. Defaults to false.
 var ENABLE_EVENT_ATTACHMENTS = false
+// CHAT_SPA_URL is a URI template (RFC 6570 style).
+// Supported expressions: {localpart},
+// {workplaceFqdn.localpart}, {workplaceFqdn.domain}
+// Examples:
+//   'https://{workplaceFqdn.localpart}-chat.{workplaceFqdn.domain}/#/bridge/web/#/chat/@{target}:{workplaceFqdn.domain}'
+//   'https://{localpart}-chat.twake.linagora.com/#/bridge/web/#/chat/@{target}:linagora.com'
+var CHAT_SPA_URL = 'https://{workplaceFqdn.localpart}-chat.{workplaceFqdn.domain}/#/bridge/web/#/chat/@{target}:{workplaceFqdn.domain}'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
     "paths": {
       "@common/*": ["./common/src/*"],
-      "@injected/*": ["./common/src/*"],
       "@private/*": ["./apps/private/src/*"],
       "@public/*": ["./apps/public/src/*"]
     }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared attendee actions UI with “Send mail”, “Create event”, and “Open chat” (chat only for internal attendees).
  * Introduced configurable chat-link support via the `CHAT_SPA_URL` URI-template setting.
  * Added localized tooltips for creating events and chat actions (EN/FR/RU/VI).
* **Bug Fixes**
  * Improved consistent attendee popover actions across public and private experiences.
  * Prevented opening chat when the attendee is external or chat link cannot be resolved.
* **Configuration**
  * Documented `CHAT_SPA_URL` in the environment example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->