### PR TITLE
fix(events): use uri type for videoconference jCal property

### DIFF
--- a/__test__/features/Events/EventTransformers.test.tsx
+++ b/__test__/features/Events/EventTransformers.test.tsx
@@ -398,6 +398,7 @@ describe('makeSeriesJCal', () => {
     const override = getOverrideFromJCal(jCal)
 
     const videoconf = getProp(override, 'x-openpaas-videoconference')
+    expect(videoconf[2]).toBe('uri')
     expect(videoconf[3]).toBe('https://meet.new.com')
   })
 

--- a/__test__/features/Events/eventUtils.test.ts
+++ b/__test__/features/Events/eventUtils.test.ts
@@ -500,7 +500,7 @@ describe('calendarEventToJCal', () => {
         ['class', {}, 'text', 'PUBLIC'],
         ['location', {}, 'text', 'Room 101'],
         ['description', {}, 'text', 'Discuss project roadmap.'],
-        ['x-openpaas-videoconference', {}, 'unknown', null],
+        ['x-openpaas-videoconference', {}, 'uri', null],
         ['rrule', {}, 'recur', { freq: 'WEEKLY' }],
         [
           'organizer',
@@ -657,7 +657,7 @@ describe('calendarEventToJCal', () => {
         ['class', {}, 'text', 'PUBLIC'],
         ['location', {}, 'text', 'Room 101'],
         ['description', {}, 'text', 'Discuss project roadmap.'],
-        ['x-openpaas-videoconference', {}, 'unknown', null],
+        ['x-openpaas-videoconference', {}, 'uri', null],
         ['rrule', {}, 'recur', { freq: 'WEEKLY', interval: 2 }],
         [
           'organizer',

--- a/common/src/features/Events/utils/makeVevent.ts
+++ b/common/src/features/Events/utils/makeVevent.ts
@@ -26,7 +26,7 @@ export function makeVevent(
       [
         'x-openpaas-videoconference',
         {},
-        'unknown',
+        'uri',
         event.x_openpass_videoconference ?? null
       ],
       ['summary', {}, 'text', event.title ?? ''],


### PR DESCRIPTION
The videoconference field represents a URI and should be serialized with the correct jCal type for consistency and interoperability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video conference links in exported calendar events are now correctly identified as URI values.
  * Improved compatibility with calendar applications that rely on accurate iCalendar property types.
  * Updated event conversion checks to verify the corrected video conference link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->