### PR TITLE
[#1206] Open attendee card for anyone but the current user

### DIFF
--- a/common/src/components/Attendees/AttendeePopover.tsx
+++ b/common/src/components/Attendees/AttendeePopover.tsx
@@ -161,6 +161,7 @@ export function AttendeePopover({
   isPublic
 }: AttendeePopoverProps): React.ReactElement {
   const theme = useTheme()
+  const userEmail = useAppSelector(state => state.user.userData?.email)
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
 
@@ -174,7 +175,13 @@ export function AttendeePopover({
 
   const open = Boolean(anchorEl)
 
-  if (attendee.role === 'CHAIR' || attendee.cutype === 'RESOURCE') {
+  const normalizeEmail = (email: string): string =>
+    email.replace(/^mailto:/i, '').toLowerCase()
+  const isSelf =
+    !!userEmail &&
+    normalizeEmail(attendee.cal_address) === normalizeEmail(userEmail)
+
+  if (isSelf || attendee.cutype === 'RESOURCE') {
     return <>{children}</>
   }
 


### PR DESCRIPTION
Closes #1206

## Problem

In the event detail / preview view, clicking on the **organizer** of an event I did not organize did nothing, while clicking on the **attendee that is me** opened the email modal (send mail, create event, …).

The `AttendeePopover` suppressed the card for `role === "CHAIR"` (the organizer) — the wrong criterion.

## Fix

Suppress the popover for the **current user** instead of the organizer. The card now opens for *anybody else but me*; the organizer becomes clickable and my own entry no longer opens the modal. Resources (`cutype === "RESOURCE"`) remain excluded.

The self-match normalizes the `mailto:` prefix and case before comparing against the logged-in user email.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attendee identification by recognizing the current user’s own attendance record.
  * Email comparisons now handle capitalization differences and `mailto:` prefixes consistently.
  * Preserved support for resource attendees when displaying attendee details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->