### PR TITLE
[#1217] Increment SEQUENCE when deleting recurring occurrences via EXDATE

### DIFF
--- a/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
+++ b/__test__/features/Events/updateEventHelpers/makeDeleteEventInstanceJCal.test.ts
@@ -401,6 +401,66 @@ describe('makeDeleteEventInstanceJCal', () => {
     })
   })
 
+  describe('SEQUENCE handling (#1217)', () => {
+    const sequenceOf = (result: VCalComponent): number | undefined => {
+      const masterProps = result[2][0][1] as VObjectProperty[]
+      const sequence = masterProps.find(([k]) => k === 'sequence')
+      return sequence?.[3] as number | undefined
+    }
+
+    it('increments an existing SEQUENCE when a new EXDATE is added', () => {
+      const vevents: VCalComponent[] = [
+        makeMasterVEvent([['sequence', {}, 'integer', 1]])
+      ]
+
+      const result = makeDeleteEventInstanceJCal(vevents, baseCalendarEvent)
+
+      expect(sequenceOf(result)).toBe(2)
+    })
+
+    it('initialises SEQUENCE to 1 when the master has none and a new EXDATE is added', () => {
+      const vevents: VCalComponent[] = [makeMasterVEvent()]
+
+      const result = makeDeleteEventInstanceJCal(vevents, baseCalendarEvent)
+
+      expect(sequenceOf(result)).toBe(1)
+    })
+
+    it('leaves SEQUENCE unchanged when the EXDATE already exists and no override is removed', () => {
+      const existingExdate: VObjectProperty = [
+        'exdate',
+        {},
+        'date-time',
+        '2024-03-15T10:00:00'
+      ]
+      const vevents: VCalComponent[] = [
+        makeMasterVEvent([['sequence', {}, 'integer', 1], existingExdate])
+      ]
+
+      const result = makeDeleteEventInstanceJCal(vevents, baseCalendarEvent)
+
+      expect(sequenceOf(result)).toBe(1)
+    })
+
+    it('increments SEQUENCE when a matching override is removed even if the EXDATE already existed', () => {
+      const existingExdate: VObjectProperty = [
+        'exdate',
+        {},
+        'date-time',
+        '2024-03-15T10:00:00'
+      ]
+      const override = makeOverrideVEvent('2024-03-15T10:00:00')
+      const vevents: VCalComponent[] = [
+        makeMasterVEvent([['sequence', {}, 'integer', 1], existingExdate]),
+        override
+      ]
+
+      const result = makeDeleteEventInstanceJCal(vevents, baseCalendarEvent)
+
+      expect(sequenceOf(result)).toBe(2)
+    })
+  })
+
   describe('edge cases', () => {
     it('handles a recurrenceId with a trailing Z correctly when adding EXDATE', () => {
       const event: CalendarEvent = {

--- a/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
+++ b/common/src/features/Events/transformers/makeDeleteEventInstanceJCal.ts
@@ -9,6 +9,7 @@ import { Calendar } from '@common/types/CalendarTypes'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { TIMEZONES } from '@common/utils/timezone-data'
 import moment from 'moment-timezone'
+import { incrementSequenceNumber } from './makeSeriesJCal'
 import { filterComponents } from './parseFetchedEvent'
 import { getTzidParam, sameRecurrence } from './recurrenceInstant'
 
@@ -71,13 +72,14 @@ export function makeDeleteEventInstanceJCal(
     )
   })
 
+  let updatedMasterProps = masterProps
   if (!isDuplicate) {
     // Add new EXDATE property as a separate entry
-    masterProps.push(['exdate', exdateParams, valueType, exdateProperty])
+    updatedMasterProps = [
+      ...masterProps,
+      ['exdate', exdateParams, valueType, exdateProperty]
+    ]
   }
-
-  // Update the master VEVENT with the new properties
-  vevents[masterIndex][1] = masterProps
 
   // Remove the override instance if it exists (in case it was an override being
   // deleted). Match by instant so an override stored in TZID/UTC form is still
@@ -94,6 +96,19 @@ export function makeDeleteEventInstanceJCal(
       seriesEvent.timezone
     ) // Remove matching override
   })
+
+  // This is an organizer-side change to the recurring master, so the CUA must
+  // manage SEQUENCE (the CalDAV server stores the data as-is). Bump it whenever
+  // the master effectively changed: a fresh EXDATE was added, or a matching
+  // override VEVENT was removed. A duplicate EXDATE with no override removal is
+  // a no-op and must not increment. See #1217.
+  const overrideRemoved = filteredVevents.length < vevents.length
+  if (!isDuplicate || overrideRemoved) {
+    updatedMasterProps = incrementSequenceNumber(updatedMasterProps)
+  }
+
+  // Update the master VEVENT with the new properties
+  vevents[masterIndex][1] = updatedMasterProps
 
   // Build the updated jCal with all VEVENTs and timezone
   const timezoneData = TIMEZONES.zones[seriesEvent.timezone]

--- a/common/src/features/Events/transformers/makeSeriesJCal.ts
+++ b/common/src/features/Events/transformers/makeSeriesJCal.ts
@@ -102,7 +102,7 @@ const applyMetadataChanges = (
 }
 
 // Increment the sequence number in properties
-const incrementSequenceNumber = (
+export const incrementSequenceNumber = (
   props: VObjectProperty[]
 ): VObjectProperty[] => {
   const newProps = [...props]


### PR DESCRIPTION
Closes #1217

## What

When deleting a single occurrence from a recurring event, the frontend mutates the master `VEVENT` (adds an `EXDATE`, and may remove a matching override `VEVENT` with `RECURRENCE-ID`). This is an organizer-side change, so the CUA must manage `SEQUENCE` — Sabre stores the submitted CalDAV PUT as-is and does not auto-increment it.

`makeDeleteEventInstanceJCal` now bumps the master `SEQUENCE` whenever the delete effectively changes the master:

- If the master has `SEQUENCE:N`, it becomes `SEQUENCE:N+1`.
- If the master has no `SEQUENCE`, it is initialised to `SEQUENCE:1`.
- If the `EXDATE` already exists and no override is removed, `SEQUENCE` is left unchanged (no effective change).
- If a matching override `VEVENT` is removed, `SEQUENCE` is incremented even when the `EXDATE` already existed.

The increment reuses the existing `incrementSequenceNumber` helper (now exported from `makeSeriesJCal.ts`) so the two organizer-side mutation paths stay consistent.

## Tests

Added a `SEQUENCE handling (#1217)` suite to `makeDeleteEventInstanceJCal.test.ts` covering the four cases from the issue:

1. Existing `SEQUENCE:1` + new `EXDATE` => `SEQUENCE:2`.
2. Master without `SEQUENCE` + new `EXDATE` => `SEQUENCE:1`.
3. Duplicate `EXDATE` + no override removal => unchanged.
4. Duplicate `EXDATE` + matching override removal => incremented.

> Note: the Jest suite could not be executed in my sandbox (it requires Node 24 via nvm, which the environment blocks; the system Node is v12). The changes were verified by manual review against the existing type definitions and control flow. Please rely on CI for the actual test run.

---
*Generated automatically*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting recurring event instances now correctly updates the event sequence number when a new exception or override removal changes the series.
  - Sequence numbers remain unchanged when deleting an instance produces no effective change.
  - Improved handling prevents unintended changes when an exception date already exists.

- **Tests**
  - Added coverage for sequence updates, initialization, and no-op deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->