### PR TITLE
#1142 line wrap in event preview

### DIFF
--- a/common/src/components/Event/InfoRow.tsx
+++ b/common/src/components/Event/InfoRow.tsx
@@ -38,7 +38,8 @@ export function InfoRow({
         alignItems,
         gap: 1,
         marginBottom: 1,
-        flexWrap
+        flexWrap,
+        wordBreak: 'break-word'
       }}
     >
       {icon}

--- a/common/src/components/EventPreview/EventPreviewModal.tsx
+++ b/common/src/components/EventPreview/EventPreviewModal.tsx
@@ -130,6 +130,7 @@ const EventPreviewModal: React.FC<{
         actionsBorderTop={hasActionsBorderTop}
         actionsJustifyContent="center"
         style={{ overflow: 'auto' }}
+        contentSx={{ overflowX: 'hidden', overflowY: 'auto' }}
         titleSx={{ backgroundColor: '#FCFCFC' }}
         title={header}
         actions={actions}

--- a/common/src/features/Events/EventModal.tsx
+++ b/common/src/features/Events/EventModal.tsx
@@ -19,7 +19,7 @@ const EventPopover: React.FC<{
   onClose: (refresh?: boolean) => void
   selectedRange: DateSelectArg | null
   setSelectedRange: React.Dispatch<React.SetStateAction<DateSelectArg | null>>
-  setDraftCalendarId: (id: string) => void
+  setDraftCalendarId?: (id: string) => void
   calendarRef: React.RefObject<CalendarApi | null>
   event?: CalendarEvent
 }> = ({


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1142

<img width="569" height="628" alt="image" src="https://github.com/user-attachments/assets/36af3e4d-7347-40ca-bdb4-6322d3b497f5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event layouts so long, unbroken text wraps correctly.
  * Updated event preview dialogs to prevent horizontal overflow while preserving vertical scrolling.
* **Improvements**
  * Event popovers can now be used without requiring calendar draft selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->