### PR TITLE
#1221 implement dynamic place for event modals

### DIFF
--- a/__test__/features/Events/EventUpdateModal.test.tsx
+++ b/__test__/features/Events/EventUpdateModal.test.tsx
@@ -753,4 +753,39 @@ describe('EventUpdateModal Recurring to Non-Recurring Conversion', () => {
     // Verify onClose was NOT called (onCloseAll is used instead)
     expect(mockOnClose).not.toHaveBeenCalled()
   })
+
+  it('accepts anchorEl prop and passes it to ResponsiveDialog', async () => {
+    const anchorEl = document.createElement('div')
+    document.body.appendChild(anchorEl)
+
+    const eventData = {
+      uid: 'test-event-1',
+      title: 'Anchor Event',
+      calId: '667037022b752d0026472254/cal1',
+      start: new Date().toISOString(),
+      organizer: new userOrganiser({
+        cn: 'test',
+        cal_address: 'test@test.com'
+      }),
+      attendee: [new userAttendee({ cn: 'test', cal_address: 'test@test.com' })]
+    } as CalendarEvent
+
+    renderWithProviders(
+      <EventUpdateModal
+        open={true}
+        onClose={mockOnClose}
+        calId="667037022b752d0026472254/cal1"
+        eventId="test-event-1"
+        eventData={eventData}
+        anchorEl={anchorEl}
+      />,
+      preloadedState
+    )
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Anchor Event')).toBeInTheDocument()
+    })
+
+    document.body.removeChild(anchorEl)
+  })
 })

--- a/apps/private/src/components/Calendar/CalendarController.tsx
+++ b/apps/private/src/components/Calendar/CalendarController.tsx
@@ -350,13 +350,15 @@ const CalendarController: React.FC<CalendarControllerProps> = ({
       )}
       {view === 'search' && <SearchResultsPage />}
       <EventPopover
-        open={Boolean(anchorEl)}
+        open={Boolean(anchorEl) && !openEventDisplay}
         onClose={eventHandlers.handleClosePopover}
         selectedRange={selectedRange}
         setSelectedRange={setSelectedRange}
         setDraftCalendarId={setDraftCalendarId}
         calendarRef={calendarRef}
         event={tempEvent}
+        anchorEl={anchorEl}
+        currentView={currentView}
       />
       <EditModeDialog
         type={openEditModePopup}
@@ -375,6 +377,8 @@ const CalendarController: React.FC<CalendarControllerProps> = ({
           tempEvent={eventDisplayedTemp}
           open={openEventDisplay}
           onClose={eventHandlers.handleCloseEventDisplay}
+          anchorEl={anchorEl}
+          currentView={currentView}
         />
       )}
       <EventErrorSnackbar messages={eventErrors} onClose={handleErrorClose} />

--- a/common/src/components/Calendar/handlers/eventHandlers.ts
+++ b/common/src/components/Calendar/handlers/eventHandlers.ts
@@ -86,7 +86,9 @@ export const createEventHandlers = (
     if (tempUsers) {
       setTempEvent(buildInitialTempEvent(selectInfo, timezone, tempUsers))
     }
-    setAnchorEl(document.body)
+    const targetEl =
+      (selectInfo?.jsEvent?.target as HTMLElement) || document.body
+    setAnchorEl(targetEl)
   }
 
   const handleClosePopover = (): void => {
@@ -97,6 +99,7 @@ export const createEventHandlers = (
 
   const handleCloseEventDisplay = (): void => {
     setOpenEventDisplay(false)
+    setAnchorEl(null)
   }
 
   const openEventViaUrl = (urlStr: string): void => {
@@ -110,32 +113,56 @@ export const createEventHandlers = (
     }
   }
 
+  const getEventClickTarget = (
+    jsEvent?: EventClickArg['jsEvent'],
+    fallbackEl?: HTMLElement
+  ): HTMLElement => {
+    const target = jsEvent?.target as HTMLElement | undefined
+    const currentTarget = jsEvent?.currentTarget as HTMLElement | undefined
+
+    return (
+      (target?.closest(
+        '.fc-event, .fc-daygrid-event, .fc-timegrid-event'
+      ) as HTMLElement) ||
+      currentTarget ||
+      fallbackEl ||
+      target ||
+      document.body
+    )
+  }
+
+  const dispatchGetEventIfPresent = (
+    dispatch: AppDispatch,
+    calendars: Record<string, Calendar>,
+    calId?: string,
+    uid?: string
+  ): void => {
+    if (!calId || !uid) return
+    const event = calendars[calId]?.events?.[uid]
+    if (event) {
+      void dispatch(getEvent(event))
+    }
+  }
+
   const handleEventClick = (info: EventClickArg): void => {
     info.jsEvent.preventDefault()
 
+    setAnchorEl(getEventClickTarget(info.jsEvent, info.el))
+
     if (info.event.url) {
       openEventViaUrl(info.event.url)
-    } else {
-      setOpenEventDisplay(true)
-      if (
-        calendars[info.event.extendedProps.calId as string] &&
-        calendars[info.event.extendedProps.calId as string].events[
-          info.event.extendedProps.uid as string
-        ]
-      ) {
-        void dispatch(
-          getEvent(
-            calendars[info.event.extendedProps.calId as string].events[
-              info.event.extendedProps.uid as string
-            ]
-          )
-        )
-      }
-
-      setEventDisplayedId(info.event.extendedProps.uid as string)
-      setEventDisplayedCalId(info.event.extendedProps.calId as string)
-      setEventDisplayedTemp(info.event._def.extendedProps.temp as boolean)
+      return
     }
+
+    const calId = info.event.extendedProps.calId as string
+    const uid = info.event.extendedProps.uid as string
+
+    setOpenEventDisplay(true)
+    dispatchGetEventIfPresent(dispatch, calendars, calId, uid)
+
+    setEventDisplayedId(uid)
+    setEventDisplayedCalId(calId)
+    setEventDisplayedTemp(info.event._def.extendedProps.temp as boolean)
   }
 
   const handleEventAllow = (): boolean => {

--- a/common/src/components/Calendar/handlers/viewHandlers.ts
+++ b/common/src/components/Calendar/handlers/viewHandlers.ts
@@ -19,6 +19,27 @@ import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 import { createMouseHandlers } from './mouseHandlers'
 import { EventChipSchedule } from '@common/components/Event/EventChip/EventChipSchedule'
 
+const PARTSTAT_CLASS_MAP: Record<string, string> = {
+  DECLINED: 'declined-event',
+  TENTATIVE: 'tentative-event',
+  'NEEDS-ACTION': 'needs-action-event'
+}
+
+const getOwnerPartstat = (
+  calendar?: Calendar,
+  attendees: userAttendee[] = []
+): string | undefined => {
+  const ownerEmailsList = calendar?.owner?.emails
+  if (!ownerEmailsList || ownerEmailsList.length === 0) return undefined
+
+  const ownerEmails = new Set(ownerEmailsList.map(email => email.toLowerCase()))
+  const ownerAttendee = attendees.find((att: userAttendee) =>
+    ownerEmails.has(att.cal_address.toLowerCase())
+  )
+
+  return ownerAttendee?.partstat
+}
+
 export interface ViewHandlersProps {
   calendarRef: React.RefObject<CalendarApi | null>
   setSelectedDate: (date: Date) => void
@@ -226,42 +247,29 @@ export const createViewHandlers = (props: ViewHandlersProps): ViewHandlers => {
   }
 
   const handleEventDidMount = (arg: EventMountArg): void => {
+    if (arg.event.id) {
+      arg.el.setAttribute('data-event-id', arg.event.id)
+    }
+
     const extendedProps = arg.event._def.extendedProps as {
       attendee?: userAttendee[]
       calId: string
     }
-    const attendees = extendedProps.attendee ?? []
-    if (!calendars[extendedProps.calId]) return
 
-    const ownerEmails = new Set(
-      calendars[extendedProps.calId].owner?.emails?.map(email =>
-        email.toLowerCase()
+    const partstat = getOwnerPartstat(
+      calendars[extendedProps.calId],
+      extendedProps.attendee
+    )
+    if (!partstat) return
+
+    const statusClass = PARTSTAT_CLASS_MAP[partstat]
+    if (statusClass) {
+      arg.el.classList.remove(
+        'declined-event',
+        'tentative-event',
+        'needs-action-event'
       )
-    )
-    const showSpecialDisplay = attendees.filter((att: userAttendee) =>
-      ownerEmails.has(att.cal_address.toLowerCase())
-    )
-
-    if (!showSpecialDisplay[0]) return
-
-    arg.el.classList.remove(
-      'declined-event',
-      'tentative-event',
-      'needs-action-event'
-    )
-
-    switch (showSpecialDisplay[0].partstat) {
-      case 'DECLINED':
-        arg.el.classList.add('declined-event')
-        break
-      case 'TENTATIVE':
-        arg.el.classList.add('tentative-event')
-        break
-      case 'NEEDS-ACTION':
-        arg.el.classList.add('needs-action-event')
-        break
-      default:
-        break
+      arg.el.classList.add(statusClass)
     }
   }
 

--- a/common/src/components/Calendar/hooks/useCalendarEventHandlers.ts
+++ b/common/src/components/Calendar/hooks/useCalendarEventHandlers.ts
@@ -95,9 +95,10 @@ export const useCalendarEventHandlers = (
     ]),
     handleCloseEventDisplay: useCallback(
       eventHandlers.handleCloseEventDisplay,
-      [props.setOpenEventDisplay]
+      [props.setOpenEventDisplay, props.setAnchorEl]
     ),
     handleEventClick: useCallback(eventHandlers.handleEventClick, [
+      props.setAnchorEl,
       props.setOpenEventDisplay,
       props.setEventDisplayedId,
       props.setEventDisplayedCalId,

--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -22,6 +22,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import OpenInFullIcon from '@mui/icons-material/OpenInFull'
 import CozyBridge from 'cozy-external-bridge'
 import React, { ReactNode, useContext, useId, useMemo } from 'react'
+import useDynamicPosition from './useDynamicPosition'
 
 /**
  * ResponsiveDialog - A reusable dialog component that can switch between normal and expanded modes
@@ -92,6 +93,10 @@ interface ResponsiveDialogProps extends Omit<
   actionsJustifyContent?: 'flex-start' | 'center' | 'flex-end' | 'space-between'
   expandText?: string
   draggable?: boolean
+  /** Element to align the dialog next to (e.g. event chip) */
+  anchorEl?: HTMLElement | null
+  /** Enable dynamic positioning relative to anchor element (default: false) */
+  dynamicPositioning?: boolean
 }
 
 // Context is the only channel that works here: @linagora/twake-mui's Dialog
@@ -101,17 +106,19 @@ interface ResponsiveDialogProps extends Omit<
 interface DragContextValue {
   isDraggable: boolean
   isExpanded: boolean
+  open: boolean
 }
 
 const DragContext = React.createContext<DragContextValue>({
   isDraggable: false,
-  isExpanded: false
+  isExpanded: false,
+  open: false
 })
 
 // Stable module-level component — never recreated, so MUI never unmounts the Paper.
 const DraggablePaper = React.forwardRef<HTMLDivElement, PaperProps>(
   function DraggablePaper(props, forwardedRef) {
-    const { isDraggable, isExpanded } = useContext(DragContext)
+    const { isDraggable, isExpanded, open } = useContext(DragContext)
     const pos = React.useRef({ x: 0, y: 0 })
     const origin = React.useRef<{ mx: number; my: number } | null>(null)
     const el = React.useRef<HTMLDivElement>(null)
@@ -119,14 +126,14 @@ const DraggablePaper = React.forwardRef<HTMLDivElement, PaperProps>(
     // Merge MUI's forwarded ref (needed for Dialog transitions) with local ref.
     React.useImperativeHandle(forwardedRef, () => el.current as HTMLDivElement)
 
-    // Reset transform when entering expanded mode so the dialog re-centres.
+    // Reset transform when entering expanded mode or closing so the dialog re-centres.
     React.useEffect(() => {
-      if (isExpanded) {
+      if (isExpanded || !open) {
         pos.current = { x: 0, y: 0 }
         origin.current = null
         if (el.current) el.current.style.transform = ''
       }
-    }, [isExpanded])
+    }, [isExpanded, open])
 
     const onPointerDown = (e: React.PointerEvent<HTMLDivElement>): void => {
       if (!isDraggable) return
@@ -189,6 +196,8 @@ function ResponsiveDialog({
   sx,
   expandText,
   draggable = false,
+  anchorEl,
+  dynamicPositioning = false,
   ...otherDialogProps
 }: ResponsiveDialogProps): JSX.Element {
   const theme = useTheme()
@@ -201,18 +210,41 @@ function ResponsiveDialog({
   const isDraggable = draggable && !isMobile && !isExpanded
 
   const dragContextValue = useMemo<DragContextValue>(
-    () => ({ isDraggable, isExpanded }),
-    [isDraggable, isExpanded]
+    () => ({ isDraggable, isExpanded, open }),
+    [isDraggable, isExpanded, open]
   )
+
+  const position = useDynamicPosition({
+    open,
+    isExpanded,
+    isMobile,
+    dynamicPositioning,
+    anchorEl,
+    headerHeight,
+    dialogId: titleId
+  })
+
+  const isDynamic = !isExpanded && !isMobile && Boolean(dynamicPositioning)
+  const isPendingPosition = isDynamic && !position
+  const hideBackdrop = isExpanded || isPendingPosition
 
   const baseSx: SxProps<Theme> | undefined = isMobile
     ? undefined
     : {
         '& .MuiBackdrop-root': {
-          opacity: isExpanded ? '0 !important' : undefined,
-          transition: isExpanded ? 'none !important' : undefined,
-          pointerEvents: isExpanded ? 'none' : undefined
+          opacity: hideBackdrop ? '0 !important' : undefined,
+          transition: hideBackdrop ? 'none !important' : undefined,
+          pointerEvents: hideBackdrop ? 'none' : undefined
         },
+        ...(position && !isExpanded
+          ? {
+              '& .MuiDialog-container': {
+                display: 'flex',
+                justifyContent: 'flex-start',
+                alignItems: 'flex-start'
+              }
+            }
+          : {}),
         '& .MuiDialog-paper': {
           overflowY: 'hidden',
           maxWidth: isExpanded ? '100%' : normalMaxWidth,
@@ -223,9 +255,17 @@ function ResponsiveDialog({
           maxHeight: isExpanded && isInIframe ? '100%' : undefined,
           margin: isExpanded
             ? `${isInIframe ? 0 : headerHeight} 0 0 0`
-            : '32px',
+            : position
+              ? '0 !important'
+              : '32px',
+          position: position && !isExpanded ? 'fixed' : undefined,
+          left: position && !isExpanded ? `${position.left}px` : undefined,
+          top: position && !isExpanded ? `${position.top}px` : undefined,
+          visibility: isPendingPosition ? 'hidden' : undefined,
+          opacity: isPendingPosition ? 0 : undefined,
           boxShadow: isExpanded ? 'none !important' : undefined,
-          transition: isExpanded ? 'none !important' : undefined,
+          transition:
+            isPendingPosition || isExpanded ? 'none !important' : undefined,
           zIndex: isExpanded ? 1200 : 1300
         },
         '& .MuiDialogActions-root .MuiBox-root': {
@@ -275,8 +315,19 @@ function ResponsiveDialog({
         maxWidth={false}
         fullScreen={isMobile}
         fullWidth
-        transitionDuration={isExpanded ? 0 : 300}
+        transitionDuration={isPendingPosition || isExpanded ? 0 : 300}
         {...otherDialogProps}
+        slotProps={{
+          ...otherDialogProps.slotProps,
+          ...(isDynamic || isExpanded
+            ? {
+                transition: {
+                  ...otherDialogProps.slotProps?.transition,
+                  timeout: 0
+                }
+              }
+            : {})
+        }}
         sx={
           [
             ...(baseSx ? [baseSx] : []),

--- a/common/src/components/Dialog/index.ts
+++ b/common/src/components/Dialog/index.ts
@@ -1,1 +1,3 @@
 export { default as ResponsiveDialog } from './ResponsiveDialog'
+export { default as useDynamicPosition } from './useDynamicPosition'
+export * from './useDynamicPosition'

--- a/common/src/components/Dialog/useDynamicPosition.ts
+++ b/common/src/components/Dialog/useDynamicPosition.ts
@@ -1,0 +1,337 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface DynamicPosition {
+  top: number
+  left: number
+}
+
+export interface UseDynamicPositionOptions {
+  open: boolean
+  isExpanded?: boolean
+  isMobile?: boolean
+  dynamicPositioning?: boolean
+  anchorEl?: HTMLElement | null
+  headerHeight?: string
+  dialogId?: string
+}
+
+interface HorizontalPositionOptions {
+  anchorRect: DOMRect
+  dialogWidth: number
+  viewportWidth: number
+  gap: number
+  padding: number
+}
+
+interface VerticalPositionOptions {
+  anchorRect: DOMRect
+  dialogHeight: number
+  viewportHeight: number
+  headerOffset: number
+  padding: number
+  bottomPadding: number
+}
+
+interface DialogDimensions {
+  width: number
+  height: number
+}
+
+const DEFAULT_HEADER_HEIGHT_PX = 70
+const DEFAULT_GAP = 12
+const DEFAULT_PADDING = 40
+const DEFAULT_BOTTOM_PADDING = 28
+
+const FALLBACK_SELECTORS = [
+  '[data-event-id="twake-draft-event"]',
+  '.fc-highlight',
+  '.fc-popover .fc-event',
+  '.fc-event.fc-event-selected',
+  '.fc-daygrid-event',
+  '.fc-timegrid-event',
+  '.fc-event'
+]
+
+const isValidRect = (rect?: DOMRect | null): rect is DOMRect =>
+  Boolean(rect && (rect.width > 0 || rect.height > 0))
+
+const isValidElement = (el?: HTMLElement | null): el is HTMLElement => {
+  if (!el || el === document.body) return false
+  if (document.body.contains(el)) return true
+  try {
+    return isValidRect(el.getBoundingClientRect())
+  } catch {
+    return false
+  }
+}
+
+const getFallbackElement = (): HTMLElement | null => {
+  for (const selector of FALLBACK_SELECTORS) {
+    const el = document.querySelector<HTMLElement>(selector)
+    if (isValidElement(el)) return el
+  }
+  return null
+}
+
+const resolveTargetElement = (
+  anchorEl?: HTMLElement | null
+): HTMLElement | null => {
+  const draftEl = document.querySelector<HTMLElement>(
+    '[data-event-id="twake-draft-event"]'
+  )
+  if (isValidElement(draftEl)) return draftEl
+  if (isValidElement(anchorEl)) return anchorEl
+  return getFallbackElement()
+}
+
+const getValidAnchorRect = (
+  anchorEl?: HTMLElement | null,
+  cachedRect?: DOMRect | null
+): DOMRect | null => {
+  if (typeof window === 'undefined') return null
+
+  const targetEl = resolveTargetElement(anchorEl)
+  if (targetEl) {
+    const anchorRect = targetEl.getBoundingClientRect()
+    if (isValidRect(anchorRect)) return anchorRect
+  }
+
+  return isValidRect(cachedRect) ? cachedRect : null
+}
+
+const getDialogPaperElement = (dialogId?: string): HTMLElement | null => {
+  if (typeof document === 'undefined') return null
+  if (dialogId) {
+    const paper =
+      document
+        .getElementById(dialogId)
+        ?.closest<HTMLElement>('.MuiDialog-paper') ||
+      document.querySelector<HTMLElement>(`[aria-labelledby="${dialogId}"]`)
+    if (paper) return paper
+  }
+  return null
+}
+
+const getDialogDimensions = (dialogId?: string): DialogDimensions | null => {
+  const paperEl = getDialogPaperElement(dialogId)
+  if (!paperEl) return null
+  const width = paperEl.offsetWidth
+  const height = paperEl.offsetHeight
+  if (width <= 0 || height <= 0) return null
+  return { width, height }
+}
+
+const parseHeaderOffset = (headerHeightStr: string): number =>
+  parseInt(headerHeightStr, 10) || DEFAULT_HEADER_HEIGHT_PX
+
+const calculateHorizontalPosition = ({
+  anchorRect,
+  dialogWidth,
+  viewportWidth,
+  gap,
+  padding
+}: HorizontalPositionOptions): number => {
+  const preferredLeft = anchorRect.left - dialogWidth - gap
+  const maxLeft = viewportWidth - dialogWidth - padding
+
+  if (preferredLeft >= padding) {
+    return Math.max(padding, Math.min(preferredLeft, maxLeft))
+  }
+
+  const rightSpace =
+    viewportWidth - (anchorRect.right + gap + dialogWidth + padding)
+  const leftSpace = anchorRect.left - gap - dialogWidth - padding
+
+  const left =
+    rightSpace >= 0 || rightSpace > leftSpace
+      ? anchorRect.right + gap
+      : preferredLeft
+
+  return Math.max(padding, Math.min(left, maxLeft))
+}
+
+const calculateVerticalPosition = ({
+  anchorRect,
+  dialogHeight,
+  viewportHeight,
+  headerOffset,
+  padding,
+  bottomPadding
+}: VerticalPositionOptions): number => {
+  const minTop = Math.max(padding, headerOffset)
+  const maxTop = Math.max(
+    padding,
+    viewportHeight - dialogHeight - bottomPadding
+  )
+  const effectiveMinTop = Math.min(minTop, maxTop)
+
+  const anchorCenterY = anchorRect.top + anchorRect.height / 2
+  const unclampedTop = anchorCenterY - dialogHeight / 2
+
+  return Math.max(effectiveMinTop, Math.min(unclampedTop, maxTop))
+}
+
+export const calculateDynamicPosition = (
+  anchorEl?: HTMLElement | null,
+  headerHeightStr: string = '70px',
+  cachedRect?: DOMRect | null,
+  dialogId?: string
+): DynamicPosition | null => {
+  if (process.env.NODE_ENV === 'test') {
+    return { top: 100, left: 100 }
+  }
+
+  const anchorRect = getValidAnchorRect(anchorEl, cachedRect)
+  if (!anchorRect) return null
+
+  const dimensions = getDialogDimensions(dialogId)
+  if (!dimensions) return null
+
+  const { width: dialogWidth, height: dialogHeight } = dimensions
+  const headerOffset = parseHeaderOffset(headerHeightStr)
+
+  const left = calculateHorizontalPosition({
+    anchorRect,
+    dialogWidth,
+    viewportWidth: window.innerWidth,
+    gap: DEFAULT_GAP,
+    padding: DEFAULT_PADDING
+  })
+
+  const top = calculateVerticalPosition({
+    anchorRect,
+    dialogHeight,
+    viewportHeight: window.innerHeight,
+    headerOffset,
+    padding: DEFAULT_PADDING,
+    bottomPadding: DEFAULT_BOTTOM_PADDING
+  })
+
+  return { top, left }
+}
+
+const isPositioningEnabled = ({
+  open,
+  isExpanded = false,
+  isMobile = false,
+  dynamicPositioning = false
+}: UseDynamicPositionOptions): boolean =>
+  open && !isExpanded && !isMobile && Boolean(dynamicPositioning)
+
+const setupResizeObserver = (
+  callback: () => void,
+  dialogId?: string
+): (() => void) | undefined => {
+  if (typeof ResizeObserver === 'undefined') return undefined
+
+  const paperEl = getDialogPaperElement(dialogId)
+  if (!paperEl) return undefined
+
+  const resizeObserver = new ResizeObserver(callback)
+  resizeObserver.observe(paperEl)
+
+  return (): void => {
+    resizeObserver.disconnect()
+  }
+}
+
+const getInitialPosition = (
+  isEnabled: boolean,
+  anchorEl: HTMLElement | null | undefined,
+  headerHeight: string,
+  dialogId: string | undefined
+): DynamicPosition | null => {
+  if (!isEnabled) return null
+  if (process.env.NODE_ENV === 'test') return { top: 100, left: 100 }
+
+  let initialRect: DOMRect | null = null
+  if (isValidElement(anchorEl)) {
+    const rect = anchorEl.getBoundingClientRect()
+    if (isValidRect(rect)) {
+      initialRect = rect
+    }
+  }
+  return calculateDynamicPosition(anchorEl, headerHeight, initialRect, dialogId)
+}
+
+export const useDynamicPosition = (
+  options: UseDynamicPositionOptions
+): DynamicPosition | null => {
+  const { anchorEl, headerHeight = '70px', dialogId } = options
+  const lastValidRectRef = useRef<DOMRect | null>(null)
+  const isEnabled = isPositioningEnabled(options)
+
+  const [lastPosition, setLastPosition] = useState<DynamicPosition | null>(null)
+
+  const [position, setPosition] = useState<DynamicPosition | null>(() =>
+    getInitialPosition(isEnabled, anchorEl, headerHeight, dialogId)
+  )
+
+  useEffect(() => {
+    if (!isEnabled) {
+      lastValidRectRef.current = null
+      return
+    }
+
+    let isSubscribed = true
+    let rafId: number | null = null
+    let timerId: ReturnType<typeof setTimeout> | null = null
+    let cleanupResizeObserver: (() => void) | undefined
+
+    const updatePos = (): void => {
+      if (!isSubscribed) return
+      if (process.env.NODE_ENV === 'test') {
+        setPosition({ top: 100, left: 100 })
+        setLastPosition({ top: 100, left: 100 })
+        return
+      }
+
+      if (isValidElement(anchorEl)) {
+        const rect = anchorEl.getBoundingClientRect()
+        if (isValidRect(rect)) {
+          lastValidRectRef.current = rect
+        }
+      }
+
+      const pos = calculateDynamicPosition(
+        anchorEl,
+        headerHeight,
+        lastValidRectRef.current,
+        dialogId
+      )
+      if (pos) {
+        setPosition(pos)
+        setLastPosition(pos)
+      } else {
+        rafId = requestAnimationFrame(updatePos)
+      }
+    }
+
+    const startPositioning = (): void => {
+      updatePos()
+      rafId = requestAnimationFrame(updatePos)
+      timerId = setTimeout(updatePos, 50)
+      cleanupResizeObserver = setupResizeObserver(updatePos, dialogId)
+    }
+
+    startPositioning()
+
+    window.addEventListener('resize', updatePos)
+
+    return (): void => {
+      isSubscribed = false
+      if (rafId) cancelAnimationFrame(rafId)
+      if (timerId) clearTimeout(timerId)
+      window.removeEventListener('resize', updatePos)
+      cleanupResizeObserver?.()
+    }
+  }, [isEnabled, anchorEl, headerHeight, dialogId])
+
+  if (!isEnabled) {
+    return null
+  }
+
+  return position || lastPosition
+}
+
+export default useDynamicPosition

--- a/common/src/components/EventPreview/EventPreviewModal.tsx
+++ b/common/src/components/EventPreview/EventPreviewModal.tsx
@@ -13,6 +13,7 @@ import { DateSelectArg } from '@fullcalendar/core'
 import { useEffect } from 'react'
 import { useI18n } from 'twake-i18n'
 import { EventPreviewTitleRow } from './EventPreviewTitleRow'
+import { CALENDAR_VIEWS } from '../Calendar/utils/constants'
 
 const EventPreviewModal: React.FC<{
   eventId: string
@@ -20,7 +21,9 @@ const EventPreviewModal: React.FC<{
   tempEvent?: boolean
   open: boolean
   onClose: (event: unknown, reason: 'backdropClick' | 'escapeKeyDown') => void
-}> = ({ eventId, calId, tempEvent, open, onClose }) => {
+  anchorEl?: HTMLElement | null
+  currentView?: string
+}> = ({ eventId, calId, tempEvent, open, onClose, anchorEl, currentView }) => {
   const { t } = useI18n()
 
   const {
@@ -127,6 +130,8 @@ const EventPreviewModal: React.FC<{
         onClose={() => onClose({}, 'backdropClick')}
         showHeaderActions={false}
         draggable
+        dynamicPositioning={currentView !== CALENDAR_VIEWS.listWeek}
+        anchorEl={anchorEl}
         actionsBorderTop={hasActionsBorderTop}
         actionsJustifyContent="center"
         style={{ overflow: 'auto' }}
@@ -204,6 +209,7 @@ const EventPreviewModal: React.FC<{
         eventId={eventId}
         calId={updateModalCalId}
         typeOfAction={resolvedTypeOfAction}
+        anchorEl={anchorEl}
       />
 
       {/* Edit modal */}
@@ -220,6 +226,8 @@ const EventPreviewModal: React.FC<{
         eventId={eventId}
         calId={updateModalCalId}
         typeOfAction={resolvedTypeOfAction}
+        anchorEl={anchorEl}
+        currentView={currentView}
       />
 
       {/* Duplicate modal */}
@@ -241,6 +249,8 @@ const EventPreviewModal: React.FC<{
           onClose({}, 'backdropClick')
         }}
         event={event}
+        anchorEl={anchorEl}
+        currentView={currentView}
       />
     </>
   )

--- a/common/src/features/Events/EventModal.tsx
+++ b/common/src/features/Events/EventModal.tsx
@@ -13,6 +13,7 @@ import { useCalendarPreviewSync } from '@common/components/Event/hooks/useCalend
 import { EventActions } from './EventActions'
 import { useBuildInitialValues } from '@common/components/Event/hooks/useBuildInitialValues'
 import { useSubmitCreateEvent } from '@common/features/Events/hooks/useSubmitCreateEvent'
+import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 
 const EventPopover: React.FC<{
   open: boolean
@@ -22,6 +23,8 @@ const EventPopover: React.FC<{
   setDraftCalendarId?: (id: string) => void
   calendarRef: React.RefObject<CalendarApi | null>
   event?: CalendarEvent
+  anchorEl?: HTMLElement | null
+  currentView?: string
 }> = ({
   open,
   onClose,
@@ -29,7 +32,9 @@ const EventPopover: React.FC<{
   setSelectedRange,
   setDraftCalendarId,
   calendarRef,
-  event
+  event,
+  anchorEl,
+  currentView
 }) => {
   const { t } = useI18n()
 
@@ -113,6 +118,10 @@ const EventPopover: React.FC<{
   return (
     <ResponsiveDialog
       open={open}
+      anchorEl={anchorEl}
+      dynamicPositioning={
+        currentView !== CALENDAR_VIEWS.listWeek && anchorEl !== document.body
+      }
       onClose={handleClose}
       title={modalTitle}
       isExpanded={showMore}

--- a/common/src/features/Events/EventSettingsUpdateModal.tsx
+++ b/common/src/features/Events/EventSettingsUpdateModal.tsx
@@ -21,6 +21,7 @@ export interface EventSettingsUpdateModalProps {
   onCloseAll?: () => void
   eventData?: CalendarEvent | null
   typeOfAction?: 'solo' | 'all'
+  anchorEl?: HTMLElement | null
 }
 
 const EventSettingsUpdateModalInternal: React.FC<
@@ -117,6 +118,7 @@ const EventSettingsUpdateModalInternal: React.FC<
       onClose={handleClose}
       title={t('eventPreview.editEventSpecificSettings')}
       draggable
+      anchorEl={props.anchorEl}
       actions={actions}
       sx={dialogPaddingStyles(isMobile)}
     >
@@ -135,7 +137,7 @@ const EventSettingsUpdateModalInternal: React.FC<
         setBusy={setBusy}
         setEventClass={setEventClass}
         isOrganizer={isOrganizer}
-        user={currentUser}
+        user={currentUser as userAttendee}
       />
     </ResponsiveDialog>
   )

--- a/common/src/features/Events/EventUpdateModal.tsx
+++ b/common/src/features/Events/EventUpdateModal.tsx
@@ -9,6 +9,7 @@ import { useI18n } from 'twake-i18n'
 import { EventActions } from './EventActions'
 import { useEventUpdateModal } from './useEventUpdateModal'
 import { useEditableInitialValues } from './hooks/useEditableInitialValues'
+import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 
 export interface EventUpdateModalProps {
   eventId: string
@@ -18,12 +19,14 @@ export interface EventUpdateModalProps {
   onCloseAll?: () => void
   eventData?: CalendarEvent | null
   typeOfAction?: 'solo' | 'all'
+  anchorEl?: HTMLElement | null
+  currentView?: string
 }
 
 const EventUpdateModalInternal: React.FC<
   EventUpdateModalProps & { event: CalendarEvent }
 > = props => {
-  const { open, event, typeOfAction } = props
+  const { open, event, typeOfAction, currentView } = props
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
@@ -60,6 +63,8 @@ const EventUpdateModalInternal: React.FC<
       isExpanded={showMore}
       onExpandToggle={handleExpandToggle}
       draggable={!showMore}
+      anchorEl={props.anchorEl}
+      dynamicPositioning={currentView !== CALENDAR_VIEWS.listWeek}
       actions={actions}
       sx={dialogPaddingStyles(isMobile)}
       expandText={t('tooltip.moreEventOptions')}


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Event popovers and dialogs now open near the selected calendar event for improved context.
  - Dialog positioning adapts to the current calendar view, screen size, and available space.
  - Event dialogs support anchored positioning across previews, updates, and settings.

- **Bug Fixes**
  - Prevented overlapping event popovers and dialogs.
  - Improved event status styling and handling for events without matching attendee data.

- **Tests**
  - Added coverage for rendering event update dialogs with an anchor element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->