### PR TITLE
#1218 implement button to trigger active status of booking link

### DIFF
--- a/__test__/components/ResponsiveDialog.test.tsx
+++ b/__test__/components/ResponsiveDialog.test.tsx
@@ -375,4 +375,39 @@ describe('ResponsiveDialog', () => {
 
     expect(mockOnExpandToggle).toHaveBeenCalledTimes(1)
   })
+
+  it('renders headerRightAction when showHeaderActions is false', () => {
+    renderWithTheme(
+      <ResponsiveDialog
+        open={true}
+        onClose={mockOnClose}
+        title="Test"
+        showHeaderActions={false}
+        headerRightAction={<button>Custom Right Action</button>}
+      >
+        <div>Content</div>
+      </ResponsiveDialog>
+    )
+
+    expect(screen.getByText('Custom Right Action')).toBeInTheDocument()
+    expect(screen.queryByLabelText('close')).not.toBeInTheDocument()
+  })
+
+  it('renders headerRightAction in desktop expanded mode', () => {
+    renderWithTheme(
+      <ResponsiveDialog
+        open={true}
+        onClose={mockOnClose}
+        title="Test"
+        isExpanded={true}
+        onExpandToggle={mockOnExpandToggle}
+        headerRightAction={<button>Custom Right Action</button>}
+      >
+        <div>Content</div>
+      </ResponsiveDialog>
+    )
+
+    expect(screen.getByText('Custom Right Action')).toBeInTheDocument()
+    expect(screen.getByLabelText('show less')).toBeInTheDocument()
+  })
 })

--- a/__test__/features/booking/components/BookingStatusSwitch.test.tsx
+++ b/__test__/features/booking/components/BookingStatusSwitch.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TwakeMuiThemeProvider } from '@linagora/twake-mui'
+import { BookingStatusSwitch } from '@private/features/booking/components/BookingStatusSwitch'
+
+jest.mock('twake-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue || key
+  })
+}))
+
+describe('BookingStatusSwitch', () => {
+  const renderWithTheme = (ui: React.ReactElement) =>
+    render(<TwakeMuiThemeProvider>{ui}</TwakeMuiThemeProvider>)
+
+  it('renders switch with active state and handles change', () => {
+    const handleChange = jest.fn()
+    renderWithTheme(
+      <BookingStatusSwitch active={true} onChange={handleChange} />
+    )
+
+    const switchElement = screen.getByRole('switch', {
+      name: /booking.inactiveSchedule/i
+    })
+    expect(switchElement).toBeChecked()
+
+    fireEvent.click(switchElement)
+    expect(handleChange).toHaveBeenCalledWith(false)
+  })
+
+  it('renders switch with inactive state', () => {
+    const handleChange = jest.fn()
+    renderWithTheme(
+      <BookingStatusSwitch active={false} onChange={handleChange} />
+    )
+
+    const switchElement = screen.getByRole('switch', {
+      name: /booking.activeSchedule/i
+    })
+    expect(switchElement).not.toBeChecked()
+  })
+})

--- a/apps/private/src/components/Calendar/CalendarSelection.tsx
+++ b/apps/private/src/components/Calendar/CalendarSelection.tsx
@@ -59,6 +59,7 @@ import { EditAppointmentModal } from '../../features/booking/EditAppointmentModa
 import { handleCopyLink } from '@calendar/common/src/utils/handleCopyLink'
 import { useVisibleBookingLinks } from './hooks/useVisibleBookingLinks'
 import { PrintScheduleModal } from './PrintSchedule/PrintScheduleModal'
+import WebAssetOffOutlinedIcon from '@mui/icons-material/WebAssetOffOutlined'
 
 type SectionHeader = {
   title: string
@@ -225,6 +226,15 @@ const getBookingLinkUrl = (publicId: string): URL => {
   return new URL(`${prefix}/${publicId}`)
 }
 
+const getBookingLinkIcon = (active: boolean, iconColor: string): ReactNode => {
+  const sx = { color: iconColor }
+  return active ? (
+    <EventIcon sx={sx} fontSize="small" />
+  ) : (
+    <WebAssetOffOutlinedIcon sx={sx} fontSize="small" />
+  )
+}
+
 const BookingLinkChip: React.FC<{
   link: BookingLink
   onDelete: (link: BookingLink) => void
@@ -289,7 +299,7 @@ const BookingLinkChip: React.FC<{
           onClick={() => onEdit(link)}
         >
           <div style={{ display: 'flex', padding: '9px', marginRight: '4px' }}>
-            <EventIcon sx={{ color: iconColor }} fontSize="small" />
+            {getBookingLinkIcon(link.active, iconColor)}
           </div>
 
           <Tooltip title={linkName} enterDelay={500} placement="bottom-start">

--- a/apps/private/src/features/booking/CreateAppointmentModal.tsx
+++ b/apps/private/src/features/booking/CreateAppointmentModal.tsx
@@ -31,6 +31,8 @@ export const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
     setCalendarid,
     color,
     setColor,
+    active,
+    setActive,
     error,
     setError,
     loading,
@@ -60,7 +62,7 @@ export const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
         name,
         durationMinutes: duration,
         calendarUrl: `/calendars/${calendarid}`,
-        active: true,
+        active,
         autoAccept: false,
         availabilityRules: availabilityRules
           .filter(rule => rule.enabled)
@@ -108,6 +110,8 @@ export const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
       setCalendarid={setCalendarid}
       color={color}
       setColor={setColor}
+      active={active}
+      onActiveChange={setActive}
       userPersonalCalendars={userPersonalCalendars}
       availabilityRules={availabilityRules}
       setAvailabilityRules={setAvailabilityRules}

--- a/apps/private/src/features/booking/EditAppointmentModal.tsx
+++ b/apps/private/src/features/booking/EditAppointmentModal.tsx
@@ -34,6 +34,8 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
     setCalendarid,
     color,
     setColor,
+    active,
+    setActive,
     error,
     setError,
     loading,
@@ -43,6 +45,29 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
     availabilityRules,
     setAvailabilityRules
   } = useAppointmentForm({ bookingLink, isOpen: open })
+
+  const handleActiveToggle = async (newActive: boolean): Promise<void> => {
+    const prevActive = active
+    setActive(newActive)
+    setLoading(true)
+    setError(null)
+    try {
+      await dispatch(
+        updateBookingLink({
+          publicId: bookingLink.publicId,
+          request: {
+            active: newActive
+          }
+        })
+      ).unwrap()
+    } catch (err) {
+      console.error('Failed to update booking link active status:', err)
+      setError(err instanceof Error ? err.message : String(err))
+      setActive(prevActive)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   const handleSave = async (): Promise<void> => {
     if (!isFormValid) {
@@ -60,6 +85,7 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
             name,
             durationMinutes: duration,
             calendarUrl: `/calendars/${calendarid}`,
+            active,
             availabilityRules: availabilityRules
               .filter(rule => rule.enabled)
               .flatMap(rule =>
@@ -106,13 +132,15 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
       setCalendarid={setCalendarid}
       color={color}
       setColor={setColor}
+      active={active}
+      onActiveChange={newActive => void handleActiveToggle(newActive)}
       userPersonalCalendars={userPersonalCalendars}
       availabilityRules={availabilityRules}
       setAvailabilityRules={setAvailabilityRules}
       error={error}
       loading={loading}
       isFormValid={isFormValid}
-      onSave={handleSave}
+      onSave={() => void handleSave()}
       saveButtonText={t('actions.save', { defaultValue: 'Save' })}
     />
   )

--- a/apps/private/src/features/booking/components/AppointmentModalForm.tsx
+++ b/apps/private/src/features/booking/components/AppointmentModalForm.tsx
@@ -20,6 +20,7 @@ import { DayAvailability } from './RegularHoursField/RegularHoursTypes'
 import { useAppSelector } from '@common/app/hooks'
 import { getAccessiblePair } from '@common/utils/getAccessiblePair'
 import { useFocusTitleOnOpen } from '@common/components/Event/hooks/useAutoFocusTitle'
+import { BookingStatusSwitch } from './BookingStatusSwitch'
 
 interface AppointmentModalFormProps {
   open: boolean
@@ -42,6 +43,8 @@ interface AppointmentModalFormProps {
   userPersonalCalendars: Calendar[]
   availabilityRules?: DayAvailability[]
   setAvailabilityRules?: React.Dispatch<React.SetStateAction<DayAvailability[]>>
+  active?: boolean
+  onActiveChange?: (active: boolean) => void
   error: string | null
   loading: boolean
   isFormValid: boolean
@@ -70,6 +73,8 @@ export const AppointmentModalForm: React.FC<AppointmentModalFormProps> = ({
   userPersonalCalendars,
   availabilityRules,
   setAvailabilityRules,
+  active,
+  onActiveChange,
   error,
   loading,
   isFormValid,
@@ -92,6 +97,15 @@ export const AppointmentModalForm: React.FC<AppointmentModalFormProps> = ({
       open={open}
       onClose={onClose}
       title={title}
+      headerRightAction={
+        onActiveChange && active !== undefined ? (
+          <BookingStatusSwitch
+            active={active}
+            onChange={onActiveChange}
+            disabled={loading}
+          />
+        ) : undefined
+      }
       actions={
         <Button
           onClick={() => void onSave()}

--- a/apps/private/src/features/booking/components/BookingStatusSwitch.tsx
+++ b/apps/private/src/features/booking/components/BookingStatusSwitch.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Box, Switch } from '@linagora/twake-mui'
+import { Tooltip } from '@common/components/Tooltip'
+import { useI18n } from 'twake-i18n'
+
+interface BookingStatusSwitchProps {
+  active: boolean
+  onChange: (active: boolean) => void
+  disabled?: boolean
+}
+
+export const BookingStatusSwitch: React.FC<BookingStatusSwitchProps> = ({
+  active,
+  onChange,
+  disabled = false
+}) => {
+  const { t } = useI18n()
+
+  const tooltipTitle = active
+    ? t('booking.inactiveSchedule')
+    : t('booking.activeSchedule')
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', mr: 1 }}>
+      <Tooltip title={tooltipTitle}>
+        <Switch
+          checked={active}
+          onChange={e => onChange(e.target.checked)}
+          disabled={disabled}
+          color="primary"
+          slotProps={{
+            input: { 'aria-label': tooltipTitle }
+          }}
+        />
+      </Tooltip>
+    </Box>
+  )
+}

--- a/apps/private/src/features/booking/hooks/useAppointmentForm.ts
+++ b/apps/private/src/features/booking/hooks/useAppointmentForm.ts
@@ -30,6 +30,7 @@ interface FormState {
   calendarid: string
   availabilityRules: DayAvailability[]
   color: string
+  active: boolean
 }
 
 interface UseAppointmentFormReturn extends FormState {
@@ -41,6 +42,7 @@ interface UseAppointmentFormReturn extends FormState {
   setCalendarid: (value: string) => void
   setAvailabilityRules: React.Dispatch<React.SetStateAction<DayAvailability[]>>
   setColor: (value: string) => void
+  setActive: (value: boolean) => void
   error: string | null
   setError: (value: string | null) => void
   loading: boolean
@@ -81,7 +83,8 @@ const formStateFromBookingLink = (
       })) || [DEFAULT_SLOT]
     }
   }),
-  color: bookingLink.color ?? calendarColor ?? defaultColors[4].dark
+  color: bookingLink.color ?? calendarColor ?? defaultColors[4].dark,
+  active: bookingLink.active ?? true
 })
 
 const defaultFormState = (
@@ -105,7 +108,8 @@ const defaultFormState = (
       slots: [DEFAULT_SLOT]
     }
   }),
-  color: defaultCalendarColor ?? defaultColors[4].dark
+  color: defaultCalendarColor ?? defaultColors[4].dark,
+  active: true
 })
 
 interface FormSetters {
@@ -117,6 +121,7 @@ interface FormSetters {
   setCalendarid: (value: string) => void
   setAvailabilityRules: React.Dispatch<React.SetStateAction<DayAvailability[]>>
   setColor: (value: string) => void
+  setActive: (value: boolean) => void
 }
 
 const makeSetters = (
@@ -150,7 +155,9 @@ const makeSetters = (
         typeof value === 'function' ? value(prev.availabilityRules) : value
     })),
   setColor: (value: string): void =>
-    setForm(prev => ({ ...prev, color: value }))
+    setForm(prev => ({ ...prev, color: value })),
+  setActive: (value: boolean): void =>
+    setForm(prev => ({ ...prev, active: value }))
 })
 
 const computeInitialFormState = (

--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -97,6 +97,8 @@ interface ResponsiveDialogProps extends Omit<
   anchorEl?: HTMLElement | null
   /** Enable dynamic positioning relative to anchor element (default: false) */
   dynamicPositioning?: boolean
+  /** Optional action element rendered on the right side of header title bar next to header action icons */
+  headerRightAction?: ReactNode
 }
 
 // Context is the only channel that works here: @linagora/twake-mui's Dialog
@@ -198,6 +200,7 @@ function ResponsiveDialog({
   draggable = false,
   anchorEl,
   dynamicPositioning = false,
+  headerRightAction,
   ...otherDialogProps
 }: ResponsiveDialogProps): JSX.Element {
   const theme = useTheme()
@@ -346,45 +349,55 @@ function ResponsiveDialog({
             [titleSx, isDraggable ? { cursor: 'move' } : {}] as SxProps<Theme>
           }
         >
-          {isExpanded && onExpandToggle && !isMobile ? (
-            <IconButton
-              onClick={onExpandToggle}
-              aria-label="show less"
-              sx={{ marginLeft: '-8px' }}
-            >
-              <ArrowBackIcon sx={{ fontSize: 30 }} />
-            </IconButton>
-          ) : showHeaderActions ? (
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                width: '100%'
-              }}
-            >
-              <Box>{title}</Box>
-              <Box>
-                {onExpandToggle && !isMobile && (
-                  <Tooltip title={expandText}>
-                    <IconButton
-                      onClick={onExpandToggle}
-                      aria-label="expand"
-                      size="small"
-                      sx={{ marginRight: 1 }}
-                    >
-                      <OpenInFullIcon sx={{ padding: '2px' }} />
-                    </IconButton>
-                  </Tooltip>
-                )}
-                <IconButton onClick={onClose} aria-label="close" size="small">
-                  <CloseIcon />
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              width: '100%'
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              {isExpanded && onExpandToggle && !isMobile ? (
+                <IconButton
+                  onClick={onExpandToggle}
+                  aria-label="show less"
+                  sx={{ marginLeft: '-8px' }}
+                >
+                  <ArrowBackIcon sx={{ fontSize: 30 }} />
                 </IconButton>
-              </Box>
+              ) : (
+                title
+              )}
             </Box>
-          ) : (
-            title
-          )}
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              {headerRightAction}
+              {showHeaderActions &&
+                !(isExpanded && onExpandToggle && !isMobile) && (
+                  <>
+                    {onExpandToggle && !isMobile && (
+                      <Tooltip title={expandText}>
+                        <IconButton
+                          onClick={onExpandToggle}
+                          aria-label="expand"
+                          size="small"
+                          sx={{ marginRight: 1 }}
+                        >
+                          <OpenInFullIcon sx={{ padding: '2px' }} />
+                        </IconButton>
+                      </Tooltip>
+                    )}
+                    <IconButton
+                      onClick={onClose}
+                      aria-label="close"
+                      size="small"
+                    >
+                      <CloseIcon />
+                    </IconButton>
+                  </>
+                )}
+            </Box>
+          </Box>
         </DialogTitle>
         <DialogContent
           dividers={dividers}

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -570,6 +570,8 @@
     "cancelSuccess": "Reservation cancelled. You can book a new slot if you wish to.",
     "createAppointmentTitle": "Create appointment schedule",
     "editAppointmentTitle": "Edit appointment schedule",
+    "activeSchedule": "Active appointment schedule",
+    "inactiveSchedule": "Inactive appointment schedule",
     "scheduleName": "Schedule name",
     "color": "Color",
     "chooseTimeSlot": "Choose time slot",

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -570,6 +570,8 @@
     "cancelSuccess": "Réservation annulée. Vous pouvez réserver un nouveau créneau si vous le souhaitez.",
     "createAppointmentTitle": "Créer un lien de prise de rendez-vous",
     "editAppointmentTitle": "Modifier le lien de prise de rendez-vous",
+    "activeSchedule": "Lien de rendez-vous actif",
+    "inactiveSchedule": "Lien de rendez-vous inactif",
     "scheduleName": "Nom du planning",
     "color": "Couleur",
     "chooseTimeSlot": "Choisir un créneau",

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -569,6 +569,8 @@
     "cancelSuccess": "Бронирование отменено. Вы можете забронировать новый слот, если хотите.",
     "createAppointmentTitle": "Создать расписание встреч",
     "editAppointmentTitle": "Редактировать расписание встреч",
+    "activeSchedule": "Активное расписание встреч",
+    "inactiveSchedule": "Неактивное расписание встреч",
     "scheduleName": "Название расписания",
     "color": "Цвет",
     "chooseTimeSlot": "Выберите время",

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -569,6 +569,8 @@
     "cancelSuccess": "Đặt chỗ đã bị hủy. Bạn có thể đặt một khung giờ mới nếu muốn.",
     "createAppointmentTitle": "Tạo lịch hẹn",
     "editAppointmentTitle": "Chỉnh sửa lịch hẹn",
+    "activeSchedule": "Lịch hẹn đang hoạt động",
+    "inactiveSchedule": "Lịch hẹn không hoạt động",
     "scheduleName": "Tên lịch trình",
     "color": "Màu sắc",
     "chooseTimeSlot": "Chọn khung giờ",


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an active/inactive toggle for appointment schedules in the create/edit booking flow.
  * The appointment dialog now includes a saveable schedule status switch with contextual labels/tooltips.
  * Added support for rendering custom actions on the right side of dialog headers.
  * Updated schedule/booking link icons to reflect active vs inactive state.
* **Localization**
  * Added English, French, Russian, and Vietnamese labels for active/inactive schedule states.
* **Tests**
  * Added and expanded tests for the schedule status switch and dialog header action rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->