### PR TITLE
#1231 fix display of attendees preview

### DIFF
--- a/__test__/components/AttendeePopover.test.tsx
+++ b/__test__/components/AttendeePopover.test.tsx
@@ -74,7 +74,7 @@ describe('AttendeePopover (Private)', () => {
 
     // Fast-forward open timer
     act(() => {
-      jest.advanceTimersByTime(200)
+      jest.advanceTimersByTime(500)
     })
     expect(screen.getByText('attendees.sendMail')).toBeInTheDocument()
 

--- a/common/src/components/Attendees/AttendeePopover.tsx
+++ b/common/src/components/Attendees/AttendeePopover.tsx
@@ -109,7 +109,7 @@ export function AttendeePopover({
     }
     openTimeoutRef.current = setTimeout(() => {
       setAnchorEl(target)
-    }, 200)
+    }, 500)
   }
 
   const handlePopoverMouseEnter = (): void => {

--- a/common/src/components/Event/utils/eventUtils.tsx
+++ b/common/src/components/Event/utils/eventUtils.tsx
@@ -73,23 +73,23 @@ function renderFullAttendeeBadge({
   const displayName = a.cn || a.cal_address
 
   return (
-    <Box
-      key={key}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 1.5,
-        marginBottom: 0.5,
-        padding: 0.5,
-        borderRadius: 1
-      }}
-    >
-      {a.cutype === 'RESOURCE' ? (
-        <Box sx={{ marginRight: 2 }}>
-          <ResourceIcon />
-        </Box>
-      ) : (
-        <AttendeePopover attendee={a}>
+    <AttendeePopover attendee={a} key={key}>
+      <Box
+        key={key}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1.5,
+          marginBottom: 0.5,
+          padding: 0.5,
+          borderRadius: 1
+        }}
+      >
+        {a.cutype === 'RESOURCE' ? (
+          <Box sx={{ marginRight: 2 }}>
+            <ResourceIcon />
+          </Box>
+        ) : (
           <Badge
             overlap="circular"
             sx={{ marginRight: 2 }}
@@ -112,26 +112,24 @@ function renderFullAttendeeBadge({
           >
             <Avatar {...stringAvatar(displayName)} />
           </Badge>
-        </AttendeePopover>
-      )}
-      <Box style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-        <AttendeePopover attendee={a}>
+        )}
+        <Box style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
           <Typography variant="body2" noWrap>
             {displayName}
           </Typography>
-        </AttendeePopover>
-        {isOrganizer && (
-          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-            {t('event.organizer')}
-          </Typography>
-        )}
-        {caption && (
-          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-            {caption}
-          </Typography>
-        )}
+          {isOrganizer && (
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              {t('event.organizer')}
+            </Typography>
+          )}
+          {caption && (
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              {caption}
+            </Typography>
+          )}
+        </Box>
       </Box>
-    </Box>
+    </AttendeePopover>
   )
 }
 

--- a/common/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/common/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -135,7 +135,16 @@ export function EventPreviewAttendees({
                 ml: isMobile ? mobileAvatarOffset : undefined
               }}
             >
-              <AvatarGroup max={ATTENDEE_DISPLAY_LIMIT}>
+              <AvatarGroup
+                max={ATTENDEE_DISPLAY_LIMIT}
+                sx={{
+                  '& .MuiAvatar-root': {
+                    '&:last-child': {
+                      marginLeft: 'var(--AvatarGroup-spacing, -8px)'
+                    }
+                  }
+                }}
+              >
                 {organizer &&
                   renderAttendeeBadge({
                     a: organizer,


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attendee popovers now open after a 500 ms hover delay.
  * Clicking or hovering across the full attendee badge, including the name and details, consistently opens the popover.

* **Bug Fixes**
  * Improved spacing for the final avatar in attendee previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->