### PR TITLE
#1230 fix bug cannot open event detail from search result and search by keyword

### DIFF
--- a/__test__/features/Search/EventSearchBar.test.tsx
+++ b/__test__/features/Search/EventSearchBar.test.tsx
@@ -1,8 +1,13 @@
 import SearchBar from '@common/components/Menubar/EventSearchBar'
 import * as searchThunk from '@common/features/Search/SearchSlice'
+import { searchPeople } from '@common/features/User/UserDao'
+import { SearchResponseItem } from '@common/types/SearchResponseItem'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '../../utils/Renderwithproviders'
+
+jest.mock('@common/features/User/UserDao')
+const mockedSearchPeople = searchPeople
 
 describe('EventSearchBar', () => {
   const today = new Date()
@@ -229,6 +234,46 @@ describe('EventSearchBar', () => {
       })
     })
   })
+
+  it('should search with keyword on Enter without auto-selecting first suggestion', async () => {
+    const mockUser = new SearchResponseItem({
+      id: '123',
+      emailAddresses: [{ value: 'keyword@example.com' }],
+      names: [{ displayName: 'Keyword User' }],
+      objectType: 'user'
+    })
+    mockedSearchPeople.mockResolvedValueOnce([mockUser])
+
+    const searchSpy = jest.spyOn(searchThunk, 'searchEvents')
+
+    renderWithProviders(<SearchBar />, preloadedState)
+
+    const searchButton = screen.getByRole('button')
+    fireEvent.click(searchButton)
+
+    const searchInput = screen.getByPlaceholderText('common.search')
+    fireEvent.change(searchInput, { target: { value: 'keyword' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Keyword User')).toBeInTheDocument()
+    })
+
+    fireEvent.keyDown(searchInput, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(searchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          search: 'keyword',
+          filters: expect.objectContaining({
+            organizers: []
+          })
+        })
+      )
+    })
+
+    expect(screen.queryByTestId('AttendeeChip')).not.toBeInTheDocument()
+    expect(searchSpy).toHaveBeenCalledTimes(1)
+  })
   it('should not trigger search on Enter key when search is empty', async () => {
     const searchSpy = jest.spyOn(searchThunk, 'searchEvents')
 
@@ -340,5 +385,39 @@ describe('EventSearchBar', () => {
 
     const inputAfter = screen.getByPlaceholderText('common.search')
     expect(inputAfter).toHaveValue('hello')
+  })
+
+  it('should not immediately sync KeywordsFilter input to top search bar until hitting Enter', async () => {
+    renderWithProviders(<SearchBar />, preloadedState)
+
+    // Expand search bar
+    fireEvent.click(screen.getByRole('button'))
+    const searchInput = screen.getByPlaceholderText('common.search')
+
+    // Open filter popover
+    const tuneBtn = screen
+      .getAllByRole('button')
+      .find(b => b.querySelector('[data-testid="TuneIcon"]'))
+    fireEvent.click(tuneBtn!)
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText('search.keywordsPlaceholder')
+      ).toBeInTheDocument()
+    })
+
+    const keywordsInput = screen.getByPlaceholderText(
+      'search.keywordsPlaceholder'
+    )
+    fireEvent.change(keywordsInput, { target: { value: 'typed keyword' } })
+
+    // Top search bar should not be updated immediately
+    expect(searchInput).toHaveValue('')
+
+    // Press Enter in keywords input
+    fireEvent.keyDown(keywordsInput, { key: 'Enter' })
+
+    // Top search bar should now be synced
+    expect(searchInput).toHaveValue('typed keyword')
   })
 })

--- a/common/src/components/Attendees/PeopleSearch.tsx
+++ b/common/src/components/Attendees/PeopleSearch.tsx
@@ -59,6 +59,7 @@ export interface PeopleSearchProps {
   inputValue?: string
   inputStyles?: SxProps
   enableEmailAutocompleteAndCommit?: boolean
+  autoHighlight?: boolean
 }
 
 const autocompleteSx = {
@@ -200,7 +201,8 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
   onSearchStateChange,
   inputValue,
   inputStyles,
-  enableEmailAutocompleteAndCommit
+  enableEmailAutocompleteAndCommit,
+  autoHighlight = true
 }) => {
   const { t } = useI18n()
   const searchPlaceholder = placeholder ?? t('peopleSearch.placeholder')
@@ -262,7 +264,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
         multiple
         options={searchState.options}
         autoComplete={false}
-        autoHighlight
+        autoHighlight={autoHighlight}
         clearOnBlur={false}
         onBlur={freeSolo ? searchState.handleBlurCommit : undefined}
         open={isOpenOptions}

--- a/common/src/components/Menubar/EventSearchBar.tsx
+++ b/common/src/components/Menubar/EventSearchBar.tsx
@@ -132,6 +132,7 @@ const SearchBar: React.FC<{
       attendees: userAttendee[]
     }
   ): Promise<void> => {
+    setSearch(searchQuery)
     if (searchQuery) {
       handleFilterChange('keywords', searchQuery)
     }
@@ -204,6 +205,7 @@ const SearchBar: React.FC<{
 
         {extended && (
           <PeopleSearch
+            autoHighlight={false}
             selectedUsers={selectedContacts}
             showCurrentUser
             onChange={(_event, users) => {
@@ -379,6 +381,7 @@ const SearchBar: React.FC<{
                 error={filterError}
                 onErrorClear={() => setFilterError(false)}
                 onKeywordsChange={(keyword: string) => setSearch(keyword)}
+                onEnter={() => void handleSearch(filters.keywords, filters)}
               />
               <OrganizersFilter
                 mode="popover"

--- a/common/src/components/Menubar/MobileEventSearchBar.tsx
+++ b/common/src/components/Menubar/MobileEventSearchBar.tsx
@@ -32,6 +32,7 @@ const MobileSearchBar: React.FC = () => {
         }}
       >
         <PeopleSearch
+          autoHighlight={false}
           selectedUsers={selectedContacts}
           onChange={(_event, users) => handleContactSelect(users)}
           hideOptions

--- a/common/src/features/Search/DesktopResultItem.tsx
+++ b/common/src/features/Search/DesktopResultItem.tsx
@@ -15,6 +15,7 @@ import {
   RenderTitle,
   RenderVideoJoin
 } from './searchResultsComponents'
+import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 
 export default function DesktopResultItem({
   eventData
@@ -65,7 +66,7 @@ export default function DesktopResultItem({
           }
         }}
       >
-        <Box display="flex" alignItems="center" sx={{ minWidth: '225px' }}>
+        <Box sx={{ minWidth: '225px', display: 'flex', alignItems: 'center' }}>
           <RenderDate
             startDate={startDate}
             endDate={endDate}
@@ -109,6 +110,7 @@ export default function DesktopResultItem({
           calId={calendar.id}
           open={openPreview}
           onClose={() => setOpenPreview(false)}
+          currentView={CALENDAR_VIEWS.listWeek}
         />
       )}
     </>

--- a/common/src/features/Search/KeywordsFilter.tsx
+++ b/common/src/features/Search/KeywordsFilter.tsx
@@ -9,13 +9,15 @@ interface Props {
   error?: boolean
   onErrorClear?: () => void
   onKeywordsChange?: (keywords: string) => void
+  onEnter?: () => void
 }
 
 export const KeywordsFilter: React.FC<Props> = ({
   mode,
   error,
   onErrorClear,
-  onKeywordsChange
+  onKeywordsChange,
+  onEnter
 }) => {
   const { t } = useI18n()
   const dispatch = useAppDispatch()
@@ -34,7 +36,12 @@ export const KeywordsFilter: React.FC<Props> = ({
         dispatch(setFilters({ keywords: e.target.value }))
         if (e.target.value.trim()) {
           onErrorClear?.()
-          onKeywordsChange?.(e.target.value)
+        }
+      }}
+      onKeyDown={e => {
+        if (e.key === 'Enter') {
+          onKeywordsChange?.(filters.keywords)
+          onEnter?.()
         }
       }}
       size="small"

--- a/common/src/features/Search/MobileSearchResultsPage.tsx
+++ b/common/src/features/Search/MobileSearchResultsPage.tsx
@@ -14,6 +14,7 @@ import {
 } from './mobileSearchResultsComponents'
 import { SearchEventResult } from './types/SearchEventResult'
 import { useEventPreview } from './useEventPreview'
+import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 
 const MobileSearchResultsPage: React.FC = () => {
   const searchResults = useAppSelector(state => state.searchResult)
@@ -130,6 +131,7 @@ const MobileResultItem: React.FC<{ eventData: SearchEventResult }> = ({
           calId={calendar.id}
           open={openPreview}
           onClose={() => setOpenPreview(false)}
+          currentView={CALENDAR_VIEWS.listWeek}
         />
       )}
     </>

--- a/common/src/features/Search/searchResultsComponents.tsx
+++ b/common/src/features/Search/searchResultsComponents.tsx
@@ -1,5 +1,6 @@
 import { stringAvatar } from '@common/components/Event/utils/eventUtils'
 import Tooltip from '@common/components/Tooltip'
+import { removeVideoConferenceFromDescription } from '@common/utils/videoConferenceUtils'
 import {
   alpha,
   Avatar,
@@ -226,7 +227,12 @@ export const RenderLocation: React.FC<{ text?: string }> = ({ text }) => {
 }
 
 export const RenderDescription: React.FC<{ text?: string }> = ({ text }) => {
-  return <RenderText text={text} sx={{ flex: '1 1 0%' }} />
+  return (
+    <RenderText
+      text={removeVideoConferenceFromDescription(text ?? '')}
+      sx={{ flex: '1 1 0%' }}
+    />
+  )
 }
 
 export const RenderVideoJoin: React.FC<VideoJoinProps> = ({ url, t }) => {

--- a/common/src/features/Search/types/SearchEventData.ts
+++ b/common/src/features/Search/types/SearchEventData.ts
@@ -1,3 +1,5 @@
+import { userAttendee } from '@common/features/User/models/attendee'
+
 export type SearchEventData = {
   uid: string
   userId: string
@@ -8,13 +10,15 @@ export type SearchEventData = {
   summary?: string
   description?: string
   location?: string
-  class?: string
+  class?: 'PRIVATE' | 'PUBLIC' | 'CONFIDENTIAL'
   dtstamp?: string
   isRecurrentMaster?: boolean
-  attendees?: unknown[]
-  organizer?: {
-    cn?: string
-    email?: string
-  }
+  attendees?: userAttendee[]
+  organizer?:
+    | userAttendee
+    | {
+        cn?: string
+        email?: string
+      }
   ['x-openpaas-videoconference']?: string
 }

--- a/common/src/features/Search/useEventPreview.ts
+++ b/common/src/features/Search/useEventPreview.ts
@@ -5,6 +5,7 @@ import { browserDefaultTimeZone } from '@common/utils/timezone'
 import { useState } from 'react'
 import { getEvent } from '../Calendars/CalendarSlice'
 import { SearchEventResult } from './types/SearchEventResult'
+import { userAttendee } from '../User/models/attendee'
 
 export function useEventPreview(
   eventData: SearchEventResult,
@@ -29,17 +30,17 @@ export function useEventPreview(
       start: eventData.data.start,
       end: eventData.data.end,
       allday: eventData.data.allDay,
-      attendee: eventData.data.attendees,
+      attendee: eventData.data.attendees as userAttendee[],
       class: eventData.data.class,
       description: eventData.data.description,
       stamp: eventData.data.dtstamp,
       location: eventData.data.location,
-      organizer: eventData.data.organizer,
+      organizer: eventData.data.organizer as userAttendee,
       title: eventData.data.summary,
       timezone: timeZone
     }
-    await dispatch(getEvent(event))
     setOpenPreview(true)
+    await dispatch(getEvent(event))
   }
 
   return { openPreview, setOpenPreview, handleOpen, timeZone }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pressing Enter in event or keyword search now applies the search as expected.
  * Keyword filters remain separate until Enter is pressed.
  * Search suggestions no longer auto-highlight results by default.

* **Bug Fixes**
  * Event previews open in the correct calendar view.
  * Event descriptions now omit video-conference details.
  * Improved attendee and organizer information when opening event previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->