### PR TITLE
fix(calendar): fall through to personal calendars on stale selectedCalendars cache

### DIFF
--- a/apps/private/src/components/Calendar/hooks/useManageCalendarSelection.ts
+++ b/apps/private/src/components/Calendar/hooks/useManageCalendarSelection.ts
@@ -40,19 +40,23 @@ export const useManageCalendarSelection = (): {
     const updateSelectedCalendars = (): void => {
       const isValid = initialLoadRef.current && calendarIds.length > 0 && userId
       if (isValid) {
+        const personalCalendarIds = calendarIds.filter(
+          id => extractEventBaseUuid(id) === userId
+        )
         const cached = localStorage.getItem('selectedCalendars')
         if (cached && cached.length > 0) {
           try {
             const parsed = JSON.parse(cached) as string[]
             const valid = parsed.filter(id => calendars[id])
-            setSelectedCalendars(valid)
+            // Fall through to the personal-calendar default when the cached
+            // list references only calendar ids that no longer exist (renamed,
+            // removed, or a fresh login on a different account). Without this
+            // fallback the calendar grid loads empty with no events fetched.
+            setSelectedCalendars(valid.length > 0 ? valid : personalCalendarIds)
           } catch {
-            setSelectedCalendars([])
+            setSelectedCalendars(personalCalendarIds)
           }
         } else {
-          const personalCalendarIds = calendarIds.filter(
-            id => extractEventBaseUuid(id) === userId
-          )
           setSelectedCalendars(personalCalendarIds)
         }
         initialLoadRef.current = false


### PR DESCRIPTION
## Summary

- `useManageCalendarSelection` reads the `selectedCalendars` localStorage key on mount and filters it against the currently-loaded calendars.
- When every cached id references a calendar that no longer exists (renamed, removed, or a fresh login on a different account), the filter returns `[]`.
- Consequence: `setSelectedCalendars([])` is dispatched, `useCalendarLoader` skips every `getCalendarDetail` fetch, and the calendar grid loads **empty** with no events even though the server has plenty.
- Same failure mode on a `JSON.parse` error.
- This PR falls through to the personal-calendar default in both cases — the same branch already used when the cache is missing entirely.

Repro (before this fix):
1. Log in as user A, tick a shared calendar
2. Log out, log in as user B (or wait for A's shared calendar to be revoked)
3. Calendar grid is empty; \`localStorage.setItem('selectedCalendars', '[]')\` becomes sticky
4. Manual workaround: DevTools → Application → clear \`selectedCalendars\`, reload

## Test plan

- [ ] Fresh login (no localStorage): personal calendars auto-selected (unchanged behaviour)
- [ ] Login with valid cached ids: cached selection restored (unchanged)
- [ ] Login where **all** cached ids reference calendars that no longer exist: falls back to personal — grid populated
- [ ] Login where **some** cached ids are stale: valid ids kept, no fallback
- [ ] Corrupted JSON in the cache: falls back to personal

Discovered while debugging an unrelated report of an empty calendar-ng grid on our deploy after a session rotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar selection now defaults to the user’s personal calendars when saved selections are unavailable, invalid, or no longer match existing calendars.
  * Existing valid calendar selections continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->