### PR TITLE
feat(events): per-attendee delegate host crown toggle

### DIFF
--- a/apps/private/src/components/Calendar/hooks/useManageCalendarSelection.ts
+++ b/apps/private/src/components/Calendar/hooks/useManageCalendarSelection.ts
@@ -40,19 +40,23 @@ export const useManageCalendarSelection = (): {
     const updateSelectedCalendars = (): void => {
       const isValid = initialLoadRef.current && calendarIds.length > 0 && userId
       if (isValid) {
+        const personalCalendarIds = calendarIds.filter(
+          id => extractEventBaseUuid(id) === userId
+        )
         const cached = localStorage.getItem('selectedCalendars')
         if (cached && cached.length > 0) {
           try {
             const parsed = JSON.parse(cached) as string[]
             const valid = parsed.filter(id => calendars[id])
-            setSelectedCalendars(valid)
+            // Fall through to the personal-calendar default when the cached
+            // list references only calendar ids that no longer exist (renamed,
+            // removed, or a fresh login on a different account). Without this
+            // fallback the calendar grid loads empty with no events fetched.
+            setSelectedCalendars(valid.length > 0 ? valid : personalCalendarIds)
           } catch {
-            setSelectedCalendars([])
+            setSelectedCalendars(personalCalendarIds)
           }
         } else {
-          const personalCalendarIds = calendarIds.filter(
-            id => extractEventBaseUuid(id) === userId
-          )
           setSelectedCalendars(personalCalendarIds)
         }
         initialLoadRef.current = false

--- a/common/src/components/Attendees/AttendeeChip.tsx
+++ b/common/src/components/Attendees/AttendeeChip.tsx
@@ -2,8 +2,15 @@ import { getAccessiblePair } from '@common/utils/getAccessiblePair'
 import { Box, Chip, Icon, IconButton, useTheme } from '@linagora/twake-mui'
 import CircleIcon from '@mui/icons-material/Circle'
 import CloseIcon from '@mui/icons-material/Close'
+import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium'
+import WorkspacePremiumOutlinedIcon from '@mui/icons-material/WorkspacePremiumOutlined'
 import { ReactElement } from 'react'
 import { User } from './types'
+
+export interface AttendeeChipAction {
+  isDelegateHost: boolean
+  onToggle: () => void
+}
 
 export interface AttendeeChipProps {
   option: string | User
@@ -16,6 +23,11 @@ export interface AttendeeChipProps {
     onDelete: (event: unknown) => void
   }
   getChipIcon?: (user: User) => ReactElement
+  // WS3 host-delegation: when provided, renders a crown toggle inside
+  // the chip label that flips the attendee's is_delegate_host bit.
+  // Return undefined to suppress the toggle for a given user (e.g. the
+  // organizer or a resource).
+  getChipAction?: (user: User) => AttendeeChipAction | undefined
   index: number
 }
 
@@ -23,6 +35,7 @@ export const AttendeeChip: React.FC<AttendeeChipProps> = ({
   option,
   getItemProps,
   getChipIcon,
+  getChipAction,
   index
 }) => {
   const theme = useTheme()
@@ -33,6 +46,8 @@ export const AttendeeChip: React.FC<AttendeeChipProps> = ({
     ? theme.palette.grey[200]
     : (option.color?.light ?? theme.palette.grey[200])
   const textColor = getAccessiblePair(chipColor, theme)
+
+  const chipAction = !isString && getChipAction ? getChipAction(option) : undefined
 
   const renderIcon = (): ReactElement | undefined => {
     if (!isString && getChipIcon) {
@@ -65,6 +80,40 @@ export const AttendeeChip: React.FC<AttendeeChipProps> = ({
     )
   }
 
+  const renderLabel = (): ReactElement => {
+    if (!chipAction) {
+      return <>{label}</>
+    }
+    const CrownIcon = chipAction.isDelegateHost
+      ? WorkspacePremiumIcon
+      : WorkspacePremiumOutlinedIcon
+    return (
+      <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}>
+        <span>{label}</span>
+        <IconButton
+          size="small"
+          onMouseDown={(e): void => {
+            // Stop the Chip from swallowing the click as a "select" event
+            e.stopPropagation()
+          }}
+          onClick={(e): void => {
+            e.stopPropagation()
+            chipAction.onToggle()
+          }}
+          sx={{ padding: 0, color: 'inherit' }}
+          aria-pressed={chipAction.isDelegateHost}
+          title={
+            chipAction.isDelegateHost
+              ? 'Delegate host (will get admin on the Meet room)'
+              : 'Mark as delegate host'
+          }
+        >
+          <CrownIcon fontSize="small" />
+        </IconButton>
+      </Box>
+    )
+  }
+
   return (
     <Chip
       {...getItemProps({ index })}
@@ -75,9 +124,9 @@ export const AttendeeChip: React.FC<AttendeeChipProps> = ({
       deleteIcon={renderDeleteIcon()}
       style={{
         color: textColor,
-        maxWidth: '200px'
+        maxWidth: '240px'
       }}
-      label={label}
+      label={renderLabel()}
     />
   )
 }

--- a/common/src/components/Attendees/AttendeeSearch.tsx
+++ b/common/src/components/Attendees/AttendeeSearch.tsx
@@ -132,6 +132,10 @@ export const AttendeeSearch: React.FC<{
   end?: string
   timezone?: string
   eventUid?: string | null
+  // WS3 host-delegation: only render the crown toggle on chips when the
+  // event has an active Meet URL — delegating admin on a non-existing
+  // room is meaningless.
+  hasVideoConference?: boolean
 }> = ({
   attendees,
   setAttendees,
@@ -141,7 +145,8 @@ export const AttendeeSearch: React.FC<{
   start,
   end,
   timezone,
-  eventUid
+  eventUid,
+  hasVideoConference
 }) => {
   const {
     selectedUsers,
@@ -164,11 +169,28 @@ export const AttendeeSearch: React.FC<{
     })
     setAddedUsers(value.filter(u => !initialEmails.has(u.email)))
     setAttendees(
-      value.map(
-        u => new userAttendee({ cal_address: u.email, cn: u.displayName })
+      value.map(u => {
+        // Preserve existing attendee metadata (partstat, is_delegate_host, …)
+        // so list mutations don't wipe the crown toggle or other bits.
+        const existing = attendees.find(a => a.cal_address === u.email)
+        if (existing) return existing
+        return new userAttendee({ cal_address: u.email, cn: u.displayName })
+      })
+    )
+  }
+
+  const toggleDelegateHost = (email: string): void => {
+    setAttendees(
+      attendees.map(a =>
+        a.cal_address === email ? a.withDelegateHost(!a.is_delegate_host) : a
       )
     )
   }
+
+  const attendeeByEmail = useMemo(
+    () => new Map(attendees.map(a => [a.cal_address, a])),
+    [attendees]
+  )
 
   return (
     <PeopleSearch
@@ -185,6 +207,18 @@ export const AttendeeSearch: React.FC<{
             )
           : undefined
       }
+      getChipAction={(user): {
+        isDelegateHost: boolean
+        onToggle: () => void
+      } | undefined => {
+        if (!hasVideoConference) return undefined
+        const att = attendeeByEmail.get(user.email)
+        if (!att || att.cutype === 'RESOURCE') return undefined
+        return {
+          isDelegateHost: att.is_delegate_host,
+          onToggle: () => toggleDelegateHost(user.email)
+        }
+      }}
       onChange={handleOnChange}
       freeSolo
       enableEmailAutocompleteAndCommit

--- a/common/src/components/Attendees/PeopleSearch.tsx
+++ b/common/src/components/Attendees/PeopleSearch.tsx
@@ -53,6 +53,7 @@ export interface PeopleSearchProps {
     listbox?: Partial<HTMLAttributes<HTMLUListElement>>
   }
   getChipIcon?: (user: User) => ReactElement
+  getChipAction?: AttendeeChipProps['getChipAction']
   hideOptions?: boolean
   showCurrentUser?: boolean
   onSearchStateChange?: (state: SearchState) => void
@@ -90,6 +91,7 @@ interface PeopleSearchValueRendererProps {
   value: User[]
   getItemProps: AttendeeChipProps['getItemProps']
   getChipIcon?: (user: User) => ReactElement
+  getChipAction?: AttendeeChipProps['getChipAction']
 }
 
 const getOptionLabel = (option: User | string): string => {
@@ -127,7 +129,8 @@ const resolveIsOpen = ({
 const PeopleSearchValueRenderer: React.FC<PeopleSearchValueRendererProps> = ({
   value,
   getItemProps,
-  getChipIcon
+  getChipIcon,
+  getChipAction
 }) => (
   <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
     {value.map((option, index) => (
@@ -137,6 +140,7 @@ const PeopleSearchValueRenderer: React.FC<PeopleSearchValueRendererProps> = ({
         getItemProps={getItemProps}
         index={index}
         getChipIcon={getChipIcon}
+        getChipAction={getChipAction}
       />
     ))}
   </Box>
@@ -196,6 +200,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
   customRenderInput,
   customSlotProps,
   getChipIcon,
+  getChipAction,
   hideOptions,
   showCurrentUser,
   onSearchStateChange,
@@ -311,6 +316,7 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
             value={value as User[]}
             getItemProps={getItemProps}
             getChipIcon={getChipIcon}
+            getChipAction={getChipAction}
           />
         )}
       />

--- a/common/src/components/Event/EventFormFields.tsx
+++ b/common/src/components/Event/EventFormFields.tsx
@@ -233,6 +233,9 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
             end={v.end}
             placeholder={t('event.form.addGuestsPlaceholder')}
             inputSlot={params => <TextField {...params} size={inputSize} />}
+            hasVideoConference={
+              !!(v.hasVideoConference && v.meetingLink)
+            }
           />
         </FieldWithLabel>
 

--- a/common/src/components/Event/utils/eventUtils.tsx
+++ b/common/src/components/Event/utils/eventUtils.tsx
@@ -13,6 +13,7 @@ import { formatDateToYYYYMMDDTHHMMSS } from '@common/utils/dateUtils'
 import { Avatar, Badge, Box, Typography } from '@linagora/twake-mui'
 import CancelIcon from '@mui/icons-material/Cancel'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import WorkspacePremiumIcon from '@mui/icons-material/WorkspacePremium'
 import { AttendeePopover } from '@common/components/Attendees/AttendeePopover'
 import { PartStat } from '@common/features/User/models/attendee'
 
@@ -48,10 +49,41 @@ export const classIcon = (
   }
 }
 
-function renderSimpleAttendeeBadge(a: userAttendee, key: string): JSX.Element {
+function renderSimpleAttendeeBadge(
+  a: userAttendee,
+  key: string,
+  showDelegateHost: boolean = false
+): JSX.Element {
+  const avatar = <Avatar {...stringAvatar(a?.cn || a?.cal_address)} />
   return (
     <AttendeePopover key={key} attendee={a}>
-      <Avatar {...stringAvatar(a?.cn || a?.cal_address)} />
+      {a.is_delegate_host && showDelegateHost ? (
+        <Badge
+          overlap="circular"
+          anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+          badgeContent={
+            <Box
+              style={{
+                fontSize: 14,
+                lineHeight: 0,
+                backgroundColor: 'white',
+                borderRadius: '50%',
+                padding: '1px'
+              }}
+            >
+              <WorkspacePremiumIcon
+                fontSize="inherit"
+                sx={{ color: 'warning.main' }}
+                titleAccess="Delegate host"
+              />
+            </Box>
+          }
+        >
+          {avatar}
+        </Badge>
+      ) : (
+        avatar
+      )}
     </AttendeePopover>
   )
 }
@@ -61,13 +93,15 @@ function renderFullAttendeeBadge({
   key,
   t,
   isOrganizer,
-  caption
+  caption,
+  showDelegateHost = false
 }: {
   a: userAttendee
   key: string
   t: (key: string) => string
   isOrganizer?: boolean
   caption?: string
+  showDelegateHost?: boolean
 }): JSX.Element {
   const icon = classIcon(a.partstat)
   const displayName = a.cn || a.cal_address
@@ -114,12 +148,26 @@ function renderFullAttendeeBadge({
           </Badge>
         )}
         <Box style={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-          <Typography variant="body2" noWrap>
-            {displayName}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <Typography variant="body2" noWrap>
+              {displayName}
+            </Typography>
+            {a.is_delegate_host && showDelegateHost && (
+              <WorkspacePremiumIcon
+                fontSize="small"
+                sx={{ color: 'warning.main' }}
+                titleAccess="Delegate host — will get admin on the Meet room"
+              />
+            )}
+          </Box>
           {isOrganizer && (
             <Typography variant="caption" sx={{ color: 'text.secondary' }}>
               {t('event.organizer')}
+            </Typography>
+          )}
+          {a.is_delegate_host && showDelegateHost && !isOrganizer && (
+            <Typography variant="caption" sx={{ color: 'warning.main' }}>
+              Delegate host
             </Typography>
           )}
           {caption && (
@@ -139,7 +187,8 @@ export function renderAttendeeBadge({
   t,
   isFull,
   isOrganizer,
-  caption
+  caption,
+  showDelegateHost = false
 }: {
   a: userAttendee
   key: string
@@ -147,13 +196,18 @@ export function renderAttendeeBadge({
   isFull?: boolean
   isOrganizer?: boolean
   caption?: string
+  // WS3: only render the delegate-host crown when the event has an
+  // active Meet URL. Without it, the flag is meaningless (nothing to
+  // delegate) — hiding it avoids showing stale data on events whose
+  // videoconference was removed after delegates were set.
+  showDelegateHost?: boolean
 }): JSX.Element {
   if (!a) return <></>
 
   if (!isFull) {
-    return renderSimpleAttendeeBadge(a, key)
+    return renderSimpleAttendeeBadge(a, key, showDelegateHost)
   }
-  return renderFullAttendeeBadge({ a, key, t, isOrganizer, caption })
+  return renderFullAttendeeBadge({ a, key, t, isOrganizer, caption, showDelegateHost })
 }
 
 export function stringToColor(string: string): string {

--- a/common/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/common/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -25,6 +25,7 @@ interface EventPreviewAttendeesProps {
   end?: string
   timezone?: string
   eventUid?: string | null
+  hasVideoConference?: boolean
 }
 
 const ATTENDEE_DISPLAY_LIMIT = 3
@@ -36,7 +37,8 @@ export function EventPreviewAttendees({
   start,
   end,
   timezone,
-  eventUid
+  eventUid,
+  hasVideoConference = false
 }: EventPreviewAttendeesProps): JSX.Element {
   const { t } = useI18n()
   const theme = useTheme()
@@ -151,14 +153,16 @@ export function EventPreviewAttendees({
                     key: 'org',
                     t,
                     isFull: showAllAttendees,
-                    isOrganizer: true
+                    isOrganizer: true,
+                    showDelegateHost: hasVideoConference
                   })}
                 {attendees.map((a, idx) =>
                   renderAttendeeBadge({
                     a,
                     key: idx.toString(),
                     t,
-                    isFull: showAllAttendees
+                    isFull: showAllAttendees,
+                    showDelegateHost: hasVideoConference
                   })
                 )}
               </AvatarGroup>
@@ -201,7 +205,8 @@ export function EventPreviewAttendees({
           key: 'org',
           t,
           isFull: showAllAttendees,
-          isOrganizer: true
+          isOrganizer: true,
+          showDelegateHost: hasVideoConference
         })}
       {showAllAttendees &&
         attendees.map((a, idx) =>
@@ -211,7 +216,8 @@ export function EventPreviewAttendees({
             t,
             isFull: showAllAttendees,
             isOrganizer: false,
-            caption: busyCaption(a)
+            caption: busyCaption(a),
+            showDelegateHost: hasVideoConference
           })
         )}
     </>

--- a/common/src/components/EventPreview/EventPreviewDetails.tsx
+++ b/common/src/components/EventPreview/EventPreviewDetails.tsx
@@ -78,7 +78,8 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
           key: 'org',
           t,
           isFull: true,
-          isOrganizer: true
+          isOrganizer: true,
+          showDelegateHost: !!event.x_openpass_videoconference
         })}
 
       {shouldShowAttendeesSection && (
@@ -90,6 +91,7 @@ export const EventPreviewDetails: React.FC<EventPreviewDetailsProps> = ({
           end={event.end}
           timezone={event.timezone}
           eventUid={event.uid}
+          hasVideoConference={!!event.x_openpass_videoconference}
         />
       )}
 

--- a/common/src/features/Events/updateEventHelpers/updateAttendeesAfterTimeChange.ts
+++ b/common/src/features/Events/updateEventHelpers/updateAttendeesAfterTimeChange.ts
@@ -23,7 +23,11 @@ export const updateAttendeesAfterTimeChange = (
         att.cal_address,
         markNeedsAction(att)
       )
-      return timeChanged ? markNeedsAction(existing) : existing
+      const base = timeChanged ? markNeedsAction(existing) : existing
+      // The form-side attendee carries UI-owned bits that the existing
+      // event attendee should not override (e.g. WS3 is_delegate_host,
+      // toggled via the crown). partstat/rsvp/role remain server-owned.
+      return base.withDelegateHost(att.is_delegate_host)
     })
 
     // Only append organizer entry if organizer exists

--- a/common/src/features/Events/utils/makeVevent.ts
+++ b/common/src/features/Events/utils/makeVevent.ts
@@ -77,6 +77,24 @@ export function makeVevent(
     vevent[1].push(att.asJcal())
   })
 
+  // WS3 host-delegation: emit X-TWAKE-DELEGATE-HOSTS with the emails of
+  // attendees flagged as delegate hosts. Only emit when the event has an
+  // active Meet URL — the side-service consumer would silently bail
+  // without one, but keeping the ICS clean is nicer for round-trip.
+  if (event.x_openpass_videoconference) {
+    const delegateEmails = event.attendee
+      .filter(att => att.is_delegate_host)
+      .map(att => att.cal_address.replace(/^mailto:/i, ''))
+    if (delegateEmails.length > 0) {
+      vevent[1].push([
+        'x-twake-delegate-hosts',
+        {},
+        'text',
+        delegateEmails.join(',')
+      ])
+    }
+  }
+
   if (event.exdates && event.exdates.length > 0) {
     event.exdates.forEach(ex => {
       vevent[1].push([

--- a/common/src/features/Events/utils/parseCalendarEvent.ts
+++ b/common/src/features/Events/utils/parseCalendarEvent.ts
@@ -27,6 +27,7 @@ const KNOWN_PROPS = new Set([
   'class',
   'x-openpaas-videoconference',
   'x-openpaas-booking-link',
+  'x-twake-delegate-hosts',
   'summary',
   'description',
   'location',
@@ -56,6 +57,10 @@ function safeString(value: VObjectValue): string {
 interface PropertyContext {
   recurrenceId?: string
   duration?: string
+  // WS3 host-delegation: emails flagged as delegate hosts, captured from
+  // the top-level X-TWAKE-DELEGATE-HOSTS property. Applied to matching
+  // attendees after all properties are parsed.
+  delegateHostEmails?: Set<string>
 }
 
 function parseDateProperty(
@@ -179,6 +184,16 @@ const PROPERTY_PARSERS: Record<
   },
   'x-openpaas-booking-link': (params, value, event) => {
     event.bookingLinkPublicId = safeString(value)
+  },
+  'x-twake-delegate-hosts': (params, value, _event, context) => {
+    const raw = safeString(value)
+    if (!raw) return
+    context.delegateHostEmails = new Set(
+      raw
+        .split(',')
+        .map(e => e.trim().toLowerCase())
+        .filter(e => e.length > 0)
+    )
   },
   summary: (params, value, event) => {
     event.title = safeString(value)
@@ -367,6 +382,24 @@ export function parseCalendarEvent({
   }
 
   processEventUid(event, context.recurrenceId)
+
+  // WS3 host-delegation: apply the X-TWAKE-DELEGATE-HOSTS emails to the
+  // matching parsed attendees so the UI can hydrate the crown toggle.
+  // Guarded try/catch — a broken attendee shape (post-Redux plain object
+  // without .withDelegateHost) would otherwise reject the whole calendar
+  // refresh via the pMap outer promise.
+  try {
+    if (context.delegateHostEmails && event.attendee) {
+      event.attendee = event.attendee.map(att =>
+        typeof att.withDelegateHost === 'function' &&
+        context.delegateHostEmails!.has((att.cal_address || '').toLowerCase())
+          ? att.withDelegateHost(true)
+          : att
+      )
+    }
+  } catch (err) {
+    console.warn('[WS3] failed to apply delegate-host flag', err)
+  }
 
   const alarms = parseAlarms(valarms)
   if (alarms?.hasAlarms()) {

--- a/common/src/features/User/models/attendee.ts
+++ b/common/src/features/User/models/attendee.ts
@@ -14,6 +14,7 @@ export interface UserAttendeeData {
   cutype: CuType
   rsvp: 'TRUE' | 'FALSE'
   cn: string
+  is_delegate_host: boolean
 }
 
 export type UserAttendeeOptions = Partial<UserAttendeeData>
@@ -25,6 +26,7 @@ export class userAttendee implements UserAttendeeData {
   cutype: CuType
   rsvp: 'TRUE' | 'FALSE'
   cn: string
+  is_delegate_host: boolean
 
   constructor({
     cal_address,
@@ -32,7 +34,8 @@ export class userAttendee implements UserAttendeeData {
     role,
     cutype,
     rsvp,
-    cn
+    cn,
+    is_delegate_host
   }: UserAttendeeOptions = {}) {
     this.cal_address = cal_address ?? ''
     this.partstat = partstat ?? 'NEEDS-ACTION'
@@ -40,6 +43,7 @@ export class userAttendee implements UserAttendeeData {
     this.cutype = cutype ?? 'INDIVIDUAL'
     this.rsvp = rsvp ?? 'FALSE'
     this.cn = cn ?? ''
+    this.is_delegate_host = is_delegate_host ?? false
   }
 
   static fromOrganizer(organizer: userOrganiser | undefined): userAttendee {
@@ -86,6 +90,10 @@ export class userAttendee implements UserAttendeeData {
 
   withRsvp(rsvp: 'TRUE' | 'FALSE'): userAttendee {
     return new userAttendee({ ...this, rsvp })
+  }
+
+  withDelegateHost(is_delegate_host: boolean): userAttendee {
+    return new userAttendee({ ...this, is_delegate_host })
   }
 
   asMailto(): string {


### PR DESCRIPTION
## Summary

- Adds a per-attendee **crown toggle** to the event editor. Ticked attendees end up in a new `X-TWAKE-DELEGATE-HOSTS` ICS custom property.
- Companion side-service PR ([linagora/twake-calendar-side-service#1001](https://github.com/linagora/twake-calendar-side-service/pull/1001)) reads that property and grants each listed email \`administrator\` on the underlying LaSuite Meet room, so delegates can admit lobby / manage recording / kick without the organizer being present.
- Read-only crown badge overlay + \"Delegate host\" caption in the event detail view, both gated on the event having an active Meet URL — otherwise the flag is meaningless.

## UX notes

- Toggle only rendered when \`event.hasVideoConference && event.meetingLink\` — resources and the organizer never get one.
- Round-trip preserved: re-open a saved event, matching attendees have the crown lit.
- Un-toggle **persists** via a fix to \`updateAttendeesAfterTimeChange\` (was previously clobbering the form-side attendee with the pre-save copy).
- Handler in \`AttendeeSearch\` fixes a pre-existing latent bug where every list mutation rebuilt attendees from scratch, wiping partstat / rsvp too.

## Files touched (12)

**State + ser/de:**
- \`types/EventsTypes.ts\`, \`User/models/attendee.ts\` — new \`is_delegate_host: boolean\` + \`withDelegateHost()\` helper.
- \`features/Events/utils/makeVevent.ts\` — emit \`X-TWAKE-DELEGATE-HOSTS\` when Meet URL + flagged attendees.
- \`features/Events/utils/parseCalendarEvent.ts\` — parse + apply to attendees on load (guarded with function-typeof + try/catch belt-and-braces).
- \`features/Events/updateEventHelpers/updateAttendeesAfterTimeChange.ts\` — overlay UI-owned bits onto the preserved attendee.

**UI:**
- \`components/Attendees/{AttendeeChip,AttendeeSearch,PeopleSearch}.tsx\` — crown IconButton inside the chip label + \`getChipAction\` prop plumbing.
- \`components/Event/EventFormFields.tsx\` — passes \`hasVideoConference\` down.
- \`components/Event/utils/eventUtils.tsx\` + \`components/EventPreview/EventPreview{Attendees,Details}.tsx\` — read-only crown badge + \"Delegate host\" caption, gated on \`event.x_openpass_videoconference\`.

## Tested

- Manual E2E on our \`twake-dev.maudet.cloud\` deploy — create event with Meet URL + tick delegate → side-service grants admin (HTTP 201) → verified in Meet DB.
- Un-toggle → re-save → reload: crown gone, property stripped from ICS.
- Remove Meet URL: crown UI hidden AND property no longer emitted even when flag is still set.

## Overlap with #1245

The branch was cut from \`main\` **before** #1245 (\`fix/selected-calendars-fallback\`) so it happens to include the same localStorage fallback commit. If #1245 lands first this PR will fast-forward cleanly; if this PR merges first, please close #1245.

## Not tested / follow-up

- Tooltip text is hard-coded EN via \`title=\`. Follow-up: extract to i18n keys once the maintainer confirms the key namespace.
- No unit tests added — happy to add coverage on \`makeVevent\` / \`parseCalendarEvent\` round-trip if requested.