### PR TITLE
feat(event): Ask the server for the video conference room

### DIFF
--- a/__test__/features/Events/VideoConferenceDao.test.tsx
+++ b/__test__/features/Events/VideoConferenceDao.test.tsx
@@ -1,0 +1,75 @@
+import { createVideoConference } from '@common/features/Events/VideoConferenceDao'
+import { api } from '@common/utils/apiUtils'
+import { HTTPError } from 'ky'
+
+jest.mock('@common/utils/apiUtils')
+
+const mockedApi = api as jest.Mocked<typeof api>
+
+function jsonResponse(body: unknown): { json: () => Promise<unknown> } {
+  return { json: () => Promise.resolve(body) }
+}
+
+/**
+ * Built from plain objects rather than `new Response(...)`: jsdom provides
+ * neither `Response` nor `Request`, and ky's constructor only reads
+ * `status`, `statusText`, `method` and `url` to compose its message.
+ */
+function httpError(status: number): HTTPError {
+  return new HTTPError(
+    { status, statusText: '' } as Response,
+    {
+      method: 'POST',
+      url: 'https://example.test/api/videoconference'
+    } as Request,
+    {} as never
+  )
+}
+
+describe('createVideoConference', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('returns the link the server minted', async () => {
+    mockedApi.post = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ url: 'https://meet.example.test/pkp-cmre-umg' })
+      ) as never
+
+    await expect(createVideoConference()).resolves.toBe(
+      'https://meet.example.test/pkp-cmre-umg'
+    )
+    expect(mockedApi.post).toHaveBeenCalledWith('api/videoconference')
+  })
+
+  // The deployment-does-not-mint-rooms case. It has to be distinguishable from
+  // a failure: the caller falls back to generating a link locally, which is
+  // exactly what those deployments expect.
+  it('returns null when the route is absent', async () => {
+    mockedApi.post = jest.fn().mockRejectedValue(httpError(404)) as never
+
+    await expect(createVideoConference()).resolves.toBeNull()
+  })
+
+  // The other polarity of the same branch. Without it, a DAO that swallowed
+  // every HTTP error would pass the test above just as well — and a
+  // conferencing backend that is down would look like a deployment that never
+  // had one.
+  it('rethrows any other HTTP failure', async () => {
+    mockedApi.post = jest.fn().mockRejectedValue(httpError(502)) as never
+
+    await expect(createVideoConference()).rejects.toBeInstanceOf(HTTPError)
+  })
+
+  it('rejects a room that comes back without a link', async () => {
+    // An empty href in an invitation reads as a broken product rather than a
+    // broken deployment, so this must be loud.
+    mockedApi.post = jest
+      .fn()
+      .mockResolvedValue(jsonResponse({ slug: 'pkp-cmre-umg' })) as never
+
+    await expect(createVideoConference()).rejects.toThrow('no url')
+  })
+})

--- a/common/src/components/Event/fields/VideoConferenceField.tsx
+++ b/common/src/components/Event/fields/VideoConferenceField.tsx
@@ -90,20 +90,27 @@ const VideoConferenceFieldInExpandedMode: React.FC<{
   cameraIcon: React.ReactNode
   handleDeleteVideoConference: () => void
   handleAddVideoConference: () => void
+  isAddingVideoConference: boolean
 }> = ({
   hasVideoConference,
   meetingLink,
   cameraIcon,
   handleDeleteVideoConference,
-  handleAddVideoConference
+  handleAddVideoConference,
+  isAddingVideoConference
 }) => {
   const { t } = useI18n()
 
   return (
     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+      {/* The room is now created server-side, so adding a conference is a
+          round trip rather than a string concatenation. Disabling the button
+          while it is in flight keeps a second click from asking for a second
+          room — the first one would then be orphaned. */}
       <Button
         startIcon={cameraIcon}
         onClick={handleAddVideoConference}
+        disabled={isAddingVideoConference}
         size="medium"
         variant="contained"
         color="secondary"
@@ -141,15 +148,18 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
-  const { handleAddVideoConference, handleDeleteVideoConference } =
-    useVideoConference({
-      description,
-      setDescription,
-      setHasVideoConference,
-      setMeetingLink,
-      showMore,
-      setShowDescription
-    })
+  const {
+    handleAddVideoConference,
+    handleDeleteVideoConference,
+    isAddingVideoConference
+  } = useVideoConference({
+    description,
+    setDescription,
+    setHasVideoConference,
+    setMeetingLink,
+    showMore,
+    setShowDescription
+  })
 
   const cameraIcon = (
     <img src={iconCamera} alt="camera" width={24} height={24} />
@@ -167,7 +177,7 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
             meetingLink={meetingLink}
             cameraIcon={cameraIcon}
             handleDeleteVideoConference={handleDeleteVideoConference}
-            handleAddVideoConference={handleAddVideoConference}
+            handleAddVideoConference={() => void handleAddVideoConference()}
           />
         ) : (
           <VideoConferenceFieldInExpandedMode
@@ -175,7 +185,8 @@ export const VideoConferenceField: React.FC<VideoConferenceFieldProps> = ({
             meetingLink={meetingLink}
             cameraIcon={cameraIcon}
             handleDeleteVideoConference={handleDeleteVideoConference}
-            handleAddVideoConference={handleAddVideoConference}
+            handleAddVideoConference={() => void handleAddVideoConference()}
+            isAddingVideoConference={isAddingVideoConference}
           />
         )}
       </FieldWithLabel>

--- a/common/src/components/Event/hooks/useVideoConference.ts
+++ b/common/src/components/Event/hooks/useVideoConference.ts
@@ -1,5 +1,7 @@
 import { useAppSelector } from '@common/app/hooks'
+import { createVideoConference } from '@common/features/Events/VideoConferenceDao'
 import { generateMeetingLink } from '@common/utils/videoConferenceUtils'
+import { useState } from 'react'
 
 interface UseVideoConferenceProps {
   description: string
@@ -11,8 +13,9 @@ interface UseVideoConferenceProps {
 }
 
 interface UseVideoConferenceReturn {
-  handleAddVideoConference: () => void
+  handleAddVideoConference: () => Promise<void>
   handleDeleteVideoConference: () => void
+  isAddingVideoConference: boolean
 }
 
 export const useVideoConference = ({
@@ -25,16 +28,43 @@ export const useVideoConference = ({
     state => state.user.userData?.workplaceFqdn
   )
   const email = useAppSelector(state => state.user.userData?.email)
+  const [isAddingVideoConference, setIsAddingVideoConference] = useState(false)
 
-  const handleAddVideoConference = (): void => {
-    const newMeetingLink = generateMeetingLink({
-      localpart: email?.split('@')[0],
-      workplaceFqdn
-    })
-    setHasVideoConference(true)
-    setMeetingLink(newMeetingLink)
-    if (showMore) {
-      setShowDescription?.(true)
+  /**
+   * The link now comes from the server, which creates the room before the
+   * invitation goes out. `generateMeetingLink` remains the fallback for
+   * deployments whose server does not mint rooms — it is the old behaviour,
+   * kept for them and only for them.
+   */
+  const handleAddVideoConference = async (): Promise<void> => {
+    if (isAddingVideoConference) return
+    setIsAddingVideoConference(true)
+    try {
+      const localLink = (): string =>
+        generateMeetingLink({
+          localpart: email?.split('@')[0],
+          workplaceFqdn
+        })
+
+      let newMeetingLink: string
+      try {
+        newMeetingLink = (await createVideoConference()) ?? localLink()
+      } catch {
+        // A conferencing backend that is down must not block saving the
+        // event. The local link is what this form produced until now, so
+        // falling back to it is no worse than the previous behaviour.
+        newMeetingLink = localLink()
+      }
+
+      if (!newMeetingLink) return
+
+      setHasVideoConference(true)
+      setMeetingLink(newMeetingLink)
+      if (showMore) {
+        setShowDescription?.(true)
+      }
+    } finally {
+      setIsAddingVideoConference(false)
     }
   }
 
@@ -45,6 +75,7 @@ export const useVideoConference = ({
 
   return {
     handleAddVideoConference,
-    handleDeleteVideoConference
+    handleDeleteVideoConference,
+    isAddingVideoConference
   }
 }

--- a/common/src/features/Events/VideoConferenceDao.ts
+++ b/common/src/features/Events/VideoConferenceDao.ts
@@ -1,0 +1,41 @@
+import { api } from '@common/utils/apiUtils'
+import { HTTPError } from 'ky'
+
+interface CreateVideoConferenceResponse {
+  url?: string
+}
+
+/**
+ * Ask the server to create a video conference room and return its link.
+ *
+ * The link used to be invented in the browser — three then four then three
+ * random letters — and written straight into the event. Nothing told the
+ * conferencing backend about it, so on any deployment that refuses
+ * unregistered rooms every generated link was dead. Asking the server fixes
+ * that at the source, and makes the organiser the room's owner, which a
+ * locally minted code could never do.
+ *
+ * Resolves to `null` when this deployment does not mint rooms: the route
+ * answers 404 when the server has no conferencing credentials, and the caller
+ * then falls back to generating a link itself — the behaviour deployments
+ * running with unregistered rooms enabled still rely on.
+ */
+export async function createVideoConference(): Promise<string | null> {
+  let response
+  try {
+    response = await api.post('api/videoconference')
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 404) {
+      return null
+    }
+    throw error
+  }
+
+  const body = await response.json<CreateVideoConferenceResponse>()
+  if (!body.url) {
+    // A room without a link would put an empty href in an invitation, which
+    // reads as a broken product rather than a broken deployment.
+    throw new Error('createVideoConference returned no url')
+  }
+  return body.url
+}


### PR DESCRIPTION
Part of linagora/twake-calendar-side-service#1004.

## The problem

`generateMeetingId` invents the room code in the browser — three then four then
three random letters — and `handleAddVideoConference` writes it straight into the
event:

```ts
export function generateMeetingId(): string {
  const chars = 'abcdefghijklmnopqrstuvwxyz'
  const generateSegment = (length: number): string =>
    Array.from({ length }, () => chars[Math.floor(Math.random() * chars.length)]).join('')
  return `${generateSegment(3)}-${generateSegment(4)}-${generateSegment(3)}`
}
```

Nothing tells the conferencing backend about that code. On any deployment that
refuses unregistered rooms, **every generated link is dead** — the room it names
has never been created, and no client can join it:

```
$ curl -s -o - -w '%{http_code}' https://<meet-host>/api/v1.0/rooms/mjj-beyv-zai/
{"detail":"No Room matches the given query."}404
```

It also silently breaks host delegation, which cannot grant rights on a room that
does not exist.

## What this changes

The room now comes from the server, which creates it **before the invitation goes
out** and makes the organiser its owner — something a locally minted code could
never do, and the reason lobby admission and recording never worked on links
created here.

- `common/src/features/Events/VideoConferenceDao.ts` — `createVideoConference()`,
  `POST api/videoconference` through the existing `ky` instance.
- `common/src/components/Event/hooks/useVideoConference.ts` — the handler becomes
  async and asks the server.
- `common/src/components/Event/fields/VideoConferenceField.tsx` — the expanded
  button is disabled while the request is in flight.

`generateMeetingLink` stays, **on purpose and only for the deployments that still
rely on it**: the server route answers `404` where it has no conferencing
credentials, and those deployments run their backend with unregistered rooms
enabled, where a locally minted link is exactly right.

Two different signals, kept apart: `404` resolves to `null` and falls back;
anything else rethrows. A backend that is merely *down* must not be mistaken for
a deployment that never had one — and it must not block saving the event either,
so the hook falls back there too.

Adding a conference is now a round trip, so the button reports it. The handler is
guarded against re-entry and the button is disabled in flight; otherwise a second
click would ask for a second room and orphan the first.

## Measured on a Twake deployment

Two video conferences created from this editor produced two real rooms in the
conferencing backend, seconds apart, both resolving `200` where the previous
random codes returned `404`. Host delegation, which had logged
`Meet room not found for slug …` the day before, granted admin rights instead.

## Tests

Four on the DAO, executed, covering **both polarities** of the `404` branch —
verified by mutation: making the DAO swallow every `HTTPError` turns the
"rethrows any other HTTP failure" test red.

`npx jest __test__/features/Events` stays green at 26 suites / 421 tests.
`tsc --noEmit` and `eslint` are clean on the touched files.

## Companion change

The server half is linagora/twake-calendar-side-service#1002, which adds
`POST /api/videoconference`. Either alone is a no-op: this side falls back to
local generation on `404`, and that route is never called until this side asks.
