### PR TITLE
#1258 Display extra attendees in public booking view

### DIFF
--- a/apps/private/src/features/booking/utils/index.ts
+++ b/apps/private/src/features/booking/utils/index.ts
@@ -29,9 +29,7 @@ export const formatAlarms = (
   }))
 
 export const formatExtraAttendees = (attendees: userAttendee[]): string[] =>
-  attendees
-    .map(a => a.openpaasId || a.cal_address.replace(/^mailto:/i, ''))
-    .filter(Boolean)
+  attendees.map(a => a.openpaasId || '').filter(Boolean)
 
 export const formatAvailabilityRules = (
   availabilityRules: DayAvailability[],

--- a/apps/public/src/components/Booking/BookingHeader/BookingExtraAttendees.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingExtraAttendees.tsx
@@ -1,0 +1,148 @@
+import React, { useState } from 'react'
+import { AvatarGroup, Box, Button, Typography } from '@linagora/twake-mui'
+import GroupAddOutlinedIcon from '@mui/icons-material/GroupAddOutlined'
+import { useI18n } from 'twake-i18n'
+import { userAttendee } from '@common/features/User/models/attendee'
+import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
+import { renderAttendeeBadge } from '@common/components/Event/utils/eventUtils'
+
+interface BookingExtraAttendeesProps {
+  extraAttendees: userAttendee[]
+}
+
+interface CollapsedAttendeesProps {
+  extraAttendees: userAttendee[]
+  isMobile: boolean
+  onShowMore: () => void
+  t: (key: string, options?: Record<string, string>) => string
+}
+
+const ATTENDEE_DISPLAY_LIMIT = 3
+
+const CollapsedAttendees: React.FC<CollapsedAttendeesProps> = ({
+  extraAttendees,
+  onShowMore,
+  t
+}) => (
+  <Box
+    sx={{
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center'
+    }}
+  >
+    <AvatarGroup
+      max={ATTENDEE_DISPLAY_LIMIT}
+      sx={{
+        '& .MuiAvatar-root': {
+          '&:last-child': {
+            marginLeft: 'var(--AvatarGroup-spacing, -8px)'
+          }
+        }
+      }}
+    >
+      {extraAttendees.map((a, idx) =>
+        renderAttendeeBadge({
+          a,
+          key: idx.toString(),
+          t,
+          isFull: false
+        })
+      )}
+    </AvatarGroup>
+    <Button
+      variant="text"
+      size="small"
+      sx={{
+        marginLeft: 2,
+        color: 'text.secondary',
+        alignSelf: 'center'
+      }}
+      onClick={onShowMore}
+    >
+      {t('eventPreview.showMore')}
+    </Button>
+  </Box>
+)
+
+const ExpandedAttendees: React.FC<{
+  extraAttendees: userAttendee[]
+  t: (key: string, options?: Record<string, string>) => string
+}> = ({ extraAttendees, t }) => (
+  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+    {extraAttendees.map((a, idx) =>
+      renderAttendeeBadge({
+        a,
+        key: idx.toString(),
+        t,
+        isFull: true,
+        isOrganizer: false
+      })
+    )}
+  </Box>
+)
+
+const ShowLessButton: React.FC<{
+  onClick: () => void
+  t: (key: string, options?: Record<string, string>) => string
+}> = ({ onClick, t }) => (
+  <Button
+    variant="text"
+    size="small"
+    sx={{
+      marginLeft: 2,
+      fontSize: '14px',
+      color: 'text.secondary',
+      alignSelf: 'center'
+    }}
+    onClick={onClick}
+  >
+    {t('eventPreview.showLess')}
+  </Button>
+)
+
+export function BookingExtraAttendees({
+  extraAttendees
+}: BookingExtraAttendeesProps): JSX.Element {
+  const { t } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const [showAllAttendees, setShowAllAttendees] = useState(false)
+
+  const handleShowLess = (): void => setShowAllAttendees(false)
+  const handleShowMore = (): void => setShowAllAttendees(true)
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1
+        }}
+      >
+        <GroupAddOutlinedIcon sx={{ color: 'text.secondary' }} />
+
+        <Typography variant="body2" sx={{ mr: isMobile ? 0 : 2 }}>
+          {t('eventPreview.extraAttendees', {
+            count: extraAttendees.length
+          })}
+        </Typography>
+
+        {!showAllAttendees && (
+          <CollapsedAttendees
+            extraAttendees={extraAttendees}
+            isMobile={isMobile}
+            onShowMore={handleShowMore}
+            t={t}
+          />
+        )}
+
+        {showAllAttendees && <ShowLessButton onClick={handleShowLess} t={t} />}
+      </Box>
+
+      {showAllAttendees && (
+        <ExpandedAttendees extraAttendees={extraAttendees} t={t} />
+      )}
+    </>
+  )
+}

--- a/apps/public/src/components/Booking/BookingHeader/BookingHeaderDesktop.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingHeaderDesktop.tsx
@@ -14,6 +14,12 @@ export const BookingHeaderDesktop: React.FC<{
   onTimezoneChange: (tz: string) => void
   referenceDate: Date
 }> = ({ bookingInfo, selectedTimezone, onTimezoneChange, referenceDate }) => {
+  const isShowMoreBookingEvent =
+    bookingInfo.description ||
+    bookingInfo.location ||
+    bookingInfo.resources?.length ||
+    bookingInfo.extraAttendees?.and?.length
+
   return (
     <Box
       sx={{
@@ -27,7 +33,7 @@ export const BookingHeaderDesktop: React.FC<{
       <Box
         sx={{
           display: 'flex',
-          alignItems: 'flex-start',
+          alignItems: isShowMoreBookingEvent ? 'flex-start' : 'center',
           flexDirection: 'row'
         }}
       >

--- a/apps/public/src/components/Booking/BookingHeader/BookingHeaderMobile.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingHeaderMobile.tsx
@@ -1,7 +1,12 @@
 import { BookingSlotsResponse } from '@common/features/booking/types/BookingTypes'
 import { Box } from '@linagora/twake-mui'
 import React from 'react'
-import { BookingOwnerAvatar, BookingEventDetails } from './BookingOwnerInfo'
+import {
+  BookingOwnerAvatar,
+  BookingEventDetails,
+  BookingTitle,
+  BookingOwnerName
+} from './BookingOwnerInfo'
 import { BookingMetaInfo } from './BookingMetaInfo'
 
 export const BookingHeaderMobile: React.FC<{
@@ -30,7 +35,17 @@ export const BookingHeaderMobile: React.FC<{
           flexDirection: 'column'
         }}
       >
-        <BookingOwnerAvatar owner={bookingInfo.owner} size="s" />
+        <Box
+          sx={{
+            display: 'flex',
+            gap: '10px',
+            alignItems: 'center'
+          }}
+        >
+          <BookingOwnerAvatar owner={bookingInfo.owner} size="s" />
+          <BookingOwnerName owner={bookingInfo.owner} />
+        </Box>
+        <BookingTitle bookingInfo={bookingInfo} />
         <BookingEventDetails bookingInfo={bookingInfo} />
       </Box>
       <BookingMetaInfo

--- a/apps/public/src/components/Booking/BookingHeader/BookingOwnerInfo.tsx
+++ b/apps/public/src/components/Booking/BookingHeader/BookingOwnerInfo.tsx
@@ -1,23 +1,33 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Box, Typography, Avatar } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
-import { BookingSlotsResponse } from '@common/features/booking/types/BookingTypes'
+import {
+  BookingExtraAttendeeItem,
+  BookingSlotsResponse
+} from '@common/features/booking/types/BookingTypes'
 import { stringAvatar } from '@common/components/Event/utils/eventUtils'
 import { InfoRow } from '@common/components/Event/InfoRow'
 import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined'
 import LayersOutlinedIcon from '@mui/icons-material/LayersOutlined'
+import { BookingExtraAttendees } from './BookingExtraAttendees'
+import { userAttendee } from '@common/features/User/models/attendee'
+import Tooltip from '@common/components/Tooltip'
 
 export const BookingOwnerAvatar: React.FC<{
   owner: BookingSlotsResponse['owner']
   size?: 's' | 'm' | 'l'
 }> = ({ owner, size }) => {
   return (
-    <Avatar
-      size={size}
-      {...stringAvatar(owner.displayName || owner.email)}
-      sx={{ mr: 1 }}
-    />
+    <Tooltip title={owner.displayName || owner.email}>
+      <Box>
+        <Avatar
+          size={size}
+          {...stringAvatar(owner.displayName || owner.email)}
+          sx={{ mr: 1 }}
+        />
+      </Box>
+    </Tooltip>
   )
 }
 
@@ -54,7 +64,7 @@ export const BookingTitle: React.FC<{ bookingInfo: BookingSlotsResponse }> = ({
   const { t } = useI18n()
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: '8px', ml: 1 }}>
       {bookingInfo.name && (
         <Typography variant="h6">{bookingInfo.name}</Typography>
       )}
@@ -76,40 +86,86 @@ export const BookingTitle: React.FC<{ bookingInfo: BookingSlotsResponse }> = ({
   )
 }
 
+const BookingDescription: React.FC<{ description?: string }> = ({
+  description
+}) => {
+  if (!description) return null
+  return (
+    <Typography variant="body2" sx={{ color: 'text.secondary', mt: '4px' }}>
+      {description}
+    </Typography>
+  )
+}
+
+const BookingLocation: React.FC<{ location?: string }> = ({ location }) => {
+  if (!location) return null
+  return (
+    <Box sx={{ mt: 1 }}>
+      <InfoRow
+        icon={
+          <LocationOnOutlinedIcon sx={{ color: 'text.secondary', mr: 1 }} />
+        }
+        text={location}
+      />
+    </Box>
+  )
+}
+
+const BookingResources: React.FC<{
+  resources?:
+    | {
+        name: string
+        photoUrl?: string | undefined
+      }[]
+    | string[]
+    | undefined
+}> = ({ resources }) => {
+  if (!resources || resources.length === 0) return null
+  const resourceNames = resources
+    .map(resource => (typeof resource === 'string' ? resource : resource.name))
+    .filter((name): name is string => Boolean(name))
+    .join(', ')
+  if (!resourceNames) return null
+  if (!resourceNames) return null
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: 1
+      }}
+    >
+      <LayersOutlinedIcon sx={{ color: 'text.secondary' }} />
+      <Typography>{resourceNames}</Typography>
+    </Box>
+  )
+}
+
 export const BookingEventDetails: React.FC<{
   bookingInfo: BookingSlotsResponse
 }> = ({ bookingInfo }) => {
+  const extraAttendees = useMemo(() => {
+    const attendees = bookingInfo.extraAttendees?.and
+    if (!attendees || !Array.isArray(attendees)) return []
+    return attendees.map(
+      (attendee: BookingExtraAttendeeItem) =>
+        new userAttendee({
+          cn: attendee.displayName,
+          cal_address: attendee.email
+        })
+    )
+  }, [bookingInfo])
+
   return (
     <Box>
-      {bookingInfo.description && (
-        <Typography variant="body2" sx={{ color: 'text.secondary', mt: '4px' }}>
-          {bookingInfo.description}
-        </Typography>
-      )}
-      {bookingInfo.location && (
-        <Box sx={{ mt: 1 }}>
-          <InfoRow
-            icon={<LocationOnOutlinedIcon sx={{ color: 'text.secondary' }} />}
-            text={bookingInfo.location}
-          />
-        </Box>
-      )}
+      <BookingDescription description={bookingInfo.description} />
+      <BookingLocation location={bookingInfo.location} />
+      <BookingResources resources={bookingInfo.resources} />
 
-      {bookingInfo.resources?.length && (
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            gap: 1
-          }}
-        >
-          <LayersOutlinedIcon sx={{ color: 'text.secondary' }} />
-          <Typography>
-            {bookingInfo.resources
-              ?.map(resource => (resource as { name: string })?.name)
-              ?.join(', ')}
-          </Typography>
+      {extraAttendees.length > 0 && (
+        <Box sx={{ mt: 1 }}>
+          <BookingExtraAttendees extraAttendees={extraAttendees} />
         </Box>
       )}
     </Box>

--- a/common/src/components/Attendees/AttendeeSearch.tsx
+++ b/common/src/components/Attendees/AttendeeSearch.tsx
@@ -8,11 +8,11 @@ import {
 import { User } from './types'
 import { FreeBusyStatus, useAttendeesFreeBusy } from './useFreeBusy'
 
-const attendeeToUser = (a: userAttendee, openpaasId = ''): User => ({
+const attendeeToUser = (a: userAttendee, openpaasId?: string): User => ({
   email: a.cal_address,
   displayName: a.cn ?? '',
   avatarUrl: '',
-  openpaasId
+  openpaasId: a.openpaasId || openpaasId || ''
 })
 
 const hasCalendar = (u: User): boolean =>

--- a/common/src/components/Event/components/EventFormFieldsExpanded.tsx
+++ b/common/src/components/Event/components/EventFormFieldsExpanded.tsx
@@ -23,12 +23,12 @@ interface EventFormFieldsExpandedProps {
   showMore: boolean
   selectedResources: Resource[]
   setSelectedResources: (resources: Resource[]) => void
-  userOrganizer: userOrganiser
-  selectedCalendar: Calendar
-  isTeamCalendar: boolean
-  isDisableOrganizerSelection: boolean
-  setSelectedOrganizer: (organizer: userOrganiser) => void
-  selectedOrganizer: userOrganiser
+  userOrganizer?: userOrganiser
+  selectedCalendar?: Calendar
+  isTeamCalendar?: boolean
+  isDisableOrganizerSelection?: boolean
+  setSelectedOrganizer?: (organizer: userOrganiser) => void
+  selectedOrganizer?: userOrganiser
 }
 
 export const EventFormFieldsExpanded: React.FC<
@@ -57,16 +57,20 @@ export const EventFormFieldsExpanded: React.FC<
 
   return (
     <>
-      {isTeamCalendar && selectedCalendar && (
-        <OrganizerSelectField
-          calendar={selectedCalendar}
-          value={selectedOrganizer}
-          onChange={setSelectedOrganizer}
-          userOrganizer={userOrganizer}
-          showMore={showMore}
-          disabled={isDisableOrganizerSelection}
-        />
-      )}
+      {isTeamCalendar &&
+        selectedCalendar &&
+        selectedOrganizer &&
+        setSelectedOrganizer &&
+        userOrganizer && (
+          <OrganizerSelectField
+            calendar={selectedCalendar}
+            value={selectedOrganizer}
+            onChange={setSelectedOrganizer}
+            userOrganizer={userOrganizer}
+            showMore={showMore}
+            disabled={isDisableOrganizerSelection}
+          />
+        )}
 
       {!window.HIDE_RESOURCES && (
         <FieldWithLabel

--- a/common/src/features/User/UserDao.ts
+++ b/common/src/features/User/UserDao.ts
@@ -1,6 +1,9 @@
 import { api } from '@common/utils/apiUtils'
 import { fetchEntityById } from './EntityDAO'
-import { OpenPaasUserData } from './type/OpenPaasUserData'
+import {
+  OpenPaasUserData,
+  normalizeOpenPaasUser
+} from './type/OpenPaasUserData'
 import { ModuleConfiguration } from './userDataTypes'
 import { SearchResponseItem } from '@common/types/SearchResponseItem'
 
@@ -8,12 +11,7 @@ export async function fetchCurrentUser(): Promise<OpenPaasUserData> {
   const response = await api.get(`api/user`)
   const data: OpenPaasUserData = await response.json()
 
-  // Normalize: ensure id is always present (fallback to _id if needed)
-  if (!data.id && data._id) {
-    data.id = data._id
-  }
-
-  return data
+  return normalizeOpenPaasUser(data)
 }
 
 export async function fetchUserByEmail(
@@ -31,7 +29,7 @@ export async function fetchUserById(id: string): Promise<OpenPaasUserData> {
   if (!entity.user) {
     throw new Error(`User entity not found for id ${id}`)
   }
-  return entity.user
+  return normalizeOpenPaasUser(entity.user)
 }
 
 export async function searchPeople(

--- a/common/src/features/User/type/OpenPaasUserData.ts
+++ b/common/src/features/User/type/OpenPaasUserData.ts
@@ -23,6 +23,15 @@ export interface OpenPaasUserData {
   resourceIcon?: string
 }
 
+export function normalizeOpenPaasUser(
+  user: OpenPaasUserData
+): OpenPaasUserData {
+  if (!user.id && user._id) {
+    user.id = user._id
+  }
+  return user
+}
+
 export function ToUserData(
   openpaas: OpenPaasUserData | undefined
 ): userData | undefined {

--- a/common/src/features/booking/types/BookingTypes.ts
+++ b/common/src/features/booking/types/BookingTypes.ts
@@ -56,6 +56,11 @@ export interface Slot {
   start: string // ISO-8601 instant
 }
 
+export interface BookingExtraAttendeeItem {
+  displayName: string
+  email: string
+}
+
 export interface BookingSlotsResponse {
   durationMinutes: number
   autoAccept: boolean
@@ -73,6 +78,9 @@ export interface BookingSlotsResponse {
     to: string
   }
   slots: Slot[]
+  extraAttendees: {
+    and: BookingExtraAttendeeItem[]
+  }
 }
 
 export interface BookingCreator {

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -328,6 +328,7 @@
     "workingDaysUpdateError": "Failed to update working days setting"
   },
   "eventPreview": {
+    "extraAttendees": "%{count} extra participants",
     "emailAttendees": "Email attendees",
     "deleteEvent": "Delete event",
     "editEventSpecificSettings": "Edit personal event settings",

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -328,7 +328,8 @@
     "workingDaysUpdateError": "Échec de la mise à jour des jours ouvrés"
   },
   "eventPreview": {
-    "emailAttendees": "Envoyer un e-mail aux participants",
+    "extraAttendees": "%{count} participants supplémentaires",
+    "emailAttendees": "Email aux participants",
     "deleteEvent": "Supprimer l'événement",
     "editEventSpecificSettings": "Modifier les paramètres personnels de l'événement",
     "privateEvent": {

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -328,6 +328,7 @@
     "workingDaysUpdateError": "Не удалось обновить настройку рабочих дней"
   },
   "eventPreview": {
+    "extraAttendees": "%{count} дополнительных участников",
     "emailAttendees": "Написать участникам",
     "deleteEvent": "Удалить",
     "editEventSpecificSettings": "Редактировать персональные настройки события",

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -328,6 +328,7 @@
     "workingDaysUpdateError": "Không thể cập nhật cài đặt ngày làm việc"
   },
   "eventPreview": {
+    "extraAttendees": "%{count} người tham gia khác",
     "emailAttendees": "Gửi email cho người tham gia",
     "deleteEvent": "Xóa sự kiện",
     "editEventSpecificSettings": "Chỉnh sửa cài đặt sự kiện cá nhân",


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1258

### Record:

https://github.com/user-attachments/assets/e8c4f31d-646c-42a3-a9df-9964e444012f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Booking details now display additional attendees with avatars, attendee counts, and expandable lists.
  * Added localized labels for additional attendees in English, French, Russian, and Vietnamese.
* **Bug Fixes**
  * Improved attendee identification when alternate account identifiers are available.
  * Prevented incomplete organizer controls from appearing in event forms.
  * Removed invalid or incomplete resource details from booking information.
  * Improved handling of attendee contact details and booking participant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->