### PR TITLE
#1263 apply same display of team organizer in event preview

### DIFF
--- a/common/src/components/EventPreview/EventPreviewAttendees.tsx
+++ b/common/src/components/EventPreview/EventPreviewAttendees.tsx
@@ -89,7 +89,7 @@ export function EventPreviewAttendees({
     displayOrganizer,
     isOriginalOrganizer,
     organizerCaption
-  } = useTeamOrganizer({ teamCalendarId, isTeamCalendar, organizer, t })
+  } = useTeamOrganizer({ teamCalendarId, organizer, t })
 
   return (
     <>

--- a/common/src/components/EventPreview/useTeamOrganizer.ts
+++ b/common/src/components/EventPreview/useTeamOrganizer.ts
@@ -40,12 +40,10 @@ const useFetchTeamName = (teamCalendarId?: string): string | undefined => {
 
 export const useTeamOrganizer = ({
   teamCalendarId,
-  isTeamCalendar,
   organizer,
   t
 }: {
   teamCalendarId?: string
-  isTeamCalendar?: boolean
   organizer?: userAttendee
   t: (key: string, options?: Record<string, string>) => string
 }): {
@@ -56,7 +54,7 @@ export const useTeamOrganizer = ({
 } => {
   const teamName = useFetchTeamName(teamCalendarId)
 
-  const isTeamOverride = Boolean(!isTeamCalendar && teamCalendarId)
+  const isTeamOverride = Boolean(teamCalendarId)
   const displayOrganizer = isTeamOverride
     ? ({ ...organizer, cn: teamName } as userAttendee)
     : organizer


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1263

### Record:

<img width="574" height="524" alt="image" src="https://github.com/user-attachments/assets/439a8657-2a46-435b-b26d-5580358ff6a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team organizer details now display correctly whenever a team calendar is specified, including cases where the team calendar setting is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->