### PR TITLE
ISSUE-1265 Allow fallback for workplaceFQDN when OIDC context is not set

### DIFF
--- a/common/src/utils/__test__/uriTemplateUtils.test.ts
+++ b/common/src/utils/__test__/uriTemplateUtils.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { resolveUriTemplate } from '@common/utils/uriTemplateUtils'
 
 describe('resolveUriTemplate', () => {

--- a/common/src/utils/__test__/uriTemplateUtils.test.ts
+++ b/common/src/utils/__test__/uriTemplateUtils.test.ts
@@ -3,6 +3,10 @@ import { resolveUriTemplate } from '@common/utils/uriTemplateUtils'
 describe('resolveUriTemplate', () => {
   const fqdn = 'tmle.stg.lin-saas.com'
 
+  afterEach(() => {
+    window.WORKPLACE_FQDN_FALLBACK = undefined
+  })
+
   it('should resolve {localpart}', () => {
     const template = 'https://visio-{localpart}.twake.app/#/bridge'
     const result = resolveUriTemplate(template, { localpart: 'alice' })
@@ -37,5 +41,38 @@ describe('resolveUriTemplate', () => {
   it('should resolve missing context values to empty string', () => {
     const template = 'https://{localpart}-mail.{workplaceFqdn}'
     expect(resolveUriTemplate(template, {})).toBe('https://-mail.')
+  })
+
+  it('should fall back to WORKPLACE_FQDN_FALLBACK when no FQDN is provided', () => {
+    window.WORKPLACE_FQDN_FALLBACK = '{localpart}.twake.linagora.com'
+    const template =
+      'https://{workplaceFqdn.localpart}-mail.{workplaceFqdn.domain}'
+    const result = resolveUriTemplate(template, { localpart: 'alice' })
+    expect(result).toBe('https://alice-mail.twake.linagora.com')
+  })
+
+  it('should resolve {workplaceFqdn} from the fallback', () => {
+    window.WORKPLACE_FQDN_FALLBACK = '{localpart}.twake.linagora.com'
+    const result = resolveUriTemplate('https://mail-{workplaceFqdn}', {
+      localpart: 'alice'
+    })
+    expect(result).toBe('https://mail-alice.twake.linagora.com')
+  })
+
+  it('should prefer the context FQDN over the fallback', () => {
+    window.WORKPLACE_FQDN_FALLBACK = '{localpart}.twake.linagora.com'
+    const result = resolveUriTemplate('https://mail-{workplaceFqdn}', {
+      localpart: 'alice',
+      workplaceFqdn: fqdn
+    })
+    expect(result).toBe('https://mail-tmle.stg.lin-saas.com')
+  })
+
+  it('should support a fallback without {localpart}', () => {
+    window.WORKPLACE_FQDN_FALLBACK = 'twake.linagora.com'
+    const result = resolveUriTemplate('https://mail-{workplaceFqdn}', {
+      localpart: 'alice'
+    })
+    expect(result).toBe('https://mail-twake.linagora.com')
   })
 })

--- a/common/src/utils/uriTemplateUtils.ts
+++ b/common/src/utils/uriTemplateUtils.ts
@@ -13,6 +13,26 @@ export interface UriTemplateContext {
 }
 
 /**
+ * Resolve the workplace FQDN to use, falling back to the
+ * WORKPLACE_FQDN_FALLBACK configuration entry when the OIDC provider did not
+ * supply one.
+ *
+ * WORKPLACE_FQDN_FALLBACK is itself a template supporting {localpart}, e.g.
+ * '{localpart}.twake.linagora.com'.
+ */
+function resolveWorkplaceFqdn(
+  workplaceFqdn: string,
+  localpart: string
+): string {
+  if (workplaceFqdn) return workplaceFqdn
+
+  const fallback = window.WORKPLACE_FQDN_FALLBACK
+  if (!fallback) return ''
+
+  return fallback.replace(/\{localpart\}/g, localpart)
+}
+
+/**
  * Resolve a URI-template (RFC 6570 style) configuration value.
  *
  * Supported expressions:
@@ -22,18 +42,22 @@ export interface UriTemplateContext {
  *  - {workplaceFqdn.domain}    the FQDN without its first label (e.g. stg.lin-saas.com)
  *  - {target}                  the target username for chat url
  *
+ * When no workplace FQDN is available in the context, the
+ * WORKPLACE_FQDN_FALLBACK configuration entry is used instead.
+ *
  * Unknown expressions are left untouched.
  */
 export function resolveUriTemplate(
   template: string,
   { localpart = '', workplaceFqdn = '', target = '' }: UriTemplateContext
 ): string {
-  const [fqdnLocalpart = '', ...fqdnRest] = workplaceFqdn.split('.')
+  const effectiveFqdn = resolveWorkplaceFqdn(workplaceFqdn, localpart)
+  const [fqdnLocalpart = '', ...fqdnRest] = effectiveFqdn.split('.')
   const fqdnDomain = fqdnRest.join('.')
 
   const values: Record<string, string> = {
     localpart,
-    workplaceFqdn,
+    workplaceFqdn: effectiveFqdn,
     'workplaceFqdn.localpart': fqdnLocalpart,
     'workplaceFqdn.domain': fqdnDomain,
     target

--- a/common/src/window.d.ts
+++ b/common/src/window.d.ts
@@ -22,6 +22,7 @@ declare global {
     VIDEO_CONFERENCE_BASE_URL: string
     TDRIVE_ENABLED: boolean | undefined
     TDRIVE_INTENT_URL: string | undefined
+    WORKPLACE_FQDN_FALLBACK: string | undefined
     SUPPORT_URL: string
     PRIVACY_URL: string
     TERMS_URL: string

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -50,6 +50,11 @@ var ENABLE_EVENT_ATTACHMENTS = false
 //   'https://{workplaceFqdn.localpart}-chat.{workplaceFqdn.domain}/#/bridge/web/#/chat/@{target}:{workplaceFqdn.domain}'
 //   'https://{localpart}-chat.twake.linagora.com/#/bridge/web/#/chat/@{target}:linagora.com'
 var CHAT_SPA_URL = 'https://{workplaceFqdn.localpart}-chat.{workplaceFqdn.domain}/#/bridge/web/#/chat/@{target}:{workplaceFqdn.domain}'
+// Fallback used when the OIDC provider does not expose a workplace FQDN.
+// Supported expressions: {localpart}
+// Examples:
+//   '{localpart}.twake.linagora.com'
+// var WORKPLACE_FQDN_FALLBACK = '{localpart}.twake.linagora.com'; // optional
 var TDRIVE_ENABLED = false
 var TDRIVE_INTENT_URL = "https://{localpart}.example.com"
 // TDRIVE_INTENT_URL is a URI template (RFC 6570 style).


### PR DESCRIPTION
Cc @lethemanh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a fallback workplace domain when the identity provider does not supply one.
  - Supports URI templates containing `{localpart}` for dynamically resolving workplace domains.
  - Included an optional configuration example for enabling fallback behavior.

- **Bug Fixes**
  - Ensured the provided workplace domain takes precedence over the configured fallback.

- **Tests**
  - Added coverage for fallback resolution, precedence, and templates with or without `{localpart}`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->