### PR TITLE
#1240 remove header in tdrive file picker dialog

### DIFF
--- a/__test__/features/Tdrive/useTdrivePicker.test.tsx
+++ b/__test__/features/Tdrive/useTdrivePicker.test.tsx
@@ -128,7 +128,8 @@ describe('useTdrivePicker', () => {
         theme: { type: 'light' },
         multiple: true,
         sharingLink: { label: 'tdrive.addAsAttachment' },
-        downloadLink: null
+        downloadLink: null,
+        displayCloseButton: true
       },
       ['GET']
     )

--- a/common/src/declarations.d.ts
+++ b/common/src/declarations.d.ts
@@ -1,4 +1,15 @@
 declare module '*.styl'
+declare module 'cozy-interapp' {
+  export default class Intents {
+    constructor(options?: Record<string, unknown>)
+    create(
+      action: string,
+      type: string,
+      data?: Record<string, unknown>,
+      permissions?: string[]
+    ): unknown
+  }
+}
 
 declare module 'classnames' {
   type ClassValue =
@@ -54,12 +65,12 @@ declare const process: {
 
 declare module 'twake-i18n' {
   export function useI18n(): {
-    t: (key: string, options?: Record<string, any>) => string
+    t: (key: string, options?: Record<string, unknown>) => string
     f: (date: string, format: string) => string
     lang: string
   }
-  export const I18nContext: import('react').Context<any>
+  export const I18nContext: import('react').Context<unknown>
   export const DEFAULT_LANG: string
-  const I18n: import('react').ComponentType<any>
+  const I18n: import('react').ComponentType<unknown>
   export default I18n
 }

--- a/common/src/features/Tdrive/components/TdrivePickerDialog.tsx
+++ b/common/src/features/Tdrive/components/TdrivePickerDialog.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useCallback } from 'react'
-import { Dialog, DialogTitle, Box, IconButton } from '@linagora/twake-mui'
+import { Dialog, Box, IconButton } from '@linagora/twake-mui'
 import { Close as CloseIcon } from '@mui/icons-material'
-import { useI18n } from 'twake-i18n'
-import { TdriveFile } from '../hooks/useTdrivePicker'
+import { TdriveFile } from '../types'
 import { PickerSkeleton } from './PickerSkeleton'
 
 interface TdrivePickerDialogProps {
@@ -48,7 +47,8 @@ const PickerContent: React.FC<PickerContentProps> = ({
             '& > iframe': {
               width: '100%',
               height: '100%',
-              border: 'none'
+              border: 'none',
+              background: '#fff'
             }
           }}
         />
@@ -63,7 +63,6 @@ export const TdrivePickerDialog: React.FC<TdrivePickerDialogProps> = ({
   containerRef,
   onReadyToUse
 }) => {
-  const { t } = useI18n()
   const [isReady, setIsReady] = useState(false)
 
   // Reset loader each time the dialog opens
@@ -85,29 +84,26 @@ export const TdrivePickerDialog: React.FC<TdrivePickerDialogProps> = ({
           height: '80vh',
           maxHeight: '800px',
           display: 'flex',
-          flexDirection: 'column'
+          flexDirection: 'column',
+          position: 'relative'
         }
       }}
     >
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          p: 2,
-          borderBottom: 1,
-          borderColor: 'divider',
-          flexShrink: 0
-        }}
-      >
-        <DialogTitle sx={{ p: 0 }}>
-          {t('event.form.tdrivePickerTitle')}
-        </DialogTitle>
-        <IconButton aria-label={t('actions.close')} onClick={onClose}>
+      <PickerContent containerRef={containerRef} isReady={isReady} />
+      {!isReady && (
+        <IconButton
+          aria-label="close"
+          onClick={onClose}
+          sx={{
+            position: 'absolute',
+            right: 12,
+            top: 12,
+            zIndex: 1
+          }}
+        >
           <CloseIcon />
         </IconButton>
-      </Box>
-      <PickerContent containerRef={containerRef} isReady={isReady} />
+      )}
     </Dialog>
   )
 }

--- a/common/src/features/Tdrive/hooks/useTdrivePicker.ts
+++ b/common/src/features/Tdrive/hooks/useTdrivePicker.ts
@@ -61,6 +61,14 @@ interface StartTdrivePickerOptions {
   t: (key: string) => string
 }
 
+interface CozyIntent {
+  start: (
+    element: HTMLElement,
+    options: { onReady?: () => void; onReadyToUse?: () => void }
+  ) => Promise<unknown>
+  stop?: () => void
+}
+
 async function startTdrivePicker({
   tdriveBaseUrl,
   idToken,
@@ -93,10 +101,11 @@ async function startTdrivePicker({
       theme: { type: 'light' },
       multiple: true,
       sharingLink: { label: t('tdrive.addAsAttachment') },
-      downloadLink: null
+      downloadLink: null,
+      displayCloseButton: true
     },
     ['GET']
-  )
+  ) as CozyIntent
 
   intentRef.current = intent
 
@@ -163,8 +172,8 @@ export function useTdrivePicker({
 
     try {
       const { files } = await startTdrivePicker({
-        tdriveBaseUrl,
-        idToken,
+        tdriveBaseUrl: tdriveBaseUrl as string,
+        idToken: idToken as string,
         containerRef,
         readyCallbackRef,
         cancellationRef,


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1240

### Change:

Currently, the TDrive iframe is placed in a dialog with a dialog header, but the header is unnecessary.

This PR removes the dialog header and displays the TDrive iframe only.

<img width="904" height="647" alt="image" src="https://github.com/user-attachments/assets/8488d6c8-31bf-486c-a1e7-ae52ee627b7b" />
