### PR TITLE
#1242 display correct folder icon

### DIFF
--- a/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
@@ -27,8 +27,12 @@ export const AttachementChip: React.FC<{
   const hasExtension = lastDot > 0 && lastDot < filename.length - 1
   const name = hasExtension ? filename.slice(0, lastDot) : filename
   const extension = hasExtension ? filename.slice(lastDot) : ''
+  const isDirectory = !attachment.fmttype && !hasExtension
   const fileIcon = (
-    <Icon icon={getFileTypeIcon(filename, attachment.fmttype)} size={20} />
+    <Icon
+      icon={getFileTypeIcon(filename, attachment.fmttype, isDirectory)}
+      size={20}
+    />
   )
 
   const safeHref = React.useMemo(() => {


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1242

### Need:

https://github.com/linagora/twake-ui/pull/55

### Result:

<img width="236" height="109" alt="SCR-20260821-npfr" src="https://github.com/user-attachments/assets/54b1312f-a017-4c43-ad58-b8f812894126" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment previews by displaying the appropriate folder icon for directory-like attachments without a MIME type or file extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->