### PR TITLE
[ENHANCEMENT] Show file picker only if we run in iframe

### DIFF
--- a/__test__/contexts/EmbeddingContext.test.tsx
+++ b/__test__/contexts/EmbeddingContext.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+
+const mockIsInIframe = jest.fn()
+
+jest.mock('cozy-external-bridge', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    isInIframe: mockIsInIframe
+  }))
+}))
+
+import CozyBridge from 'cozy-external-bridge'
+import {
+  EmbeddingProvider,
+  useIsInIframe
+} from '@common/contexts/EmbeddingContext'
+
+const MockedCozyBridge = CozyBridge as unknown as jest.Mock
+
+describe('EmbeddingContext', () => {
+  beforeEach(() => {
+    mockIsInIframe.mockReset()
+    MockedCozyBridge.mockClear()
+  })
+
+  it('should expose the embedding state detected by the bridge', () => {
+    mockIsInIframe.mockReturnValue(true)
+    const { result } = renderHook(() => useIsInIframe(), {
+      wrapper: ({ children }) => (
+        <EmbeddingProvider>{children}</EmbeddingProvider>
+      )
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('should detect only once for every consumer under the provider', () => {
+    mockIsInIframe.mockReturnValue(false)
+    const { result } = renderHook(
+      () => [useIsInIframe(), useIsInIframe(), useIsInIframe()],
+      {
+        wrapper: ({ children }) => (
+          <EmbeddingProvider>{children}</EmbeddingProvider>
+        )
+      }
+    )
+    expect(result.current).toEqual([false, false, false])
+    expect(MockedCozyBridge).toHaveBeenCalledTimes(1)
+  })
+
+  it('should fall back to detecting on the spot outside the provider', () => {
+    mockIsInIframe.mockReturnValue(true)
+    const { result } = renderHook(() => useIsInIframe())
+    expect(result.current).toBe(true)
+  })
+})

--- a/__test__/features/Tdrive/useIsTdrivePickerAvailable.test.tsx
+++ b/__test__/features/Tdrive/useIsTdrivePickerAvailable.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react'
+import { renderHook } from '@testing-library/react'
+
+const mockIsInIframe = jest.fn()
+
+jest.mock('cozy-external-bridge', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    isInIframe: mockIsInIframe
+  }))
+}))
+
+import { EmbeddingProvider } from '@common/contexts/EmbeddingContext'
+import { useIsTdrivePickerAvailable } from '@common/features/Tdrive/hooks/useIsTdrivePickerAvailable'
+
+const wrapper = ({ children }: { children: React.ReactNode }): JSX.Element => (
+  <EmbeddingProvider>{children}</EmbeddingProvider>
+)
+
+describe('useIsTdrivePickerAvailable', () => {
+  const originalUrl = window.TDRIVE_INTENT_URL
+  const originalEnabled = window.TDRIVE_ENABLED
+
+  beforeEach(() => {
+    mockIsInIframe.mockReset()
+    window.TDRIVE_INTENT_URL = 'https://drive.example.com'
+    window.TDRIVE_ENABLED = true
+  })
+
+  afterEach(() => {
+    window.TDRIVE_INTENT_URL = originalUrl
+    window.TDRIVE_ENABLED = originalEnabled
+  })
+
+  it('should be available when configured and served as a Cozy app', () => {
+    mockIsInIframe.mockReturnValue(true)
+    const { result } = renderHook(() => useIsTdrivePickerAvailable(), {
+      wrapper
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('should not be available when configured but served directly', () => {
+    mockIsInIframe.mockReturnValue(false)
+    const { result } = renderHook(() => useIsTdrivePickerAvailable(), {
+      wrapper
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('should not be available when TDRIVE_ENABLED is false', () => {
+    mockIsInIframe.mockReturnValue(true)
+    window.TDRIVE_ENABLED = false
+    const { result } = renderHook(() => useIsTdrivePickerAvailable(), {
+      wrapper
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('should not be available when TDRIVE_INTENT_URL is missing', () => {
+    mockIsInIframe.mockReturnValue(true)
+    window.TDRIVE_INTENT_URL = ''
+    const { result } = renderHook(() => useIsTdrivePickerAvailable(), {
+      wrapper
+    })
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/private/src/App.tsx
+++ b/apps/private/src/App.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from '@common/app/hooks'
 import { history } from '@common/app/store'
 import { Error as ErrorPage } from '@common/components/Error/Error'
 import { ErrorSnackbar } from '@common/components/Error/ErrorSnackbar'
+import { EmbeddingProvider } from '@common/contexts/EmbeddingContext'
 import { ErrorBoundary } from 'react-error-boundary'
 import { Loading } from '@common/components/Loading/Loading'
 import { AVAILABLE_LANGUAGES } from '@common/features/Settings/constants'
@@ -68,47 +69,52 @@ export default function App(): JSX.Element {
   useInitializeApp()
 
   return (
-    <TwakeMuiThemeProvider
-      themeOptions={{
-        ...makeCalendarOverrides()
-      }}
-    >
-      <I18n
-        dictRequire={(lang: keyof typeof locale) => locale[lang]}
-        lang={lang}
-        locales={dateLocales}
+    <EmbeddingProvider>
+      <TwakeMuiThemeProvider
+        themeOptions={{
+          ...makeCalendarOverrides()
+        }}
       >
-        <ErrorBoundary
-          FallbackComponent={({ error }) => (
-            <ErrorPage isCrashFallback errorBoundaryMessage={error as Error} />
-          )}
-          onError={(error, errorInfo) => {
-            Sentry.captureException(error, {
-              contexts: {
-                react: {
-                  componentStack: errorInfo.componentStack
-                }
-              }
-            })
-          }}
+        <I18n
+          dictRequire={(lang: keyof typeof locale) => locale[lang]}
+          lang={lang}
+          locales={dateLocales}
         >
-          <Suspense fallback={<Loading />}>
-            <WebSocketGate />
-            <Router history={history}>
-              <Routes>
-                <Route path="/" element={<HandleLogin />} />
-                <Route path="/calendar" element={<CalendarLayout />} />
-                <Route path="/events/:uid" element={<EventDeepLink />} />
-                <Route path="/newEvent" element={<NewEventDeepLink />} />
-                <Route path="/callback" element={<CallbackResume />} />
-                <Route path="/error" element={<ErrorPage />} />
-              </Routes>
-            </Router>
-            <ErrorSnackbar error={error} type="user" />
-          </Suspense>
-          {appLoading && <Loading />}
-        </ErrorBoundary>
-      </I18n>
-    </TwakeMuiThemeProvider>
+          <ErrorBoundary
+            FallbackComponent={({ error }) => (
+              <ErrorPage
+                isCrashFallback
+                errorBoundaryMessage={error as Error}
+              />
+            )}
+            onError={(error, errorInfo) => {
+              Sentry.captureException(error, {
+                contexts: {
+                  react: {
+                    componentStack: errorInfo.componentStack
+                  }
+                }
+              })
+            }}
+          >
+            <Suspense fallback={<Loading />}>
+              <WebSocketGate />
+              <Router history={history}>
+                <Routes>
+                  <Route path="/" element={<HandleLogin />} />
+                  <Route path="/calendar" element={<CalendarLayout />} />
+                  <Route path="/events/:uid" element={<EventDeepLink />} />
+                  <Route path="/newEvent" element={<NewEventDeepLink />} />
+                  <Route path="/callback" element={<CallbackResume />} />
+                  <Route path="/error" element={<ErrorPage />} />
+                </Routes>
+              </Router>
+              <ErrorSnackbar error={error} type="user" />
+            </Suspense>
+            {appLoading && <Loading />}
+          </ErrorBoundary>
+        </I18n>
+      </TwakeMuiThemeProvider>
+    </EmbeddingProvider>
   )
 }

--- a/apps/private/src/components/Calendar/CalendarLayout.tsx
+++ b/apps/private/src/components/Calendar/CalendarLayout.tsx
@@ -4,6 +4,7 @@ import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 import { ErrorSnackbar } from '@common/components/Error/ErrorSnackbar'
 import { refreshCalendars } from '@common/components/Event/utils/eventUtils'
 import { Menubar, MenubarProps } from '@common/components/Menubar/Menubar'
+import { useIsInIframe } from '@common/contexts/EmbeddingContext'
 import { setIsMobileSearchOpen } from '@common/features/Calendars/CalendarSlice'
 import SettingsPage from '@common/features/Settings/SettingsPage'
 import { setView } from '@common/features/Settings/SettingsSlice'
@@ -12,8 +13,7 @@ import { getViewRange } from '@common/utils/dateUtils'
 import type { CalendarApi } from '@fullcalendar/core'
 import CalendarController, { CalendarControllerRef } from './CalendarController'
 import cx from 'classnames'
-import CozyBridge from 'cozy-external-bridge'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useManageCalendarSelection } from './hooks/useManageCalendarSelection'
 import Sidebar from './Sidebar/SideBar'
 
@@ -53,7 +53,7 @@ export default function CalendarLayout(): JSX.Element {
     setViewMode()
   }, [isTablet, isMobile])
 
-  const isInIframe = useMemo(() => new CozyBridge().isInIframe(), [])
+  const isInIframe = useIsInIframe()
 
   // Manage calendar selection states
   const {

--- a/apps/public/src/App.tsx
+++ b/apps/public/src/App.tsx
@@ -5,6 +5,7 @@ import { Route, Routes } from 'react-router-dom'
 import { HistoryRouter as Router } from 'redux-first-history/rr6'
 import { history } from '@common/app/store'
 import { Error as ErrorPage } from '@common/components/Error/Error'
+import { EmbeddingProvider } from '@common/contexts/EmbeddingContext'
 import { ErrorBoundary } from 'react-error-boundary'
 import { Loading } from '@common/components/Loading/Loading'
 import { PublicLayout } from './components/PublicLayout'
@@ -42,68 +43,70 @@ export default function App(): JSX.Element {
   }
 
   return (
-    <TwakeMuiThemeProvider>
-      <I18n
-        dictRequire={(lang: keyof typeof locale) => locale[lang]}
-        lang={lang}
-        locales={dateLocales}
-      >
-        <PublicLanguageContext.Provider
-          value={{
-            currentLanguage: lang,
-            setCurrentLanguage: handleLanguageChange
-          }}
+    <EmbeddingProvider>
+      <TwakeMuiThemeProvider>
+        <I18n
+          dictRequire={(lang: keyof typeof locale) => locale[lang]}
+          lang={lang}
+          locales={dateLocales}
         >
-          <ErrorBoundary
-            FallbackComponent={({ error }) => (
-              <ErrorPage
-                isCrashFallback
-                errorBoundaryMessage={error as Error}
-              />
-            )}
-            onError={(error, errorInfo) => {
-              Sentry.captureException(error, {
-                contexts: {
-                  react: {
-                    componentStack: errorInfo.componentStack
-                  }
-                }
-              })
+          <PublicLanguageContext.Provider
+            value={{
+              currentLanguage: lang,
+              setCurrentLanguage: handleLanguageChange
             }}
           >
-            <Suspense fallback={<Loading />}>
-              <Router history={history}>
-                <Routes>
-                  <Route
-                    path="/excal"
-                    element={
-                      <PublicLayout>
-                        <EventPreviewPage />
-                      </PublicLayout>
+            <ErrorBoundary
+              FallbackComponent={({ error }) => (
+                <ErrorPage
+                  isCrashFallback
+                  errorBoundaryMessage={error as Error}
+                />
+              )}
+              onError={(error, errorInfo) => {
+                Sentry.captureException(error, {
+                  contexts: {
+                    react: {
+                      componentStack: errorInfo.componentStack
                     }
-                  />
-                  <Route
-                    path="/booking/confirmed/:bookingConfirmationToken"
-                    element={
-                      <PublicLayout>
-                        <BookedEventPreviewPage />
-                      </PublicLayout>
-                    }
-                  />
-                  <Route
-                    path="/booking/:bookingLinkPublicId"
-                    element={
-                      <PublicLayout>
-                        <BookingPage />
-                      </PublicLayout>
-                    }
-                  />
-                </Routes>
-              </Router>
-            </Suspense>
-          </ErrorBoundary>
-        </PublicLanguageContext.Provider>
-      </I18n>
-    </TwakeMuiThemeProvider>
+                  }
+                })
+              }}
+            >
+              <Suspense fallback={<Loading />}>
+                <Router history={history}>
+                  <Routes>
+                    <Route
+                      path="/excal"
+                      element={
+                        <PublicLayout>
+                          <EventPreviewPage />
+                        </PublicLayout>
+                      }
+                    />
+                    <Route
+                      path="/booking/confirmed/:bookingConfirmationToken"
+                      element={
+                        <PublicLayout>
+                          <BookedEventPreviewPage />
+                        </PublicLayout>
+                      }
+                    />
+                    <Route
+                      path="/booking/:bookingLinkPublicId"
+                      element={
+                        <PublicLayout>
+                          <BookingPage />
+                        </PublicLayout>
+                      }
+                    />
+                  </Routes>
+                </Router>
+              </Suspense>
+            </ErrorBoundary>
+          </PublicLanguageContext.Provider>
+        </I18n>
+      </TwakeMuiThemeProvider>
+    </EmbeddingProvider>
   )
 }

--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -17,10 +17,10 @@ import {
   useTheme
 } from '@linagora/twake-mui'
 import Tooltip from '@common/components/Tooltip'
+import { useIsInIframe } from '@common/contexts/EmbeddingContext'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import CloseIcon from '@mui/icons-material/Close'
 import OpenInFullIcon from '@mui/icons-material/OpenInFull'
-import CozyBridge from 'cozy-external-bridge'
 import React, { ReactNode, useContext, useId, useMemo } from 'react'
 import useDynamicPosition from './useDynamicPosition'
 
@@ -205,7 +205,7 @@ function ResponsiveDialog({
 }: ResponsiveDialogProps): JSX.Element {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const isInIframe = useMemo(() => new CozyBridge().isInIframe(), [])
+  const isInIframe = useIsInIframe()
 
   const uid = useId()
   const titleId = `responsive-dialog-title-${uid}`

--- a/common/src/components/Event/EventFormFields.tsx
+++ b/common/src/components/Event/EventFormFields.tsx
@@ -4,6 +4,7 @@ import { useEventOrganizer } from '@common/features/Events/useEventOrganizer'
 import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 import { saveEventFormDataToTemp } from '@common/utils/eventFormTempStorage'
+import { isSafeHttpUrl } from '@common/utils/isSafeUrl'
 import {
   browserDefaultTimeZone,
   getTimezoneOffset,
@@ -30,12 +31,14 @@ import {
   EventFormHandle,
   EventFormValues
 } from './EventFormFields.types'
+import { AttachmentField } from './fields/AttachmentField'
 import { CalendarSelectField } from './fields/CalendarSelectField'
 import { EventDateTimeField } from './fields/EventDateTimeField'
 import LocationField from './fields/LocationField'
 import { TitleField } from './fields/TitleField'
 import { VideoConferenceField } from './fields/VideoConferenceField'
 import { TdriveButton } from '@common/features/Tdrive/components/TdriveButton'
+import { useIsTdrivePickerAvailable } from '@common/features/Tdrive/hooks/useIsTdrivePickerAvailable'
 import { TdriveFile } from '@common/features/Tdrive/types'
 import { Attachment } from '@common/types/Attachment'
 import { useEventFormValues } from './hooks/useEventFormValues'
@@ -213,6 +216,12 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
     const v = formValues
     const isExpanded = showMore && !isMobile
 
+    const pickerAvailable = useIsTdrivePickerAvailable()
+
+    // AttachmentField silently skips attachments whose URI is not a safe
+    // http(s) URL, so mirror that predicate to avoid an orphan label.
+    const hasVisibleAttachments = v.attachments.some(a => isSafeHttpUrl(a.uri))
+
     const handleTdriveFilesSelected = useCallback(
       (files: TdriveFile[]): void => {
         // Convert Tdrive files to Attachments
@@ -296,13 +305,25 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
           setDescription={setDescription}
         />
 
-        {window.TDRIVE_INTENT_URL && window.TDRIVE_ENABLED && (
+        {pickerAvailable ? (
           <TdriveButton
             onFilesSelected={handleTdriveFilesSelected}
             showMore={showMore}
             attachments={v.attachments}
             setAttachments={setAttachments}
           />
+        ) : (
+          hasVisibleAttachments && (
+            <FieldWithLabel
+              label={showInputLabel(showMore, t('event.form.tdriveFiles'))}
+              isExpanded={isExpanded}
+            >
+              <AttachmentField
+                attachments={v.attachments}
+                setAttachments={setAttachments}
+              />
+            </FieldWithLabel>
+          )
         )}
 
         <LocationField

--- a/common/src/contexts/EmbeddingContext.tsx
+++ b/common/src/contexts/EmbeddingContext.tsx
@@ -1,0 +1,45 @@
+import CozyBridge from 'cozy-external-bridge'
+import React, { createContext, useContext, useMemo } from 'react'
+
+/**
+ * The same SPA is served either directly on its own domain, or embedded as a
+ * Cozy app inside the workplace. Being embedded is what tells us the workplace
+ * already provides its own top bar, and it is also what decides whether
+ * cross-origin calls to the sibling Cozy apps are allowed.
+ *
+ * The detection itself is cheap but it is a runtime, process-wide fact: resolve
+ * it once at the root instead of instantiating a bridge in every consumer.
+ */
+const detectIsInIframe = (): boolean => new CozyBridge().isInIframe()
+
+const EmbeddingContext = createContext<boolean | null>(null)
+
+export const EmbeddingProvider = ({
+  children
+}: {
+  children: React.ReactNode
+}): JSX.Element => {
+  const isInIframe = useMemo(() => detectIsInIframe(), [])
+
+  return (
+    <EmbeddingContext.Provider value={isInIframe}>
+      {children}
+    </EmbeddingContext.Provider>
+  )
+}
+
+/**
+ * Whether the app is embedded (as a Cozy app) rather than served standalone.
+ *
+ * Falls back to detecting on the spot when rendered outside the provider, so
+ * that isolated renders (unit tests, deep links mounted on their own) keep
+ * behaving like the full app.
+ */
+export const useIsInIframe = (): boolean => {
+  const provided = useContext(EmbeddingContext)
+
+  return useMemo(
+    () => (provided === null ? detectIsInIframe() : provided),
+    [provided]
+  )
+}

--- a/common/src/features/Tdrive/hooks/useIsTdrivePickerAvailable.ts
+++ b/common/src/features/Tdrive/hooks/useIsTdrivePickerAvailable.ts
@@ -1,0 +1,25 @@
+import { useIsInIframe } from '@common/contexts/EmbeddingContext'
+
+/**
+ * Whether the Tdrive file picker can be opened here.
+ *
+ * The picker talks to the Tdrive stack cross-origin (token exchange, then the
+ * intents API and the picker iframe). Only the Cozy-embedded deployment is a
+ * whitelisted origin there; the very same SPA served directly on its own
+ * domain fails on CORS. Both are driven by the same runtime configuration, so
+ * `TDRIVE_ENABLED` alone cannot tell them apart: complement it with the
+ * embedding check, which is what distinguishes the two ways of serving the SPA
+ * at runtime.
+ *
+ * This gates the picker only. Attachments already carried by an event are
+ * plain iCalendar `ATTACH` properties and are displayed regardless.
+ */
+export const useIsTdrivePickerAvailable = (): boolean => {
+  const isInIframe = useIsInIframe()
+
+  return (
+    Boolean(window.TDRIVE_INTENT_URL) &&
+    Boolean(window.TDRIVE_ENABLED) &&
+    isInIframe
+  )
+}

--- a/common/src/features/Tdrive/index.ts
+++ b/common/src/features/Tdrive/index.ts
@@ -1,6 +1,7 @@
 export { TdriveButton } from './components/TdriveButton'
 export { TdrivePickerDialog } from './components/TdrivePickerDialog'
 export { useTdrivePicker } from './hooks/useTdrivePicker'
+export { useIsTdrivePickerAvailable } from './hooks/useIsTdrivePickerAvailable'
 export type { TdriveFile } from './types'
 export { exchangeToken, createIntent } from './TdriveDao'
 export type {


### PR DESCRIPTION
To that end we mutualizes isInIframe is a react component

Cc @lethemanh 

(raw https://calendar-ng.linagora.com/ usage show a failing file picker - the intent of this work is to hide it when it will fail because of CORS)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting when the app is embedded in an iframe.
  - Added Tdrive picker availability checks based on embedding status and configuration.
  - Event attachments now safely display existing files when the Tdrive picker is unavailable.

- **Bug Fixes**
  - Improved attachment handling by filtering unsafe URLs and avoiding empty attachment fields.
  - Standardized embedded-app behavior across private and public applications, calendars, and dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->