### PR TITLE
ISSUE-1251 Fix resource administrator access handling

### DIFF
--- a/__test__/features/Calendars/CalendarAccessRights.test.tsx
+++ b/__test__/features/Calendars/CalendarAccessRights.test.tsx
@@ -260,7 +260,7 @@ describe('CalendarAccessRights', () => {
         resource: true,
         emails: ['resource1@example.com'],
         administrators: [
-          { id: 'admin1' },
+          { id: 'admin1', access: 5 },
           { id: 'admin2' },
           { id: 'resource1' } // Owner shouldn't be loaded as an admin
         ]

--- a/__test__/features/Calendars/services/helpers.test.tsx
+++ b/__test__/features/Calendars/services/helpers.test.tsx
@@ -110,7 +110,15 @@ describe('helpers', () => {
       const mockResource = {
         _id: 'r-1',
         name: 'Conference Room',
-        creator: 'u-creator'
+        creator: 'u-creator',
+        administrators: [
+          {
+            _id: 'admin-1',
+            id: 'admin-1',
+            objectType: 'user',
+            access: 5
+          }
+        ]
       } as any
       const mockCreator = {
         id: 'u-creator',
@@ -124,6 +132,7 @@ describe('helpers', () => {
       const result = await getOwnerOrResourceData('r-1')
       expect(result.resource).toBe(true)
       expect(result.id).toBe('u-creator')
+      expect(result.administrators).toEqual(mockResource.administrators)
     })
 
     it('should return team calendar owner data when fetchEntityById returns teamCalendar root key', async () => {

--- a/common/src/components/Calendar/CalendarAccessRights/index.tsx
+++ b/common/src/components/Calendar/CalendarAccessRights/index.tsx
@@ -260,7 +260,7 @@ export function CalendarAccessRights({
           .filter(admin => admin.id !== calendar.owner._id)
           .map(admin => ({
             id: admin.id,
-            access: 5 // ADMIN
+            access: (admin.access ?? 5) as AccessRight
           })) satisfies UserInCalendar[]
         const admins = await handleLoadUsers(
           resourceAdminsWithoutOwner,

--- a/common/src/features/User/type/OpenPaasUserData.ts
+++ b/common/src/features/User/type/OpenPaasUserData.ts
@@ -19,6 +19,7 @@ export interface OpenPaasUserData {
     _id: string
     id: string
     objectType: string
+    access?: number
   }[]
   resourceIcon?: string
 }

--- a/common/src/features/User/type/ResourceData.ts
+++ b/common/src/features/User/type/ResourceData.ts
@@ -10,6 +10,7 @@ export interface ResourceData {
     _id: string
     id: string
     objectType: string
+    access?: number
   }[]
   timestamps: {
     creation: string


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-frontend/issues/1251

Use the resource administrator access value returned by the existing resource API instead of always assigning administrator access (`5`).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar administrators’ access levels are now preserved and displayed correctly.
  * Administrators without an explicit access level continue to receive administrator permissions by default.

* **Tests**
  * Added coverage to verify administrator data and access levels are retained for resource calendars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->