### PR TITLE
#1237 update attachment chips to follow design

### DIFF
--- a/common/src/components/Event/fields/AttachmentField.tsx
+++ b/common/src/components/Event/fields/AttachmentField.tsx
@@ -1,10 +1,8 @@
 import { AttachementChip } from '@common/components/EventPreview/AttachementPreview/AttachementChip'
 import { Attachment } from '@common/types/Attachment'
 import { isSafeHttpUrl } from '@common/utils/isSafeUrl'
-import { Box, IconButton } from '@linagora/twake-mui'
-import CloseIcon from '@mui/icons-material/Close'
+import { Box } from '@linagora/twake-mui'
 import { MouseEvent } from 'react'
-import { useI18n } from 'twake-i18n'
 
 interface AttachmentFieldProps {
   attachments?: Attachment[]
@@ -15,7 +13,6 @@ export const AttachmentField: React.FC<AttachmentFieldProps> = ({
   attachments,
   setAttachments
 }) => {
-  const { t } = useI18n()
   const handleRemove = (
     e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>,
     index: number
@@ -45,15 +42,7 @@ export const AttachmentField: React.FC<AttachmentFieldProps> = ({
           <AttachementChip
             key={`${attachment.uri}-${index}`}
             attachment={attachment}
-            endAddorments={
-              <IconButton
-                size="small"
-                onClick={e => handleRemove(e, index)}
-                aria-label={t('actions.remove')}
-              >
-                <CloseIcon />
-              </IconButton>
-            }
+            onDelete={e => handleRemove(e, index)}
           />
         )
       })}

--- a/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
@@ -1,43 +1,19 @@
 import { Attachment } from '@common/types/Attachment'
 import { FileTypeFolder, getFileTypeIcon, Icon } from '@linagora/twake-icons'
-import { Box, Link, radius, Tooltip, Typography } from '@linagora/twake-mui'
-import React, { ReactElement } from 'react'
-
-const chipStyle = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 1,
-  border: '1px solid',
-  borderColor: 'divider',
-  borderRadius: radius.sm,
-  px: 1,
-  py: 0.5,
-  cursor: 'pointer',
-  '&:hover': {
-    backgroundColor: 'action.hover'
-  }
-}
+import { Box, Chip, radius, Tooltip, Typography } from '@linagora/twake-mui'
+import React, { MouseEvent } from 'react'
+import CloseIcon from '@mui/icons-material/Close'
 
 export const AttachementChip: React.FC<{
   attachment: Attachment
-  endAddorments?: ReactElement
-}> = ({ attachment, endAddorments }) => {
+  onDelete?: (e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => void
+}> = ({ attachment, onDelete }) => {
   const filename = attachment.x_filename ?? ''
   const lastDot = filename.lastIndexOf('.')
   const hasExtension = lastDot > 0 && lastDot < filename.length - 1
   const name = hasExtension ? filename.slice(0, lastDot) : filename
   const extension = hasExtension ? filename.slice(lastDot) : ''
   const isDirectory = !attachment.fmttype && !hasExtension
-  const fileIcon = (
-    <Icon
-      icon={
-        isDirectory
-          ? FileTypeFolder
-          : getFileTypeIcon(filename, attachment.fmttype)
-      }
-      size={20}
-    />
-  )
 
   const safeHref = React.useMemo(() => {
     try {
@@ -50,49 +26,72 @@ export const AttachementChip: React.FC<{
     }
   }, [attachment.uri])
 
-  return (
-    <Tooltip title={filename} placement="top">
-      <Link
-        href={safeHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        underline="none"
+  const openFile = (): void => {
+    if (!safeHref) return
+    window.open(safeHref, '_blank', 'noopener noreferrer')
+  }
+
+  const label = (
+    <Box sx={{ width: '100%', display: 'flex', alignItems: 'center' }}>
+      <Typography
+        variant="body2"
         sx={{
-          textDecoration: 'none',
-          '&:hover': { textDecoration: 'none' }
+          flexShrink: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          maxWidth: '100px'
         }}
       >
-        <Box sx={{ ...chipStyle, width: '150px' }}>
-          <Box sx={{ mt: '2px', flexShrink: 0 }}>{fileIcon}</Box>
-          <Box sx={{ width: 0, flex: 1, display: 'flex' }}>
-            <Typography
-              variant="body2"
-              sx={{
-                flexShrink: 1,
-                minWidth: 0,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap'
-              }}
-            >
-              {name}
-            </Typography>
-            {extension && (
-              <Typography
-                variant="body2"
-                sx={{
-                  flexShrink: 0,
-                  maxWidth: '85%',
-                  wordBreak: 'break-all'
-                }}
-              >
-                {extension}
-              </Typography>
-            )}
-          </Box>
-          {endAddorments}
-        </Box>
-      </Link>
+        {name}
+      </Typography>
+      {extension && (
+        <Typography
+          variant="body2"
+          sx={{
+            flexShrink: 0,
+            maxWidth: '85%',
+            wordBreak: 'break-all'
+          }}
+        >
+          {extension}
+        </Typography>
+      )}
+    </Box>
+  )
+
+  /**
+   * We have an issue with @linagora/twake-mui@4.3.0
+   * This version contains new override of Chip component
+   * But The style of some component like: Accordion, ButtonGroup,... are not correct as version 2.0.0
+   * TO DO:
+   * - Temporarily custom the style for Chip component in calendar
+   * - When a fix version of @linagora/twake-mui is available => Remove the custom style of Chip component
+   */
+  return (
+    <Tooltip title={filename} placement="top">
+      <Box>
+        <Chip
+          color="secondary"
+          sx={{
+            borderRadius: radius.md
+          }}
+          icon={
+            <Icon
+              icon={
+                isDirectory
+                  ? FileTypeFolder
+                  : getFileTypeIcon(filename, attachment.fmttype)
+              }
+            />
+          }
+          label={label}
+          onDelete={onDelete}
+          deleteIcon={<CloseIcon sx={{ width: '16px', height: '16px' }} />}
+          onClick={openFile}
+        />
+      </Box>
     </Tooltip>
   )
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1237

Need: https://github.com/linagora/twake-ui/pull/69

### Changes:

~~- [x] Apply new Chip component from `twake-mui` to attachment chip.~~
~~- [ ] Upgrade `@linagora/twake-mui` version.~~

Apply MuiChip component with custom style for border radius

### Records:

#### Event preview

<img width="564" height="458" alt="image" src="https://github.com/user-attachments/assets/d41039bf-eb5f-48c6-9946-41f2a22ff32d" />

### Update event

<img width="556" height="672" alt="image" src="https://github.com/user-attachments/assets/a06f021b-421a-4f1e-b644-7ef7eedc5bf3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Attachment previews now display as compact chips with file-type icons and clearer filenames.
  * Selecting an attachment opens it in a separate browser window.
  * Attachment links are handled more safely by allowing only secure HTTP(S) destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->