### PR TITLE
#1279 change icon next to team calendar participant in event preview

### DIFF
--- a/common/src/components/Event/utils/attendeeBadgeUtils.tsx
+++ b/common/src/components/Event/utils/attendeeBadgeUtils.tsx
@@ -8,7 +8,7 @@ import { PartStat } from '@common/features/User/models/attendee'
 import Tooltip from '@common/components/Tooltip'
 import GroupsIcon from '@mui/icons-material/Groups'
 import { stringAvatar } from './eventUtils'
-import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
 export const classIcon = (
   partStat?: PartStat,
@@ -127,7 +127,7 @@ function renderTeamOrganizerFullBadge({
               teamName: displayName
             })}
           >
-            <ErrorOutlineOutlinedIcon
+            <InfoOutlinedIcon
               sx={{
                 width: '18px',
                 height: '18px',


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1279

### Change:

Adjust the icon from `ErrorOutlineOutlinedIcon` into `InfoOutlinedIcon`

| Before | After |
| --- | ----------- |
| <img width="305" height="70" alt="image" src="https://github.com/user-attachments/assets/5b6001cd-7536-4eca-b497-ac11966de1e2" /> | <img width="302" height="75" alt="SCR-20260825-miio" src="https://github.com/user-attachments/assets/c51d6e75-8f36-42ef-94e0-fdc511046084" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the attendee badge tooltip icon for a clearer informational visual.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->