### PR TITLE
[#1275] bugfix: draggable move grows toward available space

### DIFF
--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -142,6 +142,12 @@ const DraggablePaper = React.forwardRef<HTMLDivElement, PaperProps>(
       const target = e.target as HTMLElement
       if (!target.closest('.draggable-dialog-title')) return
       if (target.closest('button')) return
+
+      // Re-sync pos with reality if useDynamicPosition cleared the transform
+      if (!el.current?.style.transform) {
+        pos.current = { x: 0, y: 0 }
+      }
+
       origin.current = {
         mx: e.clientX - pos.current.x,
         my: e.clientY - pos.current.y

--- a/common/src/components/Dialog/useDynamicPosition.ts
+++ b/common/src/components/Dialog/useDynamicPosition.ts
@@ -218,6 +218,22 @@ const isPositioningEnabled = ({
 }: UseDynamicPositionOptions): boolean =>
   open && !isExpanded && !isMobile && Boolean(dynamicPositioning)
 
+const clearPositionFromDOM = (dialogId?: string): void => {
+  const paperEl = getDialogPaperElement(dialogId)
+  if (!paperEl) return
+  paperEl.style.top = ''
+  paperEl.style.left = ''
+}
+
+const applyPositionToDOM = (pos: DynamicPosition, dialogId?: string): void => {
+  const paperEl = getDialogPaperElement(dialogId)
+  if (!paperEl) return
+  paperEl.style.top = `${pos.top}px`
+  paperEl.style.left = `${pos.left}px`
+  // Clear any drag transform so the clamped position is the true visual position.
+  paperEl.style.transform = ''
+}
+
 const setupResizeObserver = (
   callback: () => void,
   dialogId?: string
@@ -270,6 +286,7 @@ export const useDynamicPosition = (
   useEffect(() => {
     if (!isEnabled) {
       lastValidRectRef.current = null
+      clearPositionFromDOM(dialogId)
       return
     }
 
@@ -300,10 +317,16 @@ export const useDynamicPosition = (
         dialogId
       )
       if (pos) {
+        // In case of repositionning and the dialog size changes, we clear the transform
+        applyPositionToDOM(pos, dialogId)
         setPosition(pos)
         setLastPosition(pos)
       } else {
         rafId = requestAnimationFrame(updatePos)
+      }
+
+      if (!cleanupResizeObserver) {
+        cleanupResizeObserver = setupResizeObserver(updatePos, dialogId)
       }
     }
 
@@ -311,7 +334,6 @@ export const useDynamicPosition = (
       updatePos()
       rafId = requestAnimationFrame(updatePos)
       timerId = setTimeout(updatePos, 50)
-      cleanupResizeObserver = setupResizeObserver(updatePos, dialogId)
     }
 
     startPositioning()


### PR DESCRIPTION
resolves #1275 

draggable move grows toward available space
it's also restored to its original place when moved then resized

[Capture vidéo du 2026-08-25 09-23-32.webm](https://github.com/user-attachments/assets/de4c4bcb-d138-447f-8167-8bc61c2b0de8)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved dragging behavior for dialogs after they are repositioned.
- Dialogs now reliably apply their calculated position following window resizing or dynamic layout changes.
- Prevented stale positioning data from causing dialogs to jump or appear in the wrong location.
- Improved consistency when starting a new drag after a dialog’s position has been automatically adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->