### PR TITLE
#1280 adjust margin left and right of full screen modal on mobile

### DIFF
--- a/apps/private/src/components/Calendar/PrintSchedule/PrintScheduleModal.tsx
+++ b/apps/private/src/components/Calendar/PrintSchedule/PrintScheduleModal.tsx
@@ -42,6 +42,7 @@ import { Dayjs } from 'dayjs'
 import { useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { useVisibleBookingLinks } from '../hooks/useVisibleBookingLinks'
+import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 
 export interface PrintScheduleModalProps {
   open: boolean
@@ -58,6 +59,7 @@ export const PrintScheduleModal: React.FC<PrintScheduleModalProps> = ({
   selectedCalendars
 }) => {
   const { t, lang } = useI18n()
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
   const dispatch = useAppDispatch()
   const visibleBookingLinks = useVisibleBookingLinks()
   const userId = useAppSelector(state => state.user.userData?.openpaasId) ?? ''
@@ -241,13 +243,16 @@ export const PrintScheduleModal: React.FC<PrintScheduleModalProps> = ({
     }
   }
 
+  const paddingX = isMobile ? 2 : undefined
+
   return (
     <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
       <DialogTitle
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'center'
+          alignItems: 'center',
+          px: paddingX
         }}
       >
         {t('print.title')}
@@ -255,7 +260,7 @@ export const PrintScheduleModal: React.FC<PrintScheduleModalProps> = ({
           <CloseIcon />
         </IconButton>
       </DialogTitle>
-      <DialogContent>
+      <DialogContent sx={{ px: paddingX }}>
         <TwakeLocalizationProvider>
           <Stack spacing={2.5} sx={{ mt: 1 }}>
             <Box>
@@ -388,7 +393,7 @@ export const PrintScheduleModal: React.FC<PrintScheduleModalProps> = ({
           </Stack>
         </TwakeLocalizationProvider>
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ px: paddingX }}>
         <Button onClick={onClose} disabled={loading}>
           {t('common.cancel')}
         </Button>

--- a/common/src/components/Calendar/RegisterCalendars/SearchCalendarsDialog.tsx
+++ b/common/src/components/Calendar/RegisterCalendars/SearchCalendarsDialog.tsx
@@ -106,7 +106,7 @@ export const SearchCalendarsDialog: React.FC<SearchCalendarsDialogProps> = ({
         />
       </DialogTitle>
 
-      <DialogContent sx={{ marginTop: 1 }}>
+      <DialogContent sx={{ marginTop: 1, px: 2 }}>
         <AttendeeOptionsList
           options={searchState.options || []}
           onOptionClick={user =>

--- a/common/src/components/Calendar/TempSearchDialog.tsx
+++ b/common/src/components/Calendar/TempSearchDialog.tsx
@@ -107,7 +107,7 @@ export default function TempSearchDialog({
         />
       </DialogTitle>
 
-      <DialogContent sx={{ marginTop: 1 }}>
+      <DialogContent sx={{ marginTop: 1, px: 2 }}>
         <AttendeeOptionsList
           options={searchState.options || []}
           onOptionClick={user =>

--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -281,7 +281,8 @@ function ResponsiveDialog({
       }
 
   const baseContentSx: SxProps<Theme> = {
-    width: '100%'
+    width: '100%',
+    px: isMobile ? 2 : undefined
   }
 
   const contentWrapperSx: SxProps<Theme> = {
@@ -346,7 +347,11 @@ function ResponsiveDialog({
           id={titleId}
           className="draggable-dialog-title"
           sx={
-            [titleSx, isDraggable ? { cursor: 'move' } : {}] as SxProps<Theme>
+            [
+              titleSx,
+              isDraggable ? { cursor: 'move' } : {},
+              isMobile ? { px: 2 } : {}
+            ] as SxProps<Theme>
           }
         >
           <Box
@@ -427,7 +432,8 @@ function ResponsiveDialog({
               borderTop: actionsBorderTop
                 ? (theme: Theme): string => `1px solid ${theme.palette.divider}`
                 : undefined,
-              justifyContent: actionsJustifyContent
+              justifyContent: actionsJustifyContent,
+              px: isMobile ? 2 : undefined
             }}
           >
             {actions}


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1280

### Change:

When open a full-screen modal on mobile, the left and right margins are `32px`, they need to be reduced into `16px` for each.

| Before      | After |
| ----------- | ----------- |
| <img width="430" height="726" alt="image" src="https://github.com/user-attachments/assets/9a18f0a9-680a-4e71-9b90-6746ee7494a5" />  | <img width="434" height="731" alt="image" src="https://github.com/user-attachments/assets/972e531a-8273-4d56-94e9-d67727191063" /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dialog layouts on small screens with consistent horizontal padding.
  - Updated calendar printing, calendar search, and responsive dialogs for better mobile spacing.
  - Preserved existing desktop dialog appearance and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->