### PR TITLE
Team calendar events: allow creating events without organiser

### DIFF
--- a/__test__/features/Events/hooks/createAction.test.ts
+++ b/__test__/features/Events/hooks/createAction.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { buildNewEvent } from '@common/features/Events/hooks/submitCreateHelpers/createAction'
+import { userAttendee } from '@common/features/User/models/attendee'
+import { userOrganiser } from '@common/features/User/userDataTypes'
+import { Calendar } from '@common/types/CalendarTypes'
+import { RepetitionObject } from '@common/types/Repetition'
+import { VAlarm } from '@common/types/VAlarm'
+import { Valarms } from '@common/types/Valarms'
+
+jest.mock('p-map', () => jest.fn())
+
+const baseCalendar: Calendar = {
+  id: 'user-1/cal-1',
+  link: 'user-1/cal-1.json',
+  name: 'Personal Calendar',
+  owner: {
+    id: 'user-1',
+    emails: ['user@example.com'],
+    firstname: 'John',
+    lastname: 'Doe'
+  },
+  events: {},
+  visibility: 'private'
+}
+
+const teamCalendar: Calendar = {
+  id: 'team-1/cal-1',
+  link: 'team-1/cal-1.json',
+  name: 'Team Calendar',
+  owner: {
+    id: 'team-1',
+    emails: ['team@example.com'],
+    firstname: 'Engineering Team',
+    teamCalendar: true
+  },
+  events: {},
+  visibility: 'private'
+}
+
+const baseValues = {
+  title: 'Test Event',
+  description: '',
+  location: '',
+  start: '2025-01-15T10:00:00',
+  end: '2025-01-15T11:00:00',
+  allday: false,
+  timezone: 'Europe/Paris',
+  calendarid: 'user-1/cal-1',
+  eventClass: 'PUBLIC' as const,
+  busy: 'OPAQUE',
+  repetition: {} as RepetitionObject,
+  showRepeat: false,
+  hasEndDateChanged: false,
+  alarms: new Valarms([new VAlarm({ trigger: '-PT15M', action: 'EMAIL' })]),
+  attendees: [],
+  selectedResources: [],
+  meetingLink: '',
+  hasVideoConference: false,
+  attachments: [],
+  showDescription: false
+}
+
+describe('handleCreateEvent - team calendar organizer handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does NOT set organizer for team calendar when there are no attendees', async () => {
+    const organizer = new userOrganiser({
+      cn: 'Current User',
+      cal_address: 'mailto:user@example.com'
+    })
+
+    const newEvent = buildNewEvent({
+      values: {
+        ...baseValues,
+        calendarid: 'team-1/cal-1',
+        attendees: [],
+        selectedResources: []
+      },
+      targetCalendar: teamCalendar,
+      showMore: true,
+      organizer,
+      newEventUID: '',
+      t: (key: string) => key
+    })
+
+    // Organizer should be undefined for team calendar without attendees
+    expect(newEvent.organizer).toBeUndefined()
+    // Attendee list should also be empty (no organizer added as attendee)
+    expect(newEvent.attendee).toEqual([])
+  })
+
+  it('SETS organizer for team calendar when there ARE attendees', async () => {
+    const organizer = new userOrganiser({
+      cn: 'Current User',
+      cal_address: 'mailto:user@example.com'
+    })
+
+    const newEvent = buildNewEvent({
+      values: {
+        ...baseValues,
+        calendarid: 'team-1/cal-1',
+        attendees: [
+          new userAttendee({
+            cal_address: 'mailto:attendee@example.com',
+            cn: 'Attendee'
+          })
+        ],
+        selectedResources: []
+      },
+      targetCalendar: teamCalendar,
+      showMore: true,
+      organizer,
+      newEventUID: '',
+      t: (key: string) => key
+    })
+
+    // Organizer should be set when there are attendees
+    expect(newEvent.organizer).toBeDefined()
+    expect(newEvent.organizer?.cal_address).toBe('mailto:user@example.com')
+    // Attendee list should contain the organizer as CHAIR plus the attendee
+    expect(newEvent.attendee).toHaveLength(2)
+    const organizerAttendee = newEvent.attendee?.find(
+      (a: userAttendee) => a.role === 'CHAIR'
+    )
+    expect(organizerAttendee).toBeDefined()
+    expect(organizerAttendee?.cal_address).toBe('mailto:user@example.com')
+  })
+
+  it('SETS organizer for regular (non-team) calendar even without attendees', async () => {
+    const organizer = new userOrganiser({
+      cn: 'Current User',
+      cal_address: 'mailto:user@example.com'
+    })
+
+    const newEvent = buildNewEvent({
+      values: {
+        ...baseValues,
+        calendarid: 'user-1/cal-1',
+        attendees: [],
+        selectedResources: []
+      },
+      targetCalendar: baseCalendar,
+      showMore: true,
+      organizer,
+      newEventUID: '',
+      t: (key: string) => key
+    })
+
+    // Organizer should be set for regular calendar even without attendees
+    expect(newEvent.organizer).toBeDefined()
+    expect(newEvent.organizer?.cal_address).toBe('mailto:user@example.com')
+    // For regular calendars, attendee list still includes organizer as CHAIR
+    expect(newEvent.attendee).toHaveLength(1)
+    expect(newEvent.attendee?.[0]?.role).toBe('CHAIR')
+    expect(newEvent.attendee?.[0]?.cal_address).toBe('mailto:user@example.com')
+  })
+
+  it('SETS organizer when moving event from regular to team calendar with attendees', async () => {
+    const organizer = new userOrganiser({
+      cn: 'Current User',
+      cal_address: 'mailto:user@example.com'
+    })
+
+    const newEvent = buildNewEvent({
+      values: {
+        ...baseValues,
+        calendarid: 'team-1/cal-1',
+        attendees: [
+          new userAttendee({
+            cal_address: 'mailto:attendee@example.com',
+            cn: 'Attendee'
+          })
+        ],
+        selectedResources: []
+      },
+      targetCalendar: teamCalendar,
+      showMore: true,
+      organizer,
+      newEventUID: '',
+      t: (key: string) => key
+    })
+
+    // Organizer should be set when there are attendees, even in team calendar
+    expect(newEvent.organizer).toBeDefined()
+  })
+})

--- a/__test__/features/Events/updateEventHelpers/prepareUpdatedEvent.test.ts
+++ b/__test__/features/Events/updateEventHelpers/prepareUpdatedEvent.test.ts
@@ -37,6 +37,131 @@ const baseValues = {
 } as any
 
 describe('prepareUpdatedEvent', () => {
+  describe('team calendar organizer handling', () => {
+    it('does NOT set organizer for team calendar when there are no attendees', () => {
+      const teamCalendar = {
+        id: 'team-cal-1',
+        owner: {
+          teamCalendar: true,
+          emails: ['team@example.com']
+        }
+      } as Calendar
+
+      const eventWithOrganizer = {
+        ...baseEvent,
+        organizer: {
+          cn: 'Previous Organizer',
+          cal_address: 'mailto:prev@example.com'
+        }
+      } as CalendarEvent
+
+      const valuesNoAttendees = {
+        ...baseValues,
+        attendees: [],
+        selectedResources: []
+      }
+
+      const updatedEvent = prepareUpdatedEvent({
+        event: eventWithOrganizer,
+        values: valuesNoAttendees,
+        startISO: '2025-01-01T10:00:00.000Z',
+        endISO: '2025-01-01T11:00:00.000Z',
+        timeChanged: false,
+        targetCalendar: teamCalendar,
+        calId: 'team-cal-1',
+        newCalId: 'team-cal-1'
+      })
+
+      expect(updatedEvent.organizer).toBeUndefined()
+      expect(updatedEvent.attendee).toEqual([])
+    })
+
+    it('SETS organizer for team calendar when there ARE attendees', () => {
+      const teamCalendar = {
+        id: 'team-cal-1',
+        owner: {
+          teamCalendar: true,
+          emails: ['team@example.com']
+        }
+      } as Calendar
+
+      const eventWithOrganizer = {
+        ...baseEvent,
+        organizer: {
+          cn: 'Previous Organizer',
+          cal_address: 'mailto:prev@example.com'
+        }
+      } as CalendarEvent
+
+      const valuesWithAttendees = {
+        ...baseValues,
+        attendees: [
+          new userAttendee({
+            cal_address: 'mailto:attendee@example.com',
+            cn: 'Attendee'
+          })
+        ],
+        selectedResources: []
+      }
+
+      const updatedEvent = prepareUpdatedEvent({
+        event: eventWithOrganizer,
+        values: valuesWithAttendees,
+        startISO: '2025-01-01T10:00:00.000Z',
+        endISO: '2025-01-01T11:00:00.000Z',
+        timeChanged: false,
+        targetCalendar: teamCalendar,
+        calId: 'team-cal-1',
+        newCalId: 'team-cal-1'
+      })
+
+      expect(updatedEvent.organizer).toBeDefined()
+      expect(updatedEvent.organizer?.cal_address).toBe(
+        'mailto:prev@example.com'
+      )
+    })
+
+    it('SETS organizer for regular (non-team) calendar even without attendees', () => {
+      const regularCalendar = {
+        id: 'user-cal-1',
+        owner: {
+          teamCalendar: false,
+          emails: ['user@example.com']
+        }
+      } as Calendar
+
+      const eventWithOrganizer = {
+        ...baseEvent,
+        organizer: {
+          cn: 'Previous Organizer',
+          cal_address: 'mailto:prev@example.com'
+        }
+      } as CalendarEvent
+
+      const valuesNoAttendees = {
+        ...baseValues,
+        attendees: [],
+        selectedResources: []
+      }
+
+      const updatedEvent = prepareUpdatedEvent({
+        event: eventWithOrganizer,
+        values: valuesNoAttendees,
+        startISO: '2025-01-01T10:00:00.000Z',
+        endISO: '2025-01-01T11:00:00.000Z',
+        timeChanged: false,
+        targetCalendar: regularCalendar,
+        calId: 'user-cal-1',
+        newCalId: 'user-cal-1'
+      })
+
+      expect(updatedEvent.organizer).toBeDefined()
+      expect(updatedEvent.organizer?.cal_address).toBe(
+        'mailto:prev@example.com'
+      )
+    })
+  })
+
   it('sets alarm attendees and summary at VAlarm construction time', () => {
     const updatedEvent = prepareUpdatedEvent({
       event: baseEvent,

--- a/common/src/features/Events/hooks/submitCreateHelpers/createAction.ts
+++ b/common/src/features/Events/hooks/submitCreateHelpers/createAction.ts
@@ -16,7 +16,7 @@ import {
   showErrorNotification
 } from '@common/utils/eventFormTempStorage'
 import { addVideoConferenceToDescription } from '@common/utils/videoConferenceUtils'
-import { getAlarmAttendees } from '../submitUpdateHelpers/utils'
+import { getAlarmAttendees, hasNoAttendees } from '../submitUpdateHelpers/utils'
 import { userOrganiser } from '@common/features/User/userDataTypes'
 
 function buildAttendees({
@@ -35,7 +35,7 @@ function buildAttendees({
   ]
 }
 
-function buildNewEvent({
+export function buildNewEvent({
   values,
   targetCalendar,
   showMore,
@@ -60,6 +60,12 @@ function buildNewEvent({
     hasEndDateChanged: values.hasEndDateChanged
   })
 
+  const isTeamCalendar = Boolean(targetCalendar.owner?.teamCalendar)
+  const noAttendees = hasNoAttendees(values.attendees, values.selectedResources)
+  // Don't set organizer for team calendars when there are no attendees
+  // (needed for proper ITIP mail routing)
+  const shouldSetOrganizer = !(isTeamCalendar && noAttendees)
+
   return {
     calId: targetCalendar.id,
     title: values.title,
@@ -83,13 +89,15 @@ function buildNewEvent({
       allday: values.allday,
       timezone: values.timezone
     }),
-    organizer,
+    organizer: shouldSetOrganizer ? organizer : undefined,
     timezone: values.timezone,
-    attendee: buildAttendees({
-      organizer,
-      resources: values.selectedResources,
-      attendees: values.attendees
-    }),
+    attendee: shouldSetOrganizer
+      ? buildAttendees({
+          organizer,
+          resources: values.selectedResources,
+          attendees: values.attendees
+        })
+      : [],
     transp: values.busy,
     sequence: 1,
     color: targetCalendar?.color,

--- a/common/src/features/Events/hooks/submitCreateHelpers/createAction.ts
+++ b/common/src/features/Events/hooks/submitCreateHelpers/createAction.ts
@@ -16,7 +16,8 @@ import {
   showErrorNotification
 } from '@common/utils/eventFormTempStorage'
 import { addVideoConferenceToDescription } from '@common/utils/videoConferenceUtils'
-import { getAlarmAttendees, hasNoAttendees } from '../submitUpdateHelpers/utils'
+import { getAlarmAttendees } from '../submitUpdateHelpers/utils'
+import { hasNoAttendees } from '@common/utils/hasNoAttendees'
 import { userOrganiser } from '@common/features/User/userDataTypes'
 
 function buildAttendees({
@@ -61,7 +62,7 @@ export function buildNewEvent({
   })
 
   const isTeamCalendar = Boolean(targetCalendar.owner?.teamCalendar)
-  const noAttendees = hasNoAttendees(values.attendees, values.selectedResources)
+  const noAttendees = hasNoAttendees(values.attendees)
   // Don't set organizer for team calendars when there are no attendees
   // (needed for proper ITIP mail routing)
   const shouldSetOrganizer = !(isTeamCalendar && noAttendees)

--- a/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -111,6 +111,16 @@ function computeFinalAttendees(
   return baseAttendees
 }
 
+export function hasNoAttendees(
+  attendees: EventFormValues['attendees'],
+  resources: EventFormValues['selectedResources']
+): boolean {
+  return (
+    (!attendees || attendees.length === 0) &&
+    (!resources || resources.length === 0)
+  )
+}
+
 export function prepareUpdatedEvent({
   event,
   values,
@@ -124,16 +134,23 @@ export function prepareUpdatedEvent({
   t
 }: PrepareUpdatedEventParams): CalendarEvent {
   const currentCalId = newCalId || calId
-  const finalOrganizer = organizer ?? event.organizer
+
+  const isTeamCalendar = Boolean(targetCalendar.owner?.teamCalendar)
+  const noAttendees = hasNoAttendees(values.attendees, values.selectedResources)
+
+  // Don't set organizer for team calendars when there are no attendees
+  // (needed for proper ITIP mail routing)
+  const shouldSetOrganizer = !(isTeamCalendar && noAttendees)
+  const finalOrganizer = shouldSetOrganizer
+    ? (organizer ?? event.organizer)
+    : undefined
 
   const baseAttendees =
     updateAttendeesAfterTimeChange(event, timeChanged, values.attendees)
       .attendee ?? []
-  const finalAttendees = computeFinalAttendees(
-    baseAttendees,
-    organizer,
-    event.organizer
-  )
+  const finalAttendees = shouldSetOrganizer
+    ? computeFinalAttendees(baseAttendees, organizer, event.organizer)
+    : []
 
   const newEvent: CalendarEvent = {
     ...updateAttendeesAfterTimeChange(event, timeChanged, values.attendees),

--- a/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -16,6 +16,7 @@ import {
   PrepareUpdateDataResult,
   PrepareUpdatedEventParams
 } from './types'
+import { hasNoAttendees } from '@common/utils/hasNoAttendees'
 
 export function getAlarmAttendees(
   values: EventFormValues,
@@ -111,16 +112,6 @@ function computeFinalAttendees(
   return baseAttendees
 }
 
-export function hasNoAttendees(
-  attendees: EventFormValues['attendees'],
-  resources: EventFormValues['selectedResources']
-): boolean {
-  return (
-    (!attendees || attendees.length === 0) &&
-    (!resources || resources.length === 0)
-  )
-}
-
 export function prepareUpdatedEvent({
   event,
   values,
@@ -136,7 +127,7 @@ export function prepareUpdatedEvent({
   const currentCalId = newCalId || calId
 
   const isTeamCalendar = Boolean(targetCalendar.owner?.teamCalendar)
-  const noAttendees = hasNoAttendees(values.attendees, values.selectedResources)
+  const noAttendees = hasNoAttendees(values.attendees)
 
   // Don't set organizer for team calendars when there are no attendees
   // (needed for proper ITIP mail routing)

--- a/common/src/utils/hasNoAttendees.ts
+++ b/common/src/utils/hasNoAttendees.ts
@@ -1,0 +1,7 @@
+import { EventFormValues } from '@common/components/Event/EventFormFields.types'
+
+export function hasNoAttendees(
+  attendees: EventFormValues['attendees']
+): boolean {
+  return !attendees || attendees.length === 0
+}


### PR DESCRIPTION
resolves #1272 

Now when creating an event in a team calendar, the organiser is not set.

[Capture vidéo du 2026-08-25 16-25-38.webm](https://github.com/user-attachments/assets/2cd57e65-3265-42a0-8172-d71223869c25)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event creation and updates on team calendars without attendees.
  - Events now correctly omit organizer and attendee details when no attendees are provided.
  - Preserved organizer and attendee information when attendees are present.
  - Maintained expected organizer behavior for regular calendars.

- **Tests**
  - Added coverage for event creation and update scenarios across team and regular calendars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->