### PR TITLE
#1242 display folder icon from calendar app

### DIFF
--- a/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
+++ b/common/src/components/EventPreview/AttachementPreview/AttachementChip.tsx
@@ -1,5 +1,5 @@
 import { Attachment } from '@common/types/Attachment'
-import { getFileTypeIcon, Icon } from '@linagora/twake-icons'
+import { FileTypeFolder, getFileTypeIcon, Icon } from '@linagora/twake-icons'
 import { Box, Link, radius, Tooltip, Typography } from '@linagora/twake-mui'
 import React, { ReactElement } from 'react'
 
@@ -30,7 +30,11 @@ export const AttachementChip: React.FC<{
   const isDirectory = !attachment.fmttype && !hasExtension
   const fileIcon = (
     <Icon
-      icon={getFileTypeIcon(filename, attachment.fmttype, isDirectory)}
+      icon={
+        isDirectory
+          ? FileTypeFolder
+          : getFileTypeIcon(filename, attachment.fmttype)
+      }
       size={20}
     />
   )


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1242

### Change:

Based on Julien's feedback, I think we should generate the folder icon from the calendar app and keep `getFileTypeIcon` as is to keep this function generic.

<img width="236" height="109" alt="image" src="https://github.com/user-attachments/assets/f40bf9d6-ef79-44d2-8368-faf01fed5410" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment previews by displaying a folder icon for directory attachments.
  * Preserved file-specific icons for other attachment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->