### PR TITLE
[#1070] added env var to enable refresh button

### DIFF
--- a/__test__/components/Menubar.test.tsx
+++ b/__test__/components/Menubar.test.tsx
@@ -431,6 +431,7 @@ describe('Menubar interaction with expanded Dialog', () => {
 
   afterEach(() => {
     document.body.classList.remove('fullscreen-view')
+    delete (window as any).ENABLE_REFRESH_BUTTON
   })
 
   it('has navigation controls element with correct class', () => {
@@ -475,11 +476,11 @@ describe('Menubar interaction with expanded Dialog', () => {
     expect(dateTimeDisplay).toHaveClass('current-date-time')
   })
 
-  it('has refresh button element with correct class', () => {
+  it('has refresh button element with correct class when enabled', () => {
     const mockCalendarRef = { current: null }
     const mockOnRefresh = jest.fn()
     const mockCurrentDate = new Date('2024-04-15')
-
+    window.ENABLE_REFRESH_BUTTON = true
     const { container } = renderWithProviders(
       <Menubar
         calendarRef={mockCalendarRef}
@@ -494,6 +495,25 @@ describe('Menubar interaction with expanded Dialog', () => {
     const refreshButton = container.querySelector('.refresh-button')
     expect(refreshButton).toBeInTheDocument()
     expect(refreshButton).toHaveClass('refresh-button')
+  })
+
+  it('hide refresh button element when disabled', () => {
+    const mockCalendarRef = { current: null }
+    const mockOnRefresh = jest.fn()
+    const mockCurrentDate = new Date('2024-04-15')
+    const { container } = renderWithProviders(
+      <Menubar
+        calendarRef={mockCalendarRef}
+        onRefresh={mockOnRefresh}
+        onToggleSidebar={() => {}}
+        currentDate={mockCurrentDate}
+        currentView={CALENDAR_VIEWS.dayGridMonth}
+      />,
+      preloadedState
+    )
+
+    const refreshButton = container.querySelector('.refresh-button')
+    expect(refreshButton).toBeNull()
   })
 
   it('has view selector element with correct class', () => {
@@ -715,12 +735,10 @@ describe('Menubar interaction with expanded Dialog', () => {
 
     const navigationControls = container.querySelector('.navigation-controls')
     const dateTimeDisplay = container.querySelector('.current-date-time')
-    const refreshButton = container.querySelector('.refresh-button')
     const selectDisplay = container.querySelector('.select-display')
 
     expect(navigationControls).toBeVisible()
     expect(dateTimeDisplay).toBeVisible()
-    expect(refreshButton).toBeVisible()
     expect(selectDisplay).toBeVisible()
   })
 
@@ -728,6 +746,7 @@ describe('Menubar interaction with expanded Dialog', () => {
     const mockCalendarRef = { current: null }
     const mockOnRefresh = jest.fn()
     const mockCurrentDate = new Date('2024-04-15')
+    window.ENABLE_REFRESH_BUTTON = true
 
     const { container } = renderWithProviders(
       <Menubar

--- a/common/src/components/Menubar/DesktopMenubar.tsx
+++ b/common/src/components/Menubar/DesktopMenubar.tsx
@@ -77,18 +77,7 @@ export const DesktopMenubar: React.FC<SharedMenubarProps> = ({
           <SearchBar onToggleSearch={setIsSearchExpanded} />
         </div>
 
-        <div className="menu-items">
-          <Tooltip title={t('tooltip.refreshCalendar')}>
-            <IconButton
-              className="refresh-button"
-              onClick={onRefresh}
-              aria-label={t('menubar.refresh')}
-              sx={{ mr: 1 }}
-            >
-              <RefreshIcon />
-            </IconButton>
-          </Tooltip>
-        </div>
+        <div className="menu-items">{ResfreshButton({ t, onRefresh })}</div>
 
         <div className="menu-items">
           <SelectView currentView={currentView} onViewChange={onViewChange} />
@@ -136,5 +125,24 @@ export const DesktopMenubar: React.FC<SharedMenubarProps> = ({
         </div>
       </div>
     </header>
+  )
+}
+
+const ResfreshButton: React.FC<{
+  t: (key: string, options?: Record<string, any>) => string
+  onRefresh: () => void
+}> = ({ t, onRefresh }) => {
+  if (!window.ENABLE_REFRESH_BUTTON) return null
+  return (
+    <Tooltip title={t('tooltip.refreshCalendar')}>
+      <IconButton
+        className="refresh-button"
+        onClick={onRefresh}
+        aria-label={t('menubar.refresh')}
+        sx={{ mr: 1 }}
+      >
+        <RefreshIcon />
+      </IconButton>
+    </Tooltip>
   )
 }

--- a/common/src/components/Menubar/DesktopMenubar.tsx
+++ b/common/src/components/Menubar/DesktopMenubar.tsx
@@ -77,7 +77,9 @@ export const DesktopMenubar: React.FC<SharedMenubarProps> = ({
           <SearchBar onToggleSearch={setIsSearchExpanded} />
         </div>
 
-        <div className="menu-items">{ResfreshButton({ t, onRefresh })}</div>
+        <div className="menu-items">
+          <ResfreshButton t={t} onRefresh={onRefresh} />
+        </div>
 
         <div className="menu-items">
           <SelectView currentView={currentView} onViewChange={onViewChange} />

--- a/common/src/window.d.ts
+++ b/common/src/window.d.ts
@@ -55,6 +55,8 @@ declare global {
 
     ENABLE_EVENT_ATTACHMENTS: boolean | undefined
 
+    ENABLE_REFRESH_BUTTON: boolean | undefined
+
     ASK_FOR_TZ_UPDATE: boolean
 
     TOOLTIP_DELAY_MS: number

--- a/public/.env.example.js
+++ b/public/.env.example.js
@@ -63,3 +63,4 @@ var TDRIVE_INTENT_URL = "https://{localpart}.example.com"
 // Examples:
 //   'https://{workplaceFqdn}'
 //   'https://{workplaceFqdn.localpart}.{workplaceFqdn.domain}'
+var ENABLE_REFRESH_BUTTON = false 


### PR DESCRIPTION
resolves #1070 

added ENABLE_REFRESH_BUTTON to .env to have the refresh button hidden by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control whether the refresh button appears in the desktop menu bar.
  - The refresh button is disabled by default and retains its existing behavior when enabled.

- **Tests**
  - Added coverage for refresh-button visibility in enabled and disabled states.
  - Updated menu bar tests to validate behavior across different display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->