### PR TITLE
#1288 increase the left boundary to display the event modal

### DIFF
--- a/common/src/components/Dialog/useDynamicPosition.test.ts
+++ b/common/src/components/Dialog/useDynamicPosition.test.ts
@@ -1,0 +1,33 @@
+import { calculateHorizontalPosition } from './useDynamicPosition'
+
+describe('calculateHorizontalPosition', () => {
+  it('should handle inverted bounds when minLeft exceeds maxLeft (800px viewport)', () => {
+    // 800px viewport, 570px dialog width
+    // paddingLeft = 270, paddingRight = 40
+    // minLeft = 270
+    // maxLeft = 800 - 570 - 40 = 190
+    // minLeft (270) > maxLeft (190), so it should return Math.max(0, 190) = 190
+    const anchorRect = {
+      left: 300,
+      right: 350,
+      top: 100,
+      bottom: 150,
+      width: 50,
+      height: 50,
+      x: 300,
+      y: 100,
+      toJSON: () => {}
+    } as DOMRect
+
+    const result = calculateHorizontalPosition({
+      anchorRect,
+      dialogWidth: 570,
+      viewportWidth: 800,
+      gap: 12,
+      paddingRight: 40,
+      paddingLeft: 270
+    })
+
+    expect(result).toBe(190)
+  })
+})

--- a/common/src/components/Dialog/useDynamicPosition.ts
+++ b/common/src/components/Dialog/useDynamicPosition.ts
@@ -20,7 +20,8 @@ interface HorizontalPositionOptions {
   dialogWidth: number
   viewportWidth: number
   gap: number
-  padding: number
+  paddingRight: number
+  paddingLeft: number
 }
 
 interface VerticalPositionOptions {
@@ -40,6 +41,7 @@ interface DialogDimensions {
 const DEFAULT_HEADER_HEIGHT_PX = 70
 const DEFAULT_GAP = 12
 const DEFAULT_PADDING = 40
+const DEFAULT_LEFT_PADDING = 270
 const DEFAULT_BOTTOM_PADDING = 28
 
 const FALLBACK_SELECTORS = [
@@ -124,30 +126,43 @@ const getDialogDimensions = (dialogId?: string): DialogDimensions | null => {
 const parseHeaderOffset = (headerHeightStr: string): number =>
   parseInt(headerHeightStr, 10) || DEFAULT_HEADER_HEIGHT_PX
 
-const calculateHorizontalPosition = ({
+export const calculateHorizontalPosition = ({
   anchorRect,
   dialogWidth,
   viewportWidth,
   gap,
-  padding
+  paddingRight,
+  paddingLeft
 }: HorizontalPositionOptions): number => {
-  const preferredLeft = anchorRect.left - dialogWidth - gap
-  const maxLeft = viewportWidth - dialogWidth - padding
+  const minLeft = paddingLeft
+  const maxLeft = viewportWidth - dialogWidth - paddingRight
 
-  if (preferredLeft >= padding) {
-    return Math.max(padding, Math.min(preferredLeft, maxLeft))
+  if (minLeft > maxLeft) {
+    return Math.max(0, maxLeft)
   }
 
-  const rightSpace =
-    viewportWidth - (anchorRect.right + gap + dialogWidth + padding)
-  const leftSpace = anchorRect.left - gap - dialogWidth - padding
+  const preferredLeft = anchorRect.left - dialogWidth - gap
+  const preferredRight = anchorRect.right + gap
 
-  const left =
-    rightSpace >= 0 || rightSpace > leftSpace
-      ? anchorRect.right + gap
-      : preferredLeft
+  if (preferredLeft >= minLeft) {
+    return preferredLeft
+  }
 
-  return Math.max(padding, Math.min(left, maxLeft))
+  if (preferredRight <= maxLeft) {
+    return preferredRight
+  }
+
+  const clampedLeft = Math.max(minLeft, preferredLeft)
+  const clampedRight = Math.min(maxLeft, preferredRight)
+
+  const visibleRectIfLeft = anchorRect.right - (clampedLeft + dialogWidth)
+  const visibleRectIfRight = clampedRight - anchorRect.left
+
+  if (visibleRectIfLeft >= visibleRectIfRight) {
+    return Math.min(maxLeft, clampedLeft)
+  }
+
+  return Math.max(minLeft, clampedRight)
 }
 
 const calculateVerticalPosition = ({
@@ -171,7 +186,7 @@ const calculateVerticalPosition = ({
   return Math.max(effectiveMinTop, Math.min(unclampedTop, maxTop))
 }
 
-export const calculateDynamicPosition = (
+const calculateDynamicPosition = (
   anchorEl?: HTMLElement | null,
   headerHeightStr: string = '70px',
   cachedRect?: DOMRect | null,
@@ -195,7 +210,8 @@ export const calculateDynamicPosition = (
     dialogWidth,
     viewportWidth: window.innerWidth,
     gap: DEFAULT_GAP,
-    padding: DEFAULT_PADDING
+    paddingRight: DEFAULT_PADDING,
+    paddingLeft: DEFAULT_LEFT_PADDING
   })
 
   const top = calculateVerticalPosition({
@@ -254,7 +270,7 @@ const getInitialPosition = (
   return calculateDynamicPosition(anchorEl, headerHeight, initialRect, dialogId)
 }
 
-export const useDynamicPosition = (
+const useDynamicPosition = (
   options: UseDynamicPositionOptions
 ): DynamicPosition | null => {
   const { anchorEl, headerHeight = '70px', dialogId } = options


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1288

### Change:

Currently, when clicking on an event chip in the WED column, the event modal displays on the left side, but it hides a part of the left sidebar.

Resolving it by increasing the left boundary will ensure the left sidebar never overlaps.

<img width="1919" height="964" alt="image" src="https://github.com/user-attachments/assets/e61a39cf-e9ce-459b-ba79-8331afee1e17" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog positioning across different viewport sizes.
  * Dialogs now prioritize placement beside the anchor while respecting separate left and right screen padding.
  * When space is limited, dialogs choose the side with better visibility and remain within the viewport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->