### PR TITLE
[#1299] bugfix: show attendee email popover on hover in edit form

### DIFF
--- a/common/src/components/Attendees/AttendeeChip.tsx
+++ b/common/src/components/Attendees/AttendeeChip.tsx
@@ -1,8 +1,10 @@
 import { getAccessiblePair } from '@common/utils/getAccessiblePair'
+import { userAttendee } from '@common/features/User/models/attendee'
 import { Box, Chip, Icon, IconButton, useTheme } from '@linagora/twake-mui'
 import CircleIcon from '@mui/icons-material/Circle'
 import CloseIcon from '@mui/icons-material/Close'
 import { ReactElement } from 'react'
+import { AttendeePopover } from './AttendeePopover'
 import { User } from './types'
 
 export interface AttendeeChipProps {
@@ -65,19 +67,25 @@ export const AttendeeChip: React.FC<AttendeeChipProps> = ({
     )
   }
 
+  const attendeeForPopover = isString
+    ? new userAttendee({ cal_address: option, cn: '' })
+    : userAttendee.fromUser(option)
+
   return (
-    <Chip
-      {...getItemProps({ index })}
-      key={label}
-      variant="filled"
-      color="secondary"
-      icon={renderIcon()}
-      deleteIcon={renderDeleteIcon()}
-      style={{
-        color: textColor,
-        maxWidth: '200px'
-      }}
-      label={label}
-    />
+    <AttendeePopover attendee={attendeeForPopover}>
+      <Chip
+        {...getItemProps({ index })}
+        key={label}
+        variant="filled"
+        color="secondary"
+        icon={renderIcon()}
+        deleteIcon={renderDeleteIcon()}
+        style={{
+          color: textColor,
+          maxWidth: '200px'
+        }}
+        label={label}
+      />
+    </AttendeePopover>
   )
 }


### PR DESCRIPTION
resolves #1299

## Summary

When hovering an attendee chip in the event **create/edit** form, no popover was shown. The same hover on the event **summary** view already showed the attendee's email + copy action. When the attendee's `cn` is short (e.g. initials `H g`) the organizer had no way to verify the underlying email address of the invitee.

## Change

`common/src/components/Attendees/AttendeeChip.tsx` — wrap the returned `<Chip>` in `AttendeePopover`, using the same `userAttendee` conversion the rest of the codebase uses:
- `User` case → `userAttendee.fromUser(option)`
- Free-solo string case → `new userAttendee({ cal_address: option, cn: '' })`

This aligns the edit form with the pattern already applied by `renderSimpleAttendeeBadge` / `renderFullAttendeeBadge` in `common/src/components/Event/utils/eventUtils.tsx` for the summary view.

## Reproduction (before)

1. Open the event create modal (or edit a recurring series).
2. Add / display an attendee whose display name is initials-only, e.g. `H g`.
3. Hover the chip → no popover, no email visible.

## After

1. Same steps.
2. Hover the chip → popover shows full email + copy button, same as summary view.

## Test plan

- [ ] Hover an attendee chip in create-event modal → popover appears with email
- [ ] Hover an attendee chip in edit-event modal → popover appears
- [ ] Hover an attendee chip in edit-series modal → popover appears
- [ ] Deleting an attendee from the chip still works (click the delete icon)
- [ ] Popover behavior unchanged in the summary view (regression check)
- [ ] Hovering a chip that represents the current user → no popover (existing `isSelf` short-circuit still applies)
- [ ] Hovering a resource chip → no popover (existing `RESOURCE` short-circuit still applies)

## Context

Reported by an external tester relayed by Benjamin (production feedback on Twake Calendar). Part of a batch of issues opened from that feedback: #1299 (this), #1300 (unsaved-changes guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attendee chips now provide an interactive popover with additional attendee details.
  - Attendees can be represented using either user selections or user names while maintaining consistent chip display.
- **Improvements**
  - Attendee information is presented more consistently across chip interactions without changing the existing visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->