### PR TITLE
[#1300] feat: confirm before discarding unsaved event modal changes

### DIFF
--- a/common/src/components/Dialog/ConfirmDiscardChangesDialog.tsx
+++ b/common/src/components/Dialog/ConfirmDiscardChangesDialog.tsx
@@ -1,0 +1,40 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography
+} from '@linagora/twake-mui'
+import React from 'react'
+import { useI18n } from 'twake-i18n'
+
+interface ConfirmDiscardChangesDialogProps {
+  open: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export const ConfirmDiscardChangesDialog: React.FC<
+  ConfirmDiscardChangesDialogProps
+> = ({ open, onCancel, onConfirm }) => {
+  const { t } = useI18n()
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth="xs" fullWidth>
+      <DialogTitle>{t('editModeDialog.discardChanges.title')}</DialogTitle>
+      <DialogContent>
+        <Typography>{t('editModeDialog.discardChanges.body')}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onCancel} variant="text">
+          {t('editModeDialog.discardChanges.continueEditing')}
+        </Button>
+        <Button onClick={onConfirm} color="error" variant="contained">
+          {t('editModeDialog.discardChanges.discard')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default ConfirmDiscardChangesDialog

--- a/common/src/components/Dialog/ConfirmDiscardChangesDialog.tsx
+++ b/common/src/components/Dialog/ConfirmDiscardChangesDialog.tsx
@@ -26,10 +26,10 @@ export const ConfirmDiscardChangesDialog: React.FC<
         <Typography>{t('editModeDialog.discardChanges.body')}</Typography>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel} variant="text">
+        <Button onClick={onCancel} variant="outlined" color="secondary">
           {t('editModeDialog.discardChanges.continueEditing')}
         </Button>
-        <Button onClick={onConfirm} color="error" variant="contained">
+        <Button onClick={onConfirm} variant="contained">
           {t('editModeDialog.discardChanges.discard')}
         </Button>
       </DialogActions>

--- a/common/src/components/Event/EventFormFields.tsx
+++ b/common/src/components/Event/EventFormFields.tsx
@@ -66,7 +66,8 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       onEndChange,
       onAllDayChange,
       onCalendarChange,
-      onValidationChange
+      onValidationChange,
+      onDirtyChange
     } = props
 
     const { t } = useI18n()
@@ -89,6 +90,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
 
     const {
       formValues,
+      isDirty,
       setTitle,
       setDescription,
       setLocation,
@@ -127,6 +129,11 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       },
       [onValidationChange]
     )
+
+    useEffect(() => {
+      onDirtyChange?.(isDirty)
+    }, [isDirty, onDirtyChange])
+
     const selectedCalendar = calList?.[formValues.calendarid]
     const isTeamCalendar = Boolean(selectedCalendar?.owner?.teamCalendar)
 

--- a/common/src/components/Event/EventFormFields.tsx
+++ b/common/src/components/Event/EventFormFields.tsx
@@ -3,8 +3,10 @@ import AttendeeSelector from '@common/components/Attendees/AttendeeSearch'
 import { useEventOrganizer } from '@common/features/Events/useEventOrganizer'
 import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
-import { saveEventFormDataToTemp } from '@common/utils/eventFormTempStorage'
-import { isSafeHttpUrl } from '@common/utils/isSafeUrl'
+import {
+  EventFormContext,
+  saveEventFormDataToTemp
+} from '@common/utils/eventFormTempStorage'
 import {
   browserDefaultTimeZone,
   getTimezoneOffset,
@@ -22,7 +24,6 @@ import React, {
   useState
 } from 'react'
 import { useI18n } from 'twake-i18n'
-import { userOrganiser } from '@common/features/User/userDataTypes'
 import { AddDescButton } from './AddDescButton'
 import { EventFormFieldsExpanded } from './components/EventFormFieldsExpanded'
 import { FieldWithLabel } from './components/FieldWithLabel'
@@ -31,21 +32,82 @@ import {
   EventFormHandle,
   EventFormValues
 } from './EventFormFields.types'
-import { AttachmentField } from './fields/AttachmentField'
 import { CalendarSelectField } from './fields/CalendarSelectField'
 import { EventDateTimeField } from './fields/EventDateTimeField'
 import LocationField from './fields/LocationField'
 import { TitleField } from './fields/TitleField'
 import { VideoConferenceField } from './fields/VideoConferenceField'
-import { TdriveButton } from '@common/features/Tdrive/components/TdriveButton'
-import { useIsTdrivePickerAvailable } from '@common/features/Tdrive/hooks/useIsTdrivePickerAvailable'
-import { TdriveFile } from '@common/features/Tdrive/types'
-import { Attachment } from '@common/types/Attachment'
-import { useEventFormValues } from './hooks/useEventFormValues'
 import { validateEventFormValues } from './utils/formValidation'
+import { userOrganiser } from '@common/features/User/userDataTypes'
+import { EventFormAttachments } from './fields/EventFormAttachments'
+import { useEventFormValues } from './hooks/useEventFormValues'
 
 const showInputLabel = (showMore: boolean, label: string): string =>
   showMore ? label : ''
+
+function useEventFormImperativeHandle(
+  ref: React.ForwardedRef<EventFormHandle>,
+  {
+    formValues,
+    organizer,
+    isTeamCalendar,
+    isFormValid,
+    isSpecific,
+    showMore,
+    tempStorageKey,
+    tempStorageContext,
+    onSubmit,
+    onCancel
+  }: {
+    formValues: EventFormValues
+    organizer: userOrganiser
+    isTeamCalendar: boolean
+    isFormValid: boolean
+    isSpecific: boolean
+    showMore: boolean
+    tempStorageKey: 'create' | 'update'
+    tempStorageContext?: EventFormContext
+    onSubmit: (
+      values: EventFormValues,
+      organizer?: userOrganiser
+    ) => Promise<void>
+    onCancel: () => void
+  }
+): void {
+  const organizerRef = useRef(organizer)
+  useEffect(() => {
+    organizerRef.current = isTeamCalendar
+      ? formValues.organizer || organizer
+      : organizer
+  }, [isTeamCalendar, organizer, formValues.organizer])
+
+  const latestValuesRef = useRef(formValues)
+  useEffect(() => {
+    latestValuesRef.current = {
+      ...formValues,
+      organizer: formValues.organizer || organizer
+    }
+  }, [formValues, organizer])
+
+  useImperativeHandle(ref, () => ({
+    submit: async (): Promise<void> => {
+      if (!isFormValid && !isSpecific) return
+
+      const values = { ...latestValuesRef.current }
+      saveEventFormDataToTemp(tempStorageKey, {
+        ...values,
+        resources: values.selectedResources,
+        ...tempStorageContext,
+        fromError: false
+      })
+      await onSubmit(values, organizerRef.current)
+    },
+    cancel: (): void => onCancel(),
+    getValues: (): EventFormValues => ({ ...latestValuesRef.current }),
+    isValid: (): boolean =>
+      validateEventFormValues(latestValuesRef.current, showMore)
+  }))
+}
 
 const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
   (props, ref) => {
@@ -111,6 +173,7 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       setShowRepeat,
       setHasEndDateChanged,
       setAttachments,
+      setOrganizer,
       handleAllDayChange
     } = useEventFormValues({
       initialValues,
@@ -119,8 +182,14 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       tempStorageContext,
       onStartChange,
       onEndChange,
-      onAllDayChange
+      onAllDayChange,
+      userOrganizer,
+      eventOrganizer: event?.organizer
     })
+
+    useEffect(() => {
+      onDirtyChange?.(isDirty)
+    }, [isDirty, onDirtyChange])
 
     const handleValidationChange = useCallback(
       (valid: boolean) => {
@@ -129,10 +198,6 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       },
       [onValidationChange]
     )
-
-    useEffect(() => {
-      onDirtyChange?.(isDirty)
-    }, [isDirty, onDirtyChange])
 
     const selectedCalendar = calList?.[formValues.calendarid]
     const isTeamCalendar = Boolean(selectedCalendar?.owner?.teamCalendar)
@@ -144,102 +209,31 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
       userOrganizer
     })
 
-    const eventOrganizer = event?.organizer
-
-    const initialOrganizer = useMemo(() => {
-      if (eventOrganizer) {
-        return new userOrganiser({
-          cal_address: eventOrganizer.cal_address,
-          cn: eventOrganizer.cn
-        })
-      }
-      return userOrganizer
-    }, [eventOrganizer, userOrganizer])
-
-    const [selectedOrganizer, setSelectedOrganizer] = useState(initialOrganizer)
-    const [prevCalendarId, setPrevCalendarId] = useState(formValues.calendarid)
-    const [prevUserOrganizer, setPrevUserOrganizer] = useState(userOrganizer)
-
     useEffect(() => {
-      const initOrganizerData = (): void => {
-        if (prevCalendarId !== formValues.calendarid) {
-          setPrevCalendarId(formValues.calendarid)
-          setSelectedOrganizer(userOrganizer)
-        } else if (prevUserOrganizer !== userOrganizer && !eventOrganizer) {
-          setPrevUserOrganizer(userOrganizer)
-          setSelectedOrganizer(userOrganizer)
-        }
+      if (!formValues.organizer && organizer) {
+        setOrganizer(organizer)
       }
-      initOrganizerData()
-    }, [
-      formValues.calendarid,
-      prevCalendarId,
-      prevUserOrganizer,
-      eventOrganizer,
-      userOrganizer
-    ])
+    }, [formValues.organizer, organizer, setOrganizer])
 
     useEffect(() => {
       onCalendarChange?.(formValues.calendarid)
     }, [formValues.calendarid, onCalendarChange])
 
-    // Keep organizer in a ref so submit() can read it synchronously
-    const organizerRef = useRef(organizer)
-    useEffect(() => {
-      organizerRef.current = isTeamCalendar ? selectedOrganizer : organizer
-    }, [isTeamCalendar, organizer, selectedOrganizer])
-
-    // Use a ref to store the LATEST formValues so the imperative handlers
-    // always have the current state without needing to be re-bound
-    const latestValuesRef = useRef(formValues)
-    useEffect(() => {
-      latestValuesRef.current = formValues
-    }, [formValues])
-
-    useImperativeHandle(ref, () => ({
-      submit: async (): Promise<void> => {
-        if (!isFormValid && !isSpecific) return
-
-        const values = { ...latestValuesRef.current }
-
-        // Save snapshot to temp storage before API call
-        saveEventFormDataToTemp(tempStorageKey, {
-          ...values,
-          resources: values.selectedResources,
-          ...tempStorageContext,
-          fromError: false
-        })
-
-        await onSubmit(values, organizerRef.current)
-      },
-      cancel: (): void => {
-        onCancel()
-      },
-      getValues: (): EventFormValues => ({ ...latestValuesRef.current }),
-      isValid: (): boolean =>
-        validateEventFormValues(latestValuesRef.current, showMore)
-    }))
+    useEventFormImperativeHandle(ref, {
+      formValues,
+      organizer,
+      isTeamCalendar,
+      isFormValid,
+      isSpecific,
+      showMore,
+      tempStorageKey,
+      tempStorageContext,
+      onSubmit,
+      onCancel
+    })
 
     const v = formValues
     const isExpanded = showMore && !isMobile
-
-    const pickerAvailable = useIsTdrivePickerAvailable()
-
-    // AttachmentField silently skips attachments whose URI is not a safe
-    // http(s) URL, so mirror that predicate to avoid an orphan label.
-    const hasVisibleAttachments = v.attachments.some(a => isSafeHttpUrl(a.uri))
-
-    const handleTdriveFilesSelected = useCallback(
-      (files: TdriveFile[]): void => {
-        // Convert Tdrive files to Attachments
-        const attachments = files.map(
-          file =>
-            new Attachment(file.url, file.mimeType ?? undefined, file.name)
-        )
-        setAttachments([...v.attachments, ...attachments])
-      },
-      [v.attachments, setAttachments]
-    )
 
     return (
       <React.Fragment>
@@ -312,26 +306,12 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
           setDescription={setDescription}
         />
 
-        {pickerAvailable ? (
-          <TdriveButton
-            onFilesSelected={handleTdriveFilesSelected}
-            showMore={showMore}
-            attachments={v.attachments}
-            setAttachments={setAttachments}
-          />
-        ) : (
-          hasVisibleAttachments && (
-            <FieldWithLabel
-              label={showInputLabel(showMore, t('event.form.tdriveFiles'))}
-              isExpanded={isExpanded}
-            >
-              <AttachmentField
-                attachments={v.attachments}
-                setAttachments={setAttachments}
-              />
-            </FieldWithLabel>
-          )
-        )}
+        <EventFormAttachments
+          v={v}
+          setAttachments={setAttachments}
+          showMore={showMore}
+          isExpanded={isExpanded}
+        />
 
         <LocationField
           location={v.location}
@@ -363,8 +343,8 @@ const EventFormFields = forwardRef<EventFormHandle, EventFormFieldsProps>(
           selectedCalendar={selectedCalendar}
           isTeamCalendar={isTeamCalendar}
           isDisableOrganizerSelection={typeOfAction === 'solo'}
-          setSelectedOrganizer={setSelectedOrganizer}
-          selectedOrganizer={selectedOrganizer}
+          setSelectedOrganizer={setOrganizer}
+          selectedOrganizer={v.organizer}
         />
       </React.Fragment>
     )

--- a/common/src/components/Event/EventFormFields.types.ts
+++ b/common/src/components/Event/EventFormFields.types.ts
@@ -121,12 +121,16 @@ export interface EventFormFieldsProps {
   // Validation notification for parent (e.g. to disable Save button)
   onValidationChange?: (isValid: boolean) => void
 
+  // Dirty notification for parent (e.g. to enable unsaved-changes guard)
+  onDirtyChange?: (isDirty: boolean) => void
+
   // Callback when calendar selection changes
   onCalendarChange?: (newCalendarId: string) => void
 }
 
 export interface UseEventFormValuesReturn {
   formValues: EventFormValues
+  isDirty: boolean
   setFormValues: React.Dispatch<React.SetStateAction<EventFormValues>>
   setTitle: (v: string) => void
   setDescription: (v: string) => void

--- a/common/src/components/Event/EventFormFields.types.ts
+++ b/common/src/components/Event/EventFormFields.types.ts
@@ -34,6 +34,7 @@ export interface EventFormValues {
   showDescription: boolean
   showRepeat: boolean
   hasEndDateChanged: boolean
+  organizer?: userOrganiser
 }
 
 export const DEFAULT_FORM_VALUES: EventFormValues = {
@@ -56,7 +57,8 @@ export const DEFAULT_FORM_VALUES: EventFormValues = {
   attachments: [],
   showDescription: false,
   showRepeat: false,
-  hasEndDateChanged: false
+  hasEndDateChanged: false,
+  organizer: undefined
 }
 
 // ---------------------------------------------------------------------------
@@ -123,9 +125,6 @@ export interface EventFormFieldsProps {
 
   // Dirty notification for parent (e.g. to enable unsaved-changes guard)
   onDirtyChange?: (isDirty: boolean) => void
-
-  // Callback when calendar selection changes
-  onCalendarChange?: (newCalendarId: string) => void
 }
 
 export interface UseEventFormValuesReturn {
@@ -152,6 +151,7 @@ export interface UseEventFormValuesReturn {
   setShowRepeat: (v: boolean) => void
   setHasEndDateChanged: (v: boolean) => void
   setAttachments: (v: EventFormValues['attachments']) => void
+  setOrganizer: (v: userOrganiser | undefined) => void
   handleAllDayChange: (
     newAllDay: boolean,
     newStart: string,
@@ -171,4 +171,6 @@ export interface UseEventFormValuesParams {
     newStart: string,
     newEnd: string
   ) => void
+  userOrganizer?: userOrganiser
+  eventOrganizer?: CalendarEvent['organizer']
 }

--- a/common/src/components/Event/fields/EventFormAttachments.tsx
+++ b/common/src/components/Event/fields/EventFormAttachments.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback } from 'react'
+import { useI18n } from 'twake-i18n'
+import { TdriveButton } from '@common/features/Tdrive/components/TdriveButton'
+import { useIsTdrivePickerAvailable } from '@common/features/Tdrive/hooks/useIsTdrivePickerAvailable'
+import { TdriveFile } from '@common/features/Tdrive/types'
+import { Attachment } from '@common/types/Attachment'
+import { isSafeHttpUrl } from '@common/utils/isSafeUrl'
+import { EventFormValues } from '../EventFormFields.types'
+import { AttachmentField } from './AttachmentField'
+import { FieldWithLabel } from '../components/FieldWithLabel'
+
+const showInputLabel = (showMore: boolean, label: string): string =>
+  showMore ? label : ''
+
+export const EventFormAttachments: React.FC<{
+  v: EventFormValues
+  setAttachments: (v: Attachment[]) => void
+  showMore: boolean
+  isExpanded: boolean
+}> = ({ v, setAttachments, showMore, isExpanded }) => {
+  const { t } = useI18n()
+  const pickerAvailable = useIsTdrivePickerAvailable()
+  const hasVisibleAttachments = v.attachments.some(a => isSafeHttpUrl(a.uri))
+
+  const handleTdriveFilesSelected = useCallback(
+    (files: TdriveFile[]): void => {
+      const attachments = files.map(
+        file => new Attachment(file.url, file.mimeType ?? undefined, file.name)
+      )
+      setAttachments([...v.attachments, ...attachments])
+    },
+    [v.attachments, setAttachments]
+  )
+
+  if (pickerAvailable) {
+    return (
+      <TdriveButton
+        onFilesSelected={handleTdriveFilesSelected}
+        showMore={showMore}
+        attachments={v.attachments}
+        setAttachments={setAttachments}
+      />
+    )
+  }
+
+  if (hasVisibleAttachments) {
+    return (
+      <FieldWithLabel
+        label={showInputLabel(showMore, t('event.form.tdriveFiles'))}
+        isExpanded={isExpanded}
+      >
+        <AttachmentField
+          attachments={v.attachments}
+          setAttachments={setAttachments}
+        />
+      </FieldWithLabel>
+    )
+  }
+
+  return null
+}

--- a/common/src/components/Event/hooks/useEventFormValues.ts
+++ b/common/src/components/Event/hooks/useEventFormValues.ts
@@ -14,6 +14,8 @@ import {
 } from '@common/utils/eventFormTempStorage'
 import { isEventFormDirty } from '@common/utils/isEventFormDirty'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { userOrganiser } from '@common/features/User/userDataTypes'
+import { CalendarEvent } from '@common/types/EventsTypes'
 
 function isTempDataValidForContext(
   tempData: EventFormTempData | null,
@@ -106,6 +108,7 @@ function useEventFormSetters(
   setTitle: (v: string) => void
   setDescription: (v: string) => void
   setAttachments: (v: Attachment[]) => void
+  setOrganizer: (v: userOrganiser | undefined) => void
   setLocation: (v: string) => void
   setStart: (v: string) => void
   setEnd: (v: string) => void
@@ -196,6 +199,10 @@ function useEventFormSetters(
     (v: EventFormValues['attachments']) => set('attachments', v),
     [set]
   )
+  const setOrganizer = useCallback(
+    (v: userOrganiser | undefined) => set('organizer', v),
+    [set]
+  )
 
   const handleAllDayChange = useCallback(
     (newAllDay: boolean, newStart: string, newEnd: string) => {
@@ -231,8 +238,54 @@ function useEventFormSetters(
     setShowRepeat,
     setHasEndDateChanged,
     setAttachments,
+    setOrganizer,
     handleAllDayChange
   }
+}
+
+function useInitialOrganizer(
+  userOrganizer: userOrganiser | undefined,
+  eventOrganizer: CalendarEvent['organizer'] | undefined
+): userOrganiser | undefined {
+  return useMemo(() => {
+    if (eventOrganizer) {
+      return new userOrganiser({
+        cal_address: eventOrganizer.cal_address,
+        cn: eventOrganizer.cn
+      })
+    }
+    return userOrganizer
+  }, [eventOrganizer, userOrganizer])
+}
+
+function useEventFormOrganizerSideEffects(
+  calendarid: string,
+  userOrganizer: userOrganiser | undefined,
+  eventOrganizer: CalendarEvent['organizer'] | undefined,
+  setFormValues: React.Dispatch<React.SetStateAction<EventFormValues>>
+): void {
+  const [prevCalendarId, setPrevCalendarId] = useState(calendarid)
+  const [prevUserOrganizer, setPrevUserOrganizer] = useState(userOrganizer)
+
+  useEffect(() => {
+    const initOrganizer = (): void => {
+      if (prevCalendarId !== calendarid) {
+        setPrevCalendarId(calendarid)
+        setFormValues(prev => ({ ...prev, organizer: undefined }))
+      } else if (prevUserOrganizer !== userOrganizer && !eventOrganizer) {
+        setPrevUserOrganizer(userOrganizer)
+        setFormValues(prev => ({ ...prev, organizer: undefined }))
+      }
+    }
+    initOrganizer()
+  }, [
+    calendarid,
+    prevCalendarId,
+    prevUserOrganizer,
+    eventOrganizer,
+    userOrganizer,
+    setFormValues
+  ])
 }
 
 export function useEventFormValues({
@@ -242,18 +295,34 @@ export function useEventFormValues({
   tempStorageContext,
   onStartChange,
   onEndChange,
-  onAllDayChange
+  onAllDayChange,
+  userOrganizer,
+  eventOrganizer
 }: UseEventFormValuesParams): UseEventFormValuesReturn {
+  const initialOrganizer = useInitialOrganizer(userOrganizer, eventOrganizer)
+
+  const initialValuesWithOrganizer = useMemo(
+    () => ({ ...initialValues, organizer: initialOrganizer }),
+    [initialValues, initialOrganizer]
+  )
+
   const [formValues, setFormValues] = useState<EventFormValues>({
     ...DEFAULT_FORM_VALUES,
-    ...initialValues
+    ...initialValuesWithOrganizer
   })
 
   useEventFormSeeding(
     isOpen,
     tempStorageKey,
     tempStorageContext,
-    initialValues,
+    initialValuesWithOrganizer,
+    setFormValues
+  )
+
+  useEventFormOrganizerSideEffects(
+    formValues.calendarid,
+    userOrganizer,
+    eventOrganizer,
     setFormValues
   )
 
@@ -273,8 +342,8 @@ export function useEventFormValues({
   )
 
   const isDirty = useMemo(
-    () => isEventFormDirty(formValues, initialValues),
-    [formValues, initialValues]
+    () => isEventFormDirty(formValues, initialValuesWithOrganizer),
+    [formValues, initialValuesWithOrganizer]
   )
 
   return {

--- a/common/src/components/Event/hooks/useEventFormValues.ts
+++ b/common/src/components/Event/hooks/useEventFormValues.ts
@@ -12,7 +12,8 @@ import {
   restoreEventFormDataFromTemp,
   saveEventFormDataToTemp
 } from '@common/utils/eventFormTempStorage'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { isEventFormDirty } from '@common/utils/isEventFormDirty'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 function isTempDataValidForContext(
   tempData: EventFormTempData | null,
@@ -271,8 +272,14 @@ export function useEventFormValues({
     onAllDayChange
   )
 
+  const isDirty = useMemo(
+    () => isEventFormDirty(formValues, initialValues),
+    [formValues, initialValues]
+  )
+
   return {
     formValues,
+    isDirty,
     setFormValues,
     ...setters
   }

--- a/common/src/features/Events/EventModal.tsx
+++ b/common/src/features/Events/EventModal.tsx
@@ -1,4 +1,5 @@
 import { useAppSelector } from '@common/app/hooks'
+import { ConfirmDiscardChangesDialog } from '@common/components/Dialog/ConfirmDiscardChangesDialog'
 import { ResponsiveDialog } from '@common/components/Dialog'
 import EventFormFields from '@common/components/Event/EventFormFields'
 import type { EventFormHandle } from '@common/components/Event/EventFormFields.types'
@@ -13,6 +14,7 @@ import { useCalendarPreviewSync } from '@common/components/Event/hooks/useCalend
 import { EventActions } from './EventActions'
 import { useBuildInitialValues } from '@common/components/Event/hooks/useBuildInitialValues'
 import { useSubmitCreateEvent } from '@common/features/Events/hooks/useSubmitCreateEvent'
+import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard'
 import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 
 const EventPopover: React.FC<{
@@ -45,7 +47,10 @@ const EventPopover: React.FC<{
   const [selectedCalendarId, setSelectedCalendarId] = useState<
     string | undefined
   >(undefined)
+  const [isFormDirty, setIsFormDirty] = useState(false)
   const formRef = useRef<EventFormHandle>(null)
+
+  const guard = useUnsavedChangesGuard(open && isFormDirty)
 
   const initialValues = useBuildInitialValues({
     event,
@@ -100,12 +105,17 @@ const EventPopover: React.FC<{
     userPersonalCalendars
   })
 
-  const handleClose = useCallback(() => {
+  const performClose = useCallback(() => {
     clearEventFormTempData('create')
+    setIsFormDirty(false)
     onClose(false)
     setShowMore(false)
     setSelectedCalendarId(undefined)
   }, [onClose])
+
+  const handleClose = useCallback(() => {
+    guard.requestClose(performClose)
+  }, [guard, performClose])
 
   const handleCalendarChange = useCallback(
     (newCalendarId: string) => {
@@ -116,46 +126,57 @@ const EventPopover: React.FC<{
   )
 
   return (
-    <ResponsiveDialog
-      open={open}
-      anchorEl={anchorEl}
-      dynamicPositioning={
-        currentView !== CALENDAR_VIEWS.listWeek && anchorEl !== document.body
-      }
-      onClose={handleClose}
-      title={modalTitle}
-      isExpanded={showMore}
-      onExpandToggle={() => setShowMore(s => !s)}
-      draggable={!showMore}
-      actions={
-        <EventActions
-          showExpandedBtn={!showMore}
-          onClose={handleClose}
-          onSave={async () => {
-            await formRef.current?.submit()
-          }}
-          onExpanded={() => setShowMore(s => !s)}
+    <>
+      <ResponsiveDialog
+        open={open}
+        anchorEl={anchorEl}
+        dynamicPositioning={
+          currentView !== CALENDAR_VIEWS.listWeek && anchorEl !== document.body
+        }
+        onClose={handleClose}
+        title={modalTitle}
+        isExpanded={showMore}
+        onExpandToggle={() => setShowMore(s => !s)}
+        draggable={!showMore}
+        actions={
+          <EventActions
+            showExpandedBtn={!showMore}
+            onClose={handleClose}
+            onSave={async () => {
+              await formRef.current?.submit()
+            }}
+            onExpanded={() => setShowMore(s => !s)}
+          />
+        }
+        expandText={t('tooltip.moreEventOptions')}
+      >
+        <EventFormFields
+          ref={formRef}
+          initialValues={initialValues}
+          showMore={showMore}
+          isOpen={open}
+          typeOfAction={undefined}
+          eventId={event?.uid ?? null}
+          userPersonalCalendars={userPersonalCalendars}
+          onSubmit={handleSubmit}
+          onCancel={handleClose}
+          tempStorageKey="create"
+          onCalendarChange={handleCalendarChange}
+          onStartChange={handleStartChange}
+          onEndChange={handleEndChange}
+          onAllDayChange={handleAllDayChange}
+          onDirtyChange={setIsFormDirty}
         />
-      }
-      expandText={t('tooltip.moreEventOptions')}
-    >
-      <EventFormFields
-        ref={formRef}
-        initialValues={initialValues}
-        showMore={showMore}
-        isOpen={open}
-        typeOfAction={undefined}
-        eventId={event?.uid ?? null}
-        userPersonalCalendars={userPersonalCalendars}
-        onSubmit={handleSubmit}
-        onCancel={handleClose}
-        tempStorageKey="create"
-        onCalendarChange={handleCalendarChange}
-        onStartChange={handleStartChange}
-        onEndChange={handleEndChange}
-        onAllDayChange={handleAllDayChange}
+      </ResponsiveDialog>
+      <ConfirmDiscardChangesDialog
+        open={guard.showConfirm}
+        onCancel={guard.cancelClose}
+        onConfirm={() => {
+          performClose()
+          guard.confirmClose()
+        }}
       />
-    </ResponsiveDialog>
+    </>
   )
 }
 

--- a/common/src/features/Events/EventUpdateModal.tsx
+++ b/common/src/features/Events/EventUpdateModal.tsx
@@ -1,14 +1,16 @@
 import { useAppSelector } from '@common/app/hooks'
 import { dialogPaddingStyles } from '@common/theme/dialogPaddingStyles'
+import { ConfirmDiscardChangesDialog } from '@common/components/Dialog/ConfirmDiscardChangesDialog'
 import { ResponsiveDialog } from '@common/components/Dialog'
 import EventFormFields from '@common/components/Event/EventFormFields'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { useI18n } from 'twake-i18n'
 import { EventActions } from './EventActions'
 import { useEventUpdateModal } from './useEventUpdateModal'
 import { useEditableInitialValues } from './hooks/useEditableInitialValues'
+import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard'
 import { CALENDAR_VIEWS } from '@common/components/Calendar/utils/constants'
 
 export interface EventUpdateModalProps {
@@ -37,7 +39,7 @@ const EventUpdateModalInternal: React.FC<
     formRef,
     effectiveEvent,
     initialValues,
-    handleClose,
+    handleClose: performClose,
     handleSubmit,
     handleExpandToggle,
     handleSave,
@@ -45,6 +47,15 @@ const EventUpdateModalInternal: React.FC<
   } = useEventUpdateModal(props)
 
   const editableInitialValues = useEditableInitialValues(initialValues)
+
+  const [isFormDirty, setIsFormDirty] = useState(false)
+  const guard = useUnsavedChangesGuard(open && isFormDirty)
+  const handleClose = useCallback(() => {
+    guard.requestClose(() => {
+      setIsFormDirty(false)
+      performClose()
+    })
+  }, [guard, performClose])
 
   const actions = (
     <EventActions
@@ -56,36 +67,48 @@ const EventUpdateModalInternal: React.FC<
     />
   )
   return (
-    <ResponsiveDialog
-      open={open}
-      onClose={handleClose}
-      title={t('event.updateEvent')}
-      isExpanded={showMore}
-      onExpandToggle={handleExpandToggle}
-      draggable={!showMore}
-      anchorEl={props.anchorEl}
-      dynamicPositioning={currentView !== CALENDAR_VIEWS.listWeek}
-      actions={actions}
-      sx={dialogPaddingStyles(isMobile)}
-      expandText={t('tooltip.moreEventOptions')}
-    >
-      <EventFormFields
-        key={effectiveEvent?.uid || 'no-event'}
-        ref={formRef}
-        initialValues={editableInitialValues}
-        showMore={showMore}
-        isOpen={open}
-        isSpecific={false}
-        typeOfAction={typeOfAction}
-        eventId={event.uid}
-        event={event}
-        userPersonalCalendars={userPersonalCalendars}
-        onSubmit={handleSubmit}
-        onCancel={handleClose}
-        tempStorageKey="update"
-        tempStorageContext={tempContext}
+    <>
+      <ResponsiveDialog
+        open={open}
+        onClose={handleClose}
+        title={t('event.updateEvent')}
+        isExpanded={showMore}
+        onExpandToggle={handleExpandToggle}
+        draggable={!showMore}
+        anchorEl={props.anchorEl}
+        dynamicPositioning={currentView !== CALENDAR_VIEWS.listWeek}
+        actions={actions}
+        sx={dialogPaddingStyles(isMobile)}
+        expandText={t('tooltip.moreEventOptions')}
+      >
+        <EventFormFields
+          key={effectiveEvent?.uid || 'no-event'}
+          ref={formRef}
+          initialValues={editableInitialValues}
+          showMore={showMore}
+          isOpen={open}
+          isSpecific={false}
+          typeOfAction={typeOfAction}
+          eventId={event.uid}
+          event={event}
+          userPersonalCalendars={userPersonalCalendars}
+          onSubmit={handleSubmit}
+          onCancel={handleClose}
+          tempStorageKey="update"
+          tempStorageContext={tempContext}
+          onDirtyChange={setIsFormDirty}
+        />
+      </ResponsiveDialog>
+      <ConfirmDiscardChangesDialog
+        open={guard.showConfirm}
+        onCancel={guard.cancelClose}
+        onConfirm={() => {
+          setIsFormDirty(false)
+          performClose()
+          guard.confirmClose()
+        }}
       />
-    </ResponsiveDialog>
+    </>
   )
 }
 

--- a/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
+++ b/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  useLocation,
+  useNavigate,
+  type NavigateFunction
+} from 'react-router-dom'
 
 export interface UseUnsavedChangesGuardResult {
   showConfirm: boolean
@@ -13,44 +17,25 @@ export interface UseUnsavedChangesGuardResult {
 // router and throws otherwise, so we implement blocking manually with
 // useLocation + a navigate-back trap and let `beforeunload` handle browser
 // closures / refresh.
-export function useUnsavedChangesGuard(
-  isEnabled: boolean
-): UseUnsavedChangesGuardResult {
-  const [pendingClose, setPendingClose] = useState<(() => void) | null>(null)
-  const [blockedPath, setBlockedPath] = useState<string | null>(null)
 
-  const location = useLocation()
-  const navigate = useNavigate()
-
-  const anchorPathRef = useRef<string | null>(null)
-  const bypassRef = useRef(false)
-
+function useAnchorPath(
+  isEnabled: boolean,
+  currentPath: string
+): React.MutableRefObject<string | null> {
+  const anchorRef = useRef<string | null>(null)
   useEffect(() => {
-    if (isEnabled && anchorPathRef.current === null) {
-      anchorPathRef.current = location.pathname
-    }
     if (!isEnabled) {
-      anchorPathRef.current = null
-    }
-  }, [isEnabled, location.pathname])
-
-  useEffect(() => {
-    if (!isEnabled) return
-    if (bypassRef.current) {
-      bypassRef.current = false
+      anchorRef.current = null
       return
     }
-    const anchor = anchorPathRef.current
-    if (anchor && location.pathname !== anchor && blockedPath === null) {
-      const attempted = location.pathname
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setBlockedPath(attempted)
-      navigate(anchor, { replace: true })
+    if (anchorRef.current === null) {
+      anchorRef.current = currentPath
     }
-  }, [isEnabled, location.pathname, blockedPath, navigate])
+  }, [isEnabled, currentPath])
+  return anchorRef
+}
 
-  const showConfirm = blockedPath !== null || pendingClose !== null
-
+function useBeforeUnloadWarning(isEnabled: boolean): void {
   useEffect(() => {
     if (!isEnabled) return
     const handler = (e: BeforeUnloadEvent): string => {
@@ -61,25 +46,105 @@ export function useUnsavedChangesGuard(
     window.addEventListener('beforeunload', handler)
     return (): void => window.removeEventListener('beforeunload', handler)
   }, [isEnabled])
+}
+
+function shouldTrapUrlChange(
+  isEnabled: boolean,
+  anchor: string | null,
+  currentPath: string,
+  blockedPath: string | null
+): boolean {
+  if (!isEnabled) return false
+  if (anchor === null || blockedPath !== null) return false
+  return anchor !== currentPath
+}
+
+function useUrlChangeTrap(
+  isEnabled: boolean,
+  anchorRef: React.MutableRefObject<string | null>,
+  currentPath: string,
+  blockedPath: string | null,
+  bypassRef: React.MutableRefObject<boolean>,
+  navigate: NavigateFunction,
+  onTrap: (attemptedPath: string) => void
+): void {
+  useEffect(() => {
+    if (bypassRef.current) {
+      bypassRef.current = false
+      return
+    }
+    const anchor = anchorRef.current
+    if (!shouldTrapUrlChange(isEnabled, anchor, currentPath, blockedPath)) {
+      return
+    }
+    onTrap(currentPath)
+    if (anchor !== null) navigate(anchor, { replace: true })
+  }, [
+    isEnabled,
+    anchorRef,
+    currentPath,
+    blockedPath,
+    bypassRef,
+    navigate,
+    onTrap
+  ])
+}
+
+export function useUnsavedChangesGuard(
+  isEnabled: boolean
+): UseUnsavedChangesGuardResult {
+  const [pendingClose, setPendingClose] = useState<(() => void) | null>(null)
+  const [blockedPath, setBlockedPath] = useState<string | null>(null)
+
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const anchorPathRef = useAnchorPath(isEnabled, location.pathname)
+  const bypassRef = useRef(false)
+
+  const trapAttempted = useCallback((attempted: string): void => {
+    setBlockedPath(attempted)
+  }, [])
+
+  useUrlChangeTrap(
+    isEnabled,
+    anchorPathRef,
+    location.pathname,
+    blockedPath,
+    bypassRef,
+    navigate,
+    trapAttempted
+  )
+
+  useBeforeUnloadWarning(isEnabled)
+
+  const showConfirm = blockedPath !== null || pendingClose !== null
 
   const cancelClose = useCallback((): void => {
     setPendingClose(null)
     setBlockedPath(null)
   }, [])
 
+  const confirmNavigation = useCallback(
+    (target: string): void => {
+      bypassRef.current = true
+      anchorPathRef.current = null
+      navigate(target)
+    },
+    [anchorPathRef, navigate]
+  )
+
   const confirmClose = useCallback((): void => {
     const pending = pendingClose
     const target = blockedPath
     setPendingClose(null)
     setBlockedPath(null)
-    if (target) {
-      bypassRef.current = true
-      anchorPathRef.current = null
-      navigate(target)
-    } else if (pending) {
-      pending()
+    if (target !== null) {
+      confirmNavigation(target)
+      return
     }
-  }, [pendingClose, blockedPath, navigate])
+    pending?.()
+  }, [pendingClose, blockedPath, confirmNavigation])
 
   const requestClose = useCallback(
     (proceed: () => void): void => {

--- a/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
+++ b/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useBlocker } from 'react-router-dom'
+
+export interface UseUnsavedChangesGuardResult {
+  showConfirm: boolean
+  cancelClose: () => void
+  confirmClose: () => void
+  requestClose: (proceed: () => void) => void
+}
+
+export function useUnsavedChangesGuard(
+  isEnabled: boolean
+): UseUnsavedChangesGuardResult {
+  const [pendingClose, setPendingClose] = useState<(() => void) | null>(null)
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      isEnabled && currentLocation.pathname !== nextLocation.pathname
+  )
+
+  const showConfirm = blocker.state === 'blocked' || pendingClose !== null
+
+  useEffect(() => {
+    if (!isEnabled) return
+    const handler = (e: BeforeUnloadEvent): string => {
+      e.preventDefault()
+      e.returnValue = ''
+      return ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return (): void => window.removeEventListener('beforeunload', handler)
+  }, [isEnabled])
+
+  const cancelClose = useCallback((): void => {
+    setPendingClose(null)
+    if (blocker.state === 'blocked') blocker.reset()
+  }, [blocker])
+
+  const confirmClose = useCallback((): void => {
+    const pending = pendingClose
+    setPendingClose(null)
+    if (blocker.state === 'blocked') {
+      blocker.proceed()
+    } else if (pending) {
+      pending()
+    }
+  }, [blocker, pendingClose])
+
+  const requestClose = useCallback(
+    (proceed: () => void): void => {
+      if (!isEnabled) {
+        proceed()
+        return
+      }
+      setPendingClose(() => proceed)
+    },
+    [isEnabled]
+  )
+
+  return { showConfirm, cancelClose, confirmClose, requestClose }
+}
+
+export default useUnsavedChangesGuard

--- a/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
+++ b/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { useBlocker } from 'react-router-dom'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 export interface UseUnsavedChangesGuardResult {
   showConfirm: boolean
@@ -8,17 +8,48 @@ export interface UseUnsavedChangesGuardResult {
   requestClose: (proceed: () => void) => void
 }
 
+// This app mounts <HistoryRouter> from redux-first-history/rr6, which is a
+// non-data router. react-router-dom's stable `useBlocker` requires a data
+// router and throws otherwise, so we implement blocking manually with
+// useLocation + a navigate-back trap and let `beforeunload` handle browser
+// closures / refresh.
 export function useUnsavedChangesGuard(
   isEnabled: boolean
 ): UseUnsavedChangesGuardResult {
   const [pendingClose, setPendingClose] = useState<(() => void) | null>(null)
+  const [blockedPath, setBlockedPath] = useState<string | null>(null)
 
-  const blocker = useBlocker(
-    ({ currentLocation, nextLocation }) =>
-      isEnabled && currentLocation.pathname !== nextLocation.pathname
-  )
+  const location = useLocation()
+  const navigate = useNavigate()
 
-  const showConfirm = blocker.state === 'blocked' || pendingClose !== null
+  const anchorPathRef = useRef<string | null>(null)
+  const bypassRef = useRef(false)
+
+  useEffect(() => {
+    if (isEnabled && anchorPathRef.current === null) {
+      anchorPathRef.current = location.pathname
+    }
+    if (!isEnabled) {
+      anchorPathRef.current = null
+    }
+  }, [isEnabled, location.pathname])
+
+  useEffect(() => {
+    if (!isEnabled) return
+    if (bypassRef.current) {
+      bypassRef.current = false
+      return
+    }
+    const anchor = anchorPathRef.current
+    if (anchor && location.pathname !== anchor && blockedPath === null) {
+      const attempted = location.pathname
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setBlockedPath(attempted)
+      navigate(anchor, { replace: true })
+    }
+  }, [isEnabled, location.pathname, blockedPath, navigate])
+
+  const showConfirm = blockedPath !== null || pendingClose !== null
 
   useEffect(() => {
     if (!isEnabled) return
@@ -33,18 +64,22 @@ export function useUnsavedChangesGuard(
 
   const cancelClose = useCallback((): void => {
     setPendingClose(null)
-    if (blocker.state === 'blocked') blocker.reset()
-  }, [blocker])
+    setBlockedPath(null)
+  }, [])
 
   const confirmClose = useCallback((): void => {
     const pending = pendingClose
+    const target = blockedPath
     setPendingClose(null)
-    if (blocker.state === 'blocked') {
-      blocker.proceed()
+    setBlockedPath(null)
+    if (target) {
+      bypassRef.current = true
+      anchorPathRef.current = null
+      navigate(target)
     } else if (pending) {
       pending()
     }
-  }, [blocker, pendingClose])
+  }, [pendingClose, blockedPath, navigate])
 
   const requestClose = useCallback(
     (proceed: () => void): void => {

--- a/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
+++ b/common/src/features/Events/hooks/useUnsavedChangesGuard.ts
@@ -59,15 +59,26 @@ function shouldTrapUrlChange(
   return anchor !== currentPath
 }
 
-function useUrlChangeTrap(
-  isEnabled: boolean,
-  anchorRef: React.MutableRefObject<string | null>,
-  currentPath: string,
-  blockedPath: string | null,
-  bypassRef: React.MutableRefObject<boolean>,
-  navigate: NavigateFunction,
+interface UrlChangeTrapOptions {
+  isEnabled: boolean
+  anchorRef: React.MutableRefObject<string | null>
+  currentPath: string
+  blockedPath: string | null
+  bypassRef: React.MutableRefObject<boolean>
+  navigate: NavigateFunction
   onTrap: (attemptedPath: string) => void
-): void {
+}
+
+function useUrlChangeTrap(options: UrlChangeTrapOptions): void {
+  const {
+    isEnabled,
+    anchorRef,
+    currentPath,
+    blockedPath,
+    bypassRef,
+    navigate,
+    onTrap
+  } = options
   useEffect(() => {
     if (bypassRef.current) {
       bypassRef.current = false
@@ -106,15 +117,15 @@ export function useUnsavedChangesGuard(
     setBlockedPath(attempted)
   }, [])
 
-  useUrlChangeTrap(
+  useUrlChangeTrap({
     isEnabled,
-    anchorPathRef,
-    location.pathname,
+    anchorRef: anchorPathRef,
+    currentPath: location.pathname,
     blockedPath,
     bypassRef,
     navigate,
-    trapAttempted
-  )
+    onTrap: trapAttempted
+  })
 
   useBeforeUnloadWarning(isEnabled)
 

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -270,7 +270,13 @@
     "updateParticipationStatus": "Update the participation status",
     "deleteRecurrentEvent": "Delete the recurrent event",
     "thisEvent": "This event",
-    "allEvents": "All the events"
+    "allEvents": "All the events",
+    "discardChanges": {
+      "title": "Discard changes?",
+      "body": "Your changes have not been saved. Do you really want to discard them?",
+      "continueEditing": "Continue editing",
+      "discard": "Discard"
+    }
   },
   "eventDuplication": {
     "duplicateEvent": "Duplicate event"

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -270,7 +270,13 @@
     "updateParticipationStatus": "Mettre à jour le statut de participation",
     "thisEvent": "Cet événement",
     "allEvents": "Tous les événements",
-    "deleteRecurrentEvent": "Supprimer l'événement récurrent"
+    "deleteRecurrentEvent": "Supprimer l'événement récurrent",
+    "discardChanges": {
+      "title": "Abandonner les modifications ?",
+      "body": "Vos modifications n'ont pas été enregistrées. Souhaitez-vous vraiment les abandonner ?",
+      "continueEditing": "Continuer l'édition",
+      "discard": "Abandonner"
+    }
   },
   "eventDuplication": {
     "duplicateEvent": "Dupliquer l'événement"

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -270,7 +270,13 @@
     "updateParticipationStatus": "Обновить статус участия",
     "thisEvent": "Это событие",
     "allEvents": "Все события",
-    "deleteRecurrentEvent": "Удалить повторяющееся событие"
+    "deleteRecurrentEvent": "Удалить повторяющееся событие",
+    "discardChanges": {
+      "title": "Отменить изменения?",
+      "body": "Ваши изменения не были сохранены. Вы действительно хотите их отменить?",
+      "continueEditing": "Продолжить редактирование",
+      "discard": "Отменить"
+    }
   },
   "eventDuplication": {
     "duplicateEvent": "Дублировать"

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -270,7 +270,13 @@
     "updateParticipationStatus": "Cập nhật trạng thái tham gia",
     "thisEvent": "Sự kiện này",
     "allEvents": "Tất cả sự kiện",
-    "deleteRecurrentEvent": "Xóa sự kiện lặp lại"
+    "deleteRecurrentEvent": "Xóa sự kiện lặp lại",
+    "discardChanges": {
+      "title": "Hủy các thay đổi?",
+      "body": "Các thay đổi của bạn chưa được lưu. Bạn có thực sự muốn hủy chúng không?",
+      "continueEditing": "Tiếp tục chỉnh sửa",
+      "discard": "Hủy"
+    }
   },
   "eventDuplication": {
     "duplicateEvent": "Nhân bản sự kiện"

--- a/common/src/utils/isEventFormDirty.ts
+++ b/common/src/utils/isEventFormDirty.ts
@@ -13,47 +13,47 @@ const attendeesEqual = (a: userAttendee[], b: userAttendee[]): boolean => {
   return b.every(x => keysA.has(attendeeKey(x)))
 }
 
-const alarmsKey = (v: Valarms | undefined): string => {
-  if (!v) return '[]'
+const safeStringify = (v: unknown): string => {
   try {
-    return JSON.stringify(v.getAlarms?.() ?? [])
-  } catch {
-    return JSON.stringify(v)
-  }
-}
-
-const repetitionKey = (r: unknown): string => {
-  try {
-    return JSON.stringify(r ?? {})
+    return JSON.stringify(v ?? null)
   } catch {
     return ''
   }
 }
 
+const alarmsKey = (v: Valarms | undefined): string => {
+  if (!v) return '[]'
+  const alarms = v.getAlarms?.() ?? v
+  return safeStringify(alarms)
+}
+
+type Check = (
+  current: EventFormValues,
+  initial: Partial<EventFormValues>
+) => boolean
+
+const CHECKS: Check[] = [
+  (c, i): boolean => trim(c.title) !== trim(i.title),
+  (c, i): boolean => trim(c.description) !== trim(i.description),
+  (c, i): boolean => trim(c.location) !== trim(i.location),
+  (c, i): boolean => c.start !== (i.start ?? ''),
+  (c, i): boolean => c.end !== (i.end ?? ''),
+  (c, i): boolean => c.allday !== (i.allday ?? false),
+  (c, i): boolean => c.busy !== (i.busy ?? 'OPAQUE'),
+  (c, i): boolean => c.eventClass !== (i.eventClass ?? c.eventClass),
+  (c, i): boolean => c.timezone !== (i.timezone ?? ''),
+  (c, i): boolean => c.calendarid !== (i.calendarid ?? ''),
+  (c, i): boolean => c.hasVideoConference !== (i.hasVideoConference ?? false),
+  (c, i): boolean => (c.meetingLink ?? null) !== (i.meetingLink ?? null),
+  (c, i): boolean =>
+    safeStringify(c.repetition) !== safeStringify(i.repetition),
+  (c, i): boolean => !attendeesEqual(c.attendees ?? [], i.attendees ?? []),
+  (c, i): boolean => alarmsKey(c.alarms) !== alarmsKey(i.alarms as Valarms)
+]
+
 export function isEventFormDirty(
   current: EventFormValues,
   initial: Partial<EventFormValues>
 ): boolean {
-  if (trim(current.title) !== trim(initial.title)) return true
-  if (trim(current.description) !== trim(initial.description)) return true
-  if (trim(current.location) !== trim(initial.location)) return true
-  if (current.start !== (initial.start ?? '')) return true
-  if (current.end !== (initial.end ?? '')) return true
-  if (current.allday !== (initial.allday ?? false)) return true
-  if (current.busy !== (initial.busy ?? 'OPAQUE')) return true
-  if (current.eventClass !== (initial.eventClass ?? current.eventClass))
-    return true
-  if (current.timezone !== (initial.timezone ?? '')) return true
-  if (current.calendarid !== (initial.calendarid ?? '')) return true
-  if (current.hasVideoConference !== (initial.hasVideoConference ?? false))
-    return true
-  if ((current.meetingLink ?? null) !== (initial.meetingLink ?? null))
-    return true
-  if (repetitionKey(current.repetition) !== repetitionKey(initial.repetition))
-    return true
-  if (!attendeesEqual(current.attendees ?? [], initial.attendees ?? []))
-    return true
-  if (alarmsKey(current.alarms) !== alarmsKey(initial.alarms as Valarms))
-    return true
-  return false
+  return CHECKS.some(check => check(current, initial))
 }

--- a/common/src/utils/isEventFormDirty.ts
+++ b/common/src/utils/isEventFormDirty.ts
@@ -1,0 +1,59 @@
+import { EventFormValues } from '@common/components/Event/EventFormFields.types'
+import { userAttendee } from '@common/features/User/models/attendee'
+import { Valarms } from '@common/types/Valarms'
+
+const trim = (s: string | undefined): string => (s ?? '').trim()
+
+const attendeeKey = (a: userAttendee): string =>
+  `${a.cal_address}|${a.partstat}|${a.role}|${a.cutype}`
+
+const attendeesEqual = (a: userAttendee[], b: userAttendee[]): boolean => {
+  if (a.length !== b.length) return false
+  const keysA = new Set(a.map(attendeeKey))
+  return b.every(x => keysA.has(attendeeKey(x)))
+}
+
+const alarmsKey = (v: Valarms | undefined): string => {
+  if (!v) return '[]'
+  try {
+    return JSON.stringify(v.getAlarms?.() ?? [])
+  } catch {
+    return JSON.stringify(v)
+  }
+}
+
+const repetitionKey = (r: unknown): string => {
+  try {
+    return JSON.stringify(r ?? {})
+  } catch {
+    return ''
+  }
+}
+
+export function isEventFormDirty(
+  current: EventFormValues,
+  initial: Partial<EventFormValues>
+): boolean {
+  if (trim(current.title) !== trim(initial.title)) return true
+  if (trim(current.description) !== trim(initial.description)) return true
+  if (trim(current.location) !== trim(initial.location)) return true
+  if (current.start !== (initial.start ?? '')) return true
+  if (current.end !== (initial.end ?? '')) return true
+  if (current.allday !== (initial.allday ?? false)) return true
+  if (current.busy !== (initial.busy ?? 'OPAQUE')) return true
+  if (current.eventClass !== (initial.eventClass ?? current.eventClass))
+    return true
+  if (current.timezone !== (initial.timezone ?? '')) return true
+  if (current.calendarid !== (initial.calendarid ?? '')) return true
+  if (current.hasVideoConference !== (initial.hasVideoConference ?? false))
+    return true
+  if ((current.meetingLink ?? null) !== (initial.meetingLink ?? null))
+    return true
+  if (repetitionKey(current.repetition) !== repetitionKey(initial.repetition))
+    return true
+  if (!attendeesEqual(current.attendees ?? [], initial.attendees ?? []))
+    return true
+  if (alarmsKey(current.alarms) !== alarmsKey(initial.alarms as Valarms))
+    return true
+  return false
+}

--- a/common/src/utils/isEventFormDirty.ts
+++ b/common/src/utils/isEventFormDirty.ts
@@ -1,6 +1,8 @@
 import { EventFormValues } from '@common/components/Event/EventFormFields.types'
 import { userAttendee } from '@common/features/User/models/attendee'
 import { Valarms } from '@common/types/Valarms'
+import { Attachment } from '@common/types/Attachment'
+import { Resource } from '@common/components/Attendees/ResourceSearch'
 
 const trim = (s: string | undefined): string => (s ?? '').trim()
 
@@ -11,6 +13,23 @@ const attendeesEqual = (a: userAttendee[], b: userAttendee[]): boolean => {
   if (a.length !== b.length) return false
   const keysA = new Set(a.map(attendeeKey))
   return b.every(x => keysA.has(attendeeKey(x)))
+}
+
+const resourceKey = (r: Resource): string =>
+  r.email ?? r.openpaasId ?? r.displayName
+
+const resourcesEqual = (a: Resource[], b: Resource[]): boolean => {
+  if (a.length !== b.length) return false
+  const keysA = new Set(a.map(resourceKey))
+  return b.every(x => keysA.has(resourceKey(x)))
+}
+
+const attachmentKey = (a: Attachment): string => a.uri
+
+const attachmentsEqual = (a: Attachment[], b: Attachment[]): boolean => {
+  if (a.length !== b.length) return false
+  const keysA = new Set(a.map(attachmentKey))
+  return b.every(x => keysA.has(attachmentKey(x)))
 }
 
 const safeStringify = (v: unknown): string => {
@@ -46,9 +65,14 @@ const CHECKS: Check[] = [
   (c, i): boolean => c.hasVideoConference !== (i.hasVideoConference ?? false),
   (c, i): boolean => (c.meetingLink ?? null) !== (i.meetingLink ?? null),
   (c, i): boolean =>
-    safeStringify(c.repetition) !== safeStringify(i.repetition),
+    safeStringify(c.repetition ?? {}) !== safeStringify(i.repetition ?? {}),
   (c, i): boolean => !attendeesEqual(c.attendees ?? [], i.attendees ?? []),
-  (c, i): boolean => alarmsKey(c.alarms) !== alarmsKey(i.alarms as Valarms)
+  (c, i): boolean => alarmsKey(c.alarms) !== alarmsKey(i.alarms as Valarms),
+  (c, i): boolean => c.organizer?.cal_address !== i.organizer?.cal_address,
+  (c, i): boolean =>
+    !attachmentsEqual(c.attachments ?? [], i.attachments ?? []),
+  (c, i): boolean =>
+    !resourcesEqual(c.selectedResources ?? [], i.selectedResources ?? [])
 ]
 
 export function isEventFormDirty(


### PR DESCRIPTION
resolves #1300

> Draft — needs review of dirty-detection heuristic + UX validation on staging (see Test plan). Feedback welcome before promoting.

## Summary

Prevent silent data loss when a user with a modified-but-unsaved event modal navigates away (sidebar click, Escape, backdrop, browser refresh/close). Show a confirmation dialog with **Continue editing** / **Discard**.

Reported in production: *"J'ai un autre cas où l'écran de création de RDV disparaît si l'on clic sur agenda au moment de la création non terminée."*

## Approach

1. **Dirty tracking** — `common/src/utils/isEventFormDirty.ts` shallow-compares current `EventFormValues` with `initialValues` across title, description, location, start/end, allday, repetition, attendees (set-based), alarms, calendar, busy state, event class, timezone, video conference / meeting link. Exposed as `isDirty` from `useEventFormValues` and propagated to parents via a new `onDirtyChange` prop on `EventFormFields` (mirroring the existing `onValidationChange` pattern).

2. **Navigation guard** — `common/src/features/Events/hooks/useUnsavedChangesGuard.ts` uses `react-router-dom`'s stable `useBlocker` to intercept in-app route changes when `open && isDirty`. Also registers a `beforeunload` listener for browser-level closes (tab close, F5). Exposes `{ showConfirm, cancelClose, confirmClose, requestClose }`.

3. **Confirmation dialog** — `common/src/components/Dialog/ConfirmDiscardChangesDialog.tsx`, a small MUI Dialog with two actions. i18n keys under `editModeDialog.discardChanges` in fr / en / ru / vi.

4. **Wiring** — `EventModal` (create) and `EventUpdateModal` (edit / series edit) each:
    - track `isFormDirty` state fed by `onDirtyChange`
    - route their previous `handleClose` through `guard.requestClose(performClose)` so backdrop / Escape / close button all hit the same prompt
    - render `<ConfirmDiscardChangesDialog>` next to the main dialog

## Close paths covered

| Vector | Mechanism |
|---|---|
| Sidebar click (Agenda etc.), any route change | `useBlocker` → prompt |
| Backdrop click / Escape / close button | `handleClose` → `guard.requestClose` → prompt |
| Browser tab close / F5 / back | `beforeunload` (native prompt) |
| Explicit Save | proceeds normally, `isDirty` resets after submit |

## Files changed

- **New**
  - `common/src/utils/isEventFormDirty.ts`
  - `common/src/components/Dialog/ConfirmDiscardChangesDialog.tsx`
  - `common/src/features/Events/hooks/useUnsavedChangesGuard.ts`
- **Modified**
  - `common/src/components/Event/EventFormFields.tsx` (accept + forward `onDirtyChange`)
  - `common/src/components/Event/EventFormFields.types.ts` (types)
  - `common/src/components/Event/hooks/useEventFormValues.ts` (compute + return `isDirty`)
  - `common/src/features/Events/EventModal.tsx` (guard integration)
  - `common/src/features/Events/EventUpdateModal.tsx` (guard integration)
  - `common/src/locales/{fr,en,ru,vi}.json` (translations for the confirmation dialog)

## Test plan

- [ ] Open create-event modal, type a title, click "Agenda" sidebar → confirmation appears, "Continue editing" cancels navigation, "Discard" navigates away.
- [ ] Same but hitting Escape → confirmation appears.
- [ ] Same but clicking outside (backdrop) → confirmation appears.
- [ ] Same but F5 / close tab → native `beforeunload` prompt appears.
- [ ] Open modal with no modifications → clicking Agenda / Escape / backdrop closes silently (no dirty state, no prompt).
- [ ] Fill form + Save → `isDirty` resets, subsequent close doesn't prompt.
- [ ] Same test matrix for **EventUpdateModal** (edit event + edit series).
- [ ] Cross-check with existing `sessionStorage` draft persistence (`saveEventFormDataToTemp` — should still work; `Discard` calls `clearEventFormTempData` as before).
- [ ] i18n visual check on fr / en; ru and vi translations are best-effort — a native speaker should review.

## Not in scope (potential follow-ups)

- Restoring a persisted draft with a "Resume unsaved event" banner (bonus safety net for crashes). The `restoreEventFormDataFromTemp` machinery already exists but isn't hooked to a visible banner.
- Extending dirty tracking to attachments / selectedResources / showDescription / showRepeat / hasEndDateChanged. Left out because they're UI-state-ish, but easy to add if needed.

## Context

Part of a triage of production feedback (the "Bonjour Benjamin" batch). Sibling PR for the same batch: #1301 (attendee popover in edit form, issue #1299). Related backend issues: linagora/twake-calendar-side-service#1033, #1034.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unsaved-changes protection when creating or editing events.
  * Users are prompted to continue editing or discard changes before closing.
  * Browser navigation and page closure now warn about unsaved event changes.
  * Event organizers are preserved and updated more reliably.
  * Added improved attachment handling in event forms.
  * Added localized discard-changes messaging in English, French, Russian, and Vietnamese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->