### PR TITLE
#1296 adjust responsive UI of booking management modal on mobile

### DIFF
--- a/apps/private/src/features/booking/EditAppointmentModal.tsx
+++ b/apps/private/src/features/booking/EditAppointmentModal.tsx
@@ -174,6 +174,7 @@ export const EditAppointmentModal: React.FC<EditAppointmentModalProps> = ({
       isFormValid={isFormValid}
       onSave={() => void handleSave()}
       saveButtonText={t('actions.save', { defaultValue: 'Save' })}
+      isEdit
     />
   )
 }

--- a/apps/private/src/features/booking/components/AppointmentModalForm.tsx
+++ b/apps/private/src/features/booking/components/AppointmentModalForm.tsx
@@ -1,21 +1,20 @@
-import React, { useState } from 'react'
-import { TextField, Typography, useTheme } from '@linagora/twake-mui'
+import React, { useEffect, useState } from 'react'
+import { Typography } from '@linagora/twake-mui'
 import { ResponsiveDialog } from '@common/components/Dialog'
 import { useI18n } from 'twake-i18n'
 import { TimeSlotSelectField } from './TimeSlotSelectField'
+import { TitleField } from './TitleField'
+import { ColorField } from './ColorField'
 import { AppointmentModalExpandedFields } from './AppointmentModalExpandedFields'
 import { HeaderRightAction } from './HeaderRightAction'
 import { ModalActions } from './ModalActions'
-import { ColorPicker } from '@common/components/Calendar/CalendarColorPicker'
 import type { Calendar } from '@common/types/CalendarTypes'
 import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 import { RegularHoursField } from './RegularHoursField'
 import { DayAvailability } from './RegularHoursField/RegularHoursTypes'
 import { useAppSelector } from '@common/app/hooks'
-import { getAccessiblePair } from '@common/utils/getAccessiblePair'
 import { useFocusTitleOnOpen } from '@common/components/Event/hooks/useAutoFocusTitle'
 import { userAttendee } from '@common/features/User/models/attendee'
-import { FieldWithLabel } from '@common/components/Event/components/FieldWithLabel'
 import { Resource } from '@common/components/Attendees/ResourceSearch'
 import { Valarms } from '@common/types/Valarms'
 import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
@@ -60,6 +59,7 @@ interface AppointmentModalFormProps {
   isFormValid: boolean
   onSave: () => void
   saveButtonText: string
+  isEdit?: boolean
 }
 
 export const AppointmentModalForm: React.FC<
@@ -88,7 +88,6 @@ export const AppointmentModalForm: React.FC<
   } = props
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
-  const theme = useTheme()
 
   const nameInputRef = React.useRef<HTMLInputElement>(null)
 
@@ -106,6 +105,16 @@ export const AppointmentModalForm: React.FC<
   const showExpandedLabel = isExpanded && !isMobile
   const titleLabel = isExpanded ? t('booking.title') : ''
   const participantsLabel = isExpanded ? t('event.form.participants') : ''
+
+  useEffect(() => {
+    const collapseForm = (): void => {
+      if (!open) {
+        setIsExpanded(false)
+      }
+    }
+
+    collapseForm()
+  }, [open])
 
   return (
     <ResponsiveDialog
@@ -128,9 +137,11 @@ export const AppointmentModalForm: React.FC<
           buttonSize={buttonSize}
           onExpandToggle={() => setIsExpanded(s => !s)}
           onSave={onSave}
+          onClose={onClose}
           loading={loading}
           isFormValid={isFormValid}
           saveButtonText={saveButtonText}
+          isEdit={props.isEdit}
         />
       }
     >
@@ -140,19 +151,13 @@ export const AppointmentModalForm: React.FC<
         </Typography>
       )}
 
-      <FieldWithLabel label={titleLabel} isExpanded={showExpandedLabel}>
-        <TextField
-          sx={{ pt: 1 }}
-          size={isMobile ? 'medium' : 'small'}
-          margin="dense"
-          placeholder={t('booking.scheduleName')}
-          type="text"
-          fullWidth
-          value={name}
-          onChange={e => setName(e.target.value)}
-          inputRef={nameInputRef}
-        />
-      </FieldWithLabel>
+      <TitleField
+        titleLabel={titleLabel}
+        showExpandedLabel={showExpandedLabel}
+        name={name}
+        setName={setName}
+        nameInputRef={nameInputRef}
+      />
 
       <TimeSlotSelectField
         duration={duration}
@@ -167,19 +172,11 @@ export const AppointmentModalForm: React.FC<
         isExpanded={isExpanded}
       />
 
-      <FieldWithLabel
-        label={t('booking.color')}
-        isExpanded={showExpandedLabel}
-        sx={{ padding: 0, margin: 0 }}
-      >
-        <ColorPicker
-          selectedColor={{
-            light: color,
-            dark: getAccessiblePair(color, theme)
-          }}
-          onChange={c => setColor(c.light)}
-        />
-      </FieldWithLabel>
+      <ColorField
+        showExpandedLabel={showExpandedLabel}
+        color={color}
+        setColor={setColor}
+      />
 
       <AppointmentModalExpandedFields
         isExpanded={isExpanded}

--- a/apps/private/src/features/booking/components/ColorField.tsx
+++ b/apps/private/src/features/booking/components/ColorField.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { useTheme } from '@linagora/twake-mui'
+import { useI18n } from 'twake-i18n'
+import { FieldWithLabel } from '@common/components/Event/components/FieldWithLabel'
+import { ColorPicker } from '@common/components/Calendar/CalendarColorPicker'
+import { getAccessiblePair } from '@common/utils/getAccessiblePair'
+
+interface ColorFieldProps {
+  showExpandedLabel: boolean
+  color: string
+  setColor: (value: string) => void
+}
+
+export const ColorField: React.FC<ColorFieldProps> = ({
+  showExpandedLabel,
+  color,
+  setColor
+}) => {
+  const { t } = useI18n()
+  const theme = useTheme()
+
+  return (
+    <FieldWithLabel
+      label={t('booking.color')}
+      isExpanded={showExpandedLabel}
+      sx={{ padding: 0, margin: 0 }}
+    >
+      <ColorPicker
+        selectedColor={{
+          light: color,
+          dark: getAccessiblePair(color, theme)
+        }}
+        onChange={c => setColor(c.light)}
+      />
+    </FieldWithLabel>
+  )
+}

--- a/apps/private/src/features/booking/components/ModalActions.tsx
+++ b/apps/private/src/features/booking/components/ModalActions.tsx
@@ -8,17 +8,21 @@ export const ModalActions: React.FC<{
   buttonSize: 'small' | 'medium' | 'large'
   onExpandToggle: () => void
   onSave: () => void
+  onClose: () => void
   loading: boolean
   isFormValid: boolean
   saveButtonText: string
+  isEdit?: boolean
 }> = ({
   isExpanded,
   buttonSize,
   onExpandToggle,
+  onClose,
   onSave,
   loading,
   isFormValid,
-  saveButtonText
+  saveButtonText,
+  isEdit
 }) => {
   const { t } = useI18n()
 
@@ -39,13 +43,20 @@ export const ModalActions: React.FC<{
           {t('common.moreOptions')}
         </Button>
       )}
-      <Button
-        onClick={() => void onSave()}
-        variant="contained"
-        disabled={loading || !isFormValid}
-      >
-        {saveButtonText}
-      </Button>
+      <Box sx={{ display: 'flex', gap: 1, ml: isExpanded ? 'auto' : 0 }}>
+        {(isExpanded || isEdit) && (
+          <Button size={buttonSize} variant="outlined" onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+        )}
+        <Button
+          onClick={() => void onSave()}
+          variant="contained"
+          disabled={loading || !isFormValid}
+        >
+          {saveButtonText}
+        </Button>
+      </Box>
     </Box>
   )
 }

--- a/apps/private/src/features/booking/components/RegularHoursField/RegularHoursRow.tsx
+++ b/apps/private/src/features/booking/components/RegularHoursField/RegularHoursRow.tsx
@@ -76,7 +76,7 @@ const TimeSlotItem: React.FC<TimeSlotItemProps> = ({
           hasError={hasError}
         />
       </Box>
-      <Typography sx={{ mx: 1 }}>-</Typography>
+      <Typography sx={{ mx: isMobile ? 0.5 : 1 }}>-</Typography>
       <Box sx={{ width }}>
         <TimePickerField
           testId={`end-time-${day}-${index}`}

--- a/apps/private/src/features/booking/components/TimeSlotSelectField/MobileTimeSlotSelectField.tsx
+++ b/apps/private/src/features/booking/components/TimeSlotSelectField/MobileTimeSlotSelectField.tsx
@@ -23,7 +23,9 @@ export const MobileTimeSlotSelectField: React.FC<TimeSlotSelectFieldProps> = ({
   }, [duration, t])
 
   return (
-    <MobileSelector displayText={currentLabel}>
+    <MobileSelector
+      displayText={<span style={{ fontSize: 16 }}>{currentLabel}</span>}
+    >
       <List sx={{ overflow: 'auto', flex: 1, pt: 0 }}>
         {TIME_SLOT_OPTIONS.map(({ value, label }) => (
           <ListItem key={value} value={value} disablePadding>

--- a/apps/private/src/features/booking/components/TitleField.tsx
+++ b/apps/private/src/features/booking/components/TitleField.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { TextField } from '@linagora/twake-mui'
+import { useI18n } from 'twake-i18n'
+import { FieldWithLabel } from '@common/components/Event/components/FieldWithLabel'
+import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
+
+interface TitleFieldProps {
+  titleLabel: string
+  showExpandedLabel: boolean
+  name: string
+  setName: (value: string) => void
+  nameInputRef: React.RefObject<HTMLInputElement>
+}
+
+export const TitleField: React.FC<TitleFieldProps> = ({
+  titleLabel,
+  showExpandedLabel,
+  name,
+  setName,
+  nameInputRef
+}) => {
+  const { t } = useI18n()
+  const inputSize = useResponsiveInputSize()
+
+  return (
+    <FieldWithLabel label={titleLabel} isExpanded={showExpandedLabel}>
+      <TextField
+        sx={{ pt: 1 }}
+        size={inputSize}
+        margin="dense"
+        placeholder={t('booking.scheduleName')}
+        type="text"
+        fullWidth
+        value={name}
+        onChange={e => setName(e.target.value)}
+        inputRef={nameInputRef}
+      />
+    </FieldWithLabel>
+  )
+}

--- a/common/src/components/Event/components/EventFormFieldsExpanded.tsx
+++ b/common/src/components/Event/components/EventFormFieldsExpanded.tsx
@@ -12,6 +12,7 @@ import { FieldWithLabel } from './FieldWithLabel'
 import { OrganizerSelectField } from '../fields/OrganizerSelectField'
 import { Calendar } from '@common/types/CalendarTypes'
 import { userOrganiser } from '@common/features/User/userDataTypes'
+import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
 
 interface EventFormFieldsExpandedProps {
   alarms: Valarms
@@ -52,6 +53,7 @@ export const EventFormFieldsExpanded: React.FC<
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const inputSize = useResponsiveInputSize()
 
   if (!showMore) return null
 
@@ -77,11 +79,11 @@ export const EventFormFieldsExpanded: React.FC<
           label={t('event.form.resource')}
           isExpanded={showMore && !isMobile}
         >
-          <FormControl fullWidth margin="dense" size="small">
+          <FormControl fullWidth margin="dense" size={inputSize}>
             <ResourceSearch
               objectTypes={['resource']}
               selectedResources={selectedResources}
-              inputSlot={params => <TextField {...params} size="small" />}
+              inputSlot={params => <TextField {...params} size={inputSize} />}
               onChange={(_event: React.SyntheticEvent, value: Resource[]) =>
                 setSelectedResources(value)
               }

--- a/common/src/components/Event/fields/CalendarSelectField.tsx
+++ b/common/src/components/Event/fields/CalendarSelectField.tsx
@@ -18,6 +18,7 @@ import { CalendarItemList } from '@common/components/Calendar/CalendarItemList'
 import { OwnerCaption } from '@common/components/Calendar/OwnerCaption'
 import { FieldWithLabel } from '@common/components/Event/components/FieldWithLabel'
 import { SectionPreviewRow } from '@common/components/Event/components/SectionPreviewRow'
+import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
 
 export interface CalendarSelectFieldProps {
   calendarid: string
@@ -108,6 +109,7 @@ const CalendarSelectFieldExpanded: React.FC<{
   disabled
 }) => {
   const { t } = useI18n()
+  const inputSize = useResponsiveInputSize()
 
   const delegatedCalendars = userPersonalCalendars.filter(cal => cal.delegated)
   const personalCalendars = userPersonalCalendars.filter(cal => !cal.delegated)
@@ -118,7 +120,7 @@ const CalendarSelectFieldExpanded: React.FC<{
   }
 
   return (
-    <FormControl fullWidth margin="dense" size="small">
+    <FormControl fullWidth margin="dense" size={inputSize}>
       <Select
         value={calendarid ?? ''}
         label=""

--- a/common/src/components/Event/fields/FreeBusyField.tsx
+++ b/common/src/components/Event/fields/FreeBusyField.tsx
@@ -7,6 +7,7 @@ import {
 } from '@linagora/twake-mui'
 import { useI18n } from 'twake-i18n'
 import { FieldWithLabel } from '@common/components/Event/components/FieldWithLabel'
+import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
 
 export interface FreeBusyFieldProps {
   busy: string
@@ -22,13 +23,14 @@ export const FreeBusyField: React.FC<FreeBusyFieldProps> = ({
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const inputSize = useResponsiveInputSize()
 
   return (
     <FieldWithLabel
       label={t('event.form.showMeAs')}
       isExpanded={showMore && !isMobile}
     >
-      <FormControl fullWidth margin="dense" size="small">
+      <FormControl fullWidth margin="dense" size={inputSize}>
         <Select
           labelId="busy"
           value={busy}

--- a/common/src/components/Event/fields/NotificationField.tsx
+++ b/common/src/components/Event/fields/NotificationField.tsx
@@ -13,6 +13,7 @@ import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 import { translateDuration } from '@common/components/EventPreview/utils/parseDuration'
 import { VAlarm } from '@common/types/VAlarm'
 import { Valarms } from '@common/types/Valarms'
+import { useResponsiveInputSize } from '@common/hooks/useResponsiveInputSize'
 
 const PREDEFINED_VALUES = [
   '-PT1M',
@@ -42,6 +43,8 @@ export const NotificationField: React.FC<NotificationFieldProps> = ({
 }) => {
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
+  const inputSize = useResponsiveInputSize()
+
   const selectedTriggers = alarms?.getAlarms()?.map(a => a?.trigger) ?? []
 
   const customTriggers = selectedTriggers.filter(
@@ -97,7 +100,7 @@ export const NotificationField: React.FC<NotificationFieldProps> = ({
       label={t('event.form.notification')}
       isExpanded={showMore && !isMobile}
     >
-      <FormControl fullWidth margin="dense" size="small">
+      <FormControl fullWidth margin="dense" size={inputSize}>
         <Select
           labelId="notification"
           multiple

--- a/common/src/features/Events/EventActions.tsx
+++ b/common/src/features/Events/EventActions.tsx
@@ -21,33 +21,27 @@ export const EventActions: React.FC<EventActionsProps> = ({
   const { t } = useI18n()
   const { isTooSmall: isMobile } = useScreenSizeDetection()
 
-  const buttonSize = isMobile ? 'small' : 'medium'
-
   return (
     <Box
       sx={{
         display: 'flex',
         justifyContent: 'space-between',
         width: '100%',
-        px: 2
+        px: isMobile ? 0 : 2
       }}
     >
       {showExpandedBtn && (
-        <Button size={buttonSize} startIcon={<AddIcon />} onClick={onExpanded}>
+        <Button size="medium" startIcon={<AddIcon />} onClick={onExpanded}>
           {t('common.moreOptions')}
         </Button>
       )}
       <Box sx={{ display: 'flex', gap: 1, ml: !showExpandedBtn ? 'auto' : 0 }}>
         {(!showExpandedBtn || isEdit) && (
-          <Button size={buttonSize} variant="outlined" onClick={onClose}>
+          <Button size="medium" variant="outlined" onClick={onClose}>
             {t('common.cancel')}
           </Button>
         )}
-        <Button
-          size={buttonSize}
-          variant="contained"
-          onClick={() => void onSave()}
-        >
+        <Button size="medium" variant="contained" onClick={() => void onSave()}>
           {t('actions.save')}
         </Button>
       </Box>

--- a/common/src/utils/renameDefault.ts
+++ b/common/src/utils/renameDefault.ts
@@ -1,9 +1,9 @@
 export function renameDefault(
   davName: string | undefined,
   ownerName: string,
-  t: (key: string, params?: object) => string,
+  t: (key: string, params?: Record<string, unknown>) => string,
   isOwnCalendar?: boolean
-) {
+): string {
   if (!ownerName) {
     if (davName && davName !== '#default') return davName
   }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1296

### Change:

There are some fixes for booking management modal on mobile:
- Add cancel button in extend mode.
- Keep the save button on the left side in extend mode.
- Fix font size of input to 16px.

https://github.com/user-attachments/assets/d99b9416-29be-4af6-9538-e9fa7b74755b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Appointment forms now provide reusable, consistently labeled fields for schedule names and colors.
  * Edit forms include a clear Cancel action alongside Save.
* **Bug Fixes**
  * Form expansion state resets correctly when closing or reopening the appointment form.
* **Style**
  * Improved mobile spacing and time-slot text presentation.
  * Event form controls and action buttons now adapt more consistently across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->