### PR TITLE
#1307 display tdrive picker modal in full screen on mobile

### DIFF
--- a/common/src/features/Tdrive/components/TdrivePickerDialog.tsx
+++ b/common/src/features/Tdrive/components/TdrivePickerDialog.tsx
@@ -3,6 +3,7 @@ import { Dialog, Box, IconButton } from '@linagora/twake-mui'
 import { Close as CloseIcon } from '@mui/icons-material'
 import { TdriveFile } from '../types'
 import { PickerSkeleton } from './PickerSkeleton'
+import { useScreenSizeDetection } from '@common/useScreenSizeDetection'
 
 interface TdrivePickerDialogProps {
   open: boolean
@@ -63,6 +64,8 @@ export const TdrivePickerDialog: React.FC<TdrivePickerDialogProps> = ({
   containerRef,
   onReadyToUse
 }) => {
+  const { isTooSmall: isMobile } = useScreenSizeDetection()
+
   const [isReady, setIsReady] = useState(false)
 
   // Reset loader each time the dialog opens
@@ -76,13 +79,14 @@ export const TdrivePickerDialog: React.FC<TdrivePickerDialogProps> = ({
       open={open}
       onClose={onClose}
       fullWidth
+      fullScreen={isMobile}
       onTransitionEnter={handleTransitionEnter}
       sx={{
         '& .MuiDialog-paper': {
           maxWidth: '900px',
           width: '100%',
-          height: '80vh',
-          maxHeight: '800px',
+          height: isMobile ? '100vh' : '80vh',
+          maxHeight: isMobile ? undefined : '800px',
           display: 'flex',
           flexDirection: 'column',
           position: 'relative'


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1307

### Change:

On mobile, the TDrive picker modal is small so cannot display full content inside. We made this PR to able to display it in full screen.

https://github.com/user-attachments/assets/7cd414ad-be72-4d86-ab87-4f8defe67521

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * The Tdrive picker now opens in full-screen mode on mobile devices.
  * Dialog sizing adjusts responsively to better fit smaller screens.
  * Improved the picker layout with a cleaner header-free presentation and an overlaid loading close button.
  * Updated the embedded picker background for a more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->