### PR TITLE
#1298 auto detect link in description when viewing event preview

### DIFF
--- a/common/src/components/EventPreview/EventDetailsRows.tsx
+++ b/common/src/components/EventPreview/EventDetailsRows.tsx
@@ -146,6 +146,7 @@ export const EventDescriptionRow: React.FC<{
 }> = ({ description, attach }) => {
   const builder = new EventDescriptionBuilder(description ?? '', attach ?? [])
     .removeFooter()
+    .linkify()
     .sanitize()
     .filterAttachments()
 

--- a/common/src/utils/EventDescriptionBuilder.tsx
+++ b/common/src/utils/EventDescriptionBuilder.tsx
@@ -29,6 +29,31 @@ export class EventDescriptionBuilder {
     return this
   }
 
+  public linkify(): this {
+    if (!this.text) return this
+
+    const urlRegex = /(https?:\/\/[^\s<]+)/g
+    if (!urlRegex.test(this.text)) return this
+
+    let insideAnchor = false
+
+    this.text = this.text.replace(
+      /(<[^>]+>)|(https?:\/\/[^\s<"']+)/g,
+      (match: string, tag: string | undefined, url: string | undefined) => {
+        if (tag) {
+          if (/^<a[\s>]/i.test(tag)) insideAnchor = true
+          else if (/^<\/a>/i.test(tag)) insideAnchor = false
+          return tag
+        }
+        return url && !insideAnchor
+          ? `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`
+          : match
+      }
+    )
+
+    return this
+  }
+
   public sanitize(): this {
     this.text = sanitizeHtml(this.text)
     return this

--- a/common/src/utils/__test__/EventDescriptionBuilder.test.tsx
+++ b/common/src/utils/__test__/EventDescriptionBuilder.test.tsx
@@ -145,4 +145,40 @@ describe('EventDescriptionBuilder', () => {
     const builder2 = new EventDescriptionBuilder(text2)
     expect(builder2.buildPlainText()).toBe('link &amp;')
   })
+
+  describe('linkify (security & edge cases)', () => {
+    it('should convert a bare URL to a clickable link', () => {
+      const text = 'Check out https://linagora.com for more info.'
+      const builder = new EventDescriptionBuilder(text).linkify()
+      expect(builder.buildHtml()).toBe(
+        'Check out <a href="https://linagora.com" target="_blank" rel="noopener noreferrer">https://linagora.com</a> for more info.'
+      )
+    })
+
+    it('should NOT alter URLs that are already inside HTML attributes (e.g., href)', () => {
+      const text = '<a href="https://evil.com">https://good.com</a>'
+      const builder = new EventDescriptionBuilder(text).linkify()
+      // Note: The text inside the tag 'https://good.com' is technically outside an HTML tag.
+      // But the attribute 'https://evil.com' should remain untouched.
+      expect(builder.buildHtml()).toBe(
+        '<a href="https://evil.com">https://good.com</a>'
+      )
+    })
+
+    it('should NOT break existing image tags with URLs in src', () => {
+      const text = '<img src="https://example.com/image.png" />'
+      const builder = new EventDescriptionBuilder(text).linkify()
+      expect(builder.buildHtml()).toBe(
+        '<img src="https://example.com/image.png" />'
+      )
+    })
+
+    it('should NOT include trailing quotes in the URL when it is next to quotes', () => {
+      const text = 'He said: "Go to https://example.com".'
+      const builder = new EventDescriptionBuilder(text).linkify()
+      expect(builder.buildHtml()).toBe(
+        'He said: "Go to <a href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>".'
+      )
+    })
+  })
 })

--- a/common/src/utils/__test__/sanitizeUtils.test.ts
+++ b/common/src/utils/__test__/sanitizeUtils.test.ts
@@ -42,5 +42,12 @@ describe('sanitizeUtils', () => {
         '<script>alert(1)</script><p>safe text</p><iframe src="dangerous"></iframe>'
       expect(sanitizeHtml(input)).toBe('<p>safe text</p>')
     })
+
+    it('should add rel="noopener noreferrer" to links with target', () => {
+      const input = '<a href="https://example.com" target="_blank">link</a>'
+      expect(sanitizeHtml(input)).toBe(
+        '<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>'
+      )
+    })
   })
 })

--- a/common/src/utils/sanitizeUtils.ts
+++ b/common/src/utils/sanitizeUtils.ts
@@ -1,4 +1,17 @@
-import DOMPurify from 'dompurify'
+import dompurify from 'dompurify'
+
+const DOMPurify =
+  typeof window !== 'undefined' && typeof dompurify === 'function'
+    ? dompurify(window)
+    : dompurify
+
+if (typeof DOMPurify?.addHook === 'function') {
+  DOMPurify.addHook('afterSanitizeAttributes', (node: Element) => {
+    if (node.tagName === 'A' && node.hasAttribute('target')) {
+      node.setAttribute('rel', 'noopener noreferrer')
+    }
+  })
+}
 
 /**
  * Sanitizes HTML text by only allowing basic styling tags.
@@ -32,11 +45,13 @@ export function sanitizeHtml(htmlText: string): string {
     'a'
   ]
 
-  const sanitized = DOMPurify.sanitize(htmlText, {
-    ALLOWED_TAGS: allowedTags,
-    ALLOWED_ATTR: ['href'],
-    KEEP_CONTENT: true
-  })
+  if (typeof DOMPurify?.sanitize === 'function') {
+    return DOMPurify.sanitize(htmlText, {
+      ALLOWED_TAGS: allowedTags,
+      ALLOWED_ATTR: ['href', 'target', 'rel'],
+      KEEP_CONTENT: true
+    })
+  }
 
-  return sanitized
+  return htmlText
 }


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1298

### Change:

When opening an event preview, if a part of the description is formatted as a link, it should be clickable.

<img width="568" height="413" alt="image" src="https://github.com/user-attachments/assets/d3c65eb5-e456-433c-9de5-9813386ff1b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event descriptions now automatically convert plain-text URLs into clickable links.
  * Links open safely in a new browser tab.

* **Bug Fixes**
  * Existing HTML links and image URLs are preserved without being altered.
  * Trailing punctuation is excluded from generated links for cleaner navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->