### PR TITLE
#1303 prioritize the booking color over the calendar color

### DIFF
--- a/__test__/components/Event/EventChip/EventChipUtils.test.ts
+++ b/__test__/components/Event/EventChip/EventChipUtils.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getEffectiveColor } from '@common/components/Event/EventChip/EventChipUtils'
+import { createTheme } from '@mui/material/styles'
+import { Calendar } from '@common/types/CalendarTypes'
+import { getAccessiblePair } from '@common/utils/getAccessiblePair'
+
+jest.mock('@common/utils/getAccessiblePair', () => ({
+  getAccessiblePair: jest.fn((color: string) =>
+    color === '#000000' ? '#ffffff' : '#000000'
+  )
+}))
+
+jest.mock(
+  '@injected/components/Attendees/AttendeeActions',
+  () => ({
+    AttendeeActions: () => null
+  }),
+  { virtual: true }
+)
+
+jest.mock('@common/components/Event/EventChip/EventChip', () => ({
+  EVENT_DURATION: {
+    SHORT: 15,
+    MEDIUM: 30,
+    LONG: 60
+  }
+}))
+
+describe('getEffectiveColor', () => {
+  const theme = createTheme()
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should apply correct color for event created from booking', () => {
+    const bookingLinkColor = '#ff0000'
+    const calendar = {
+      color: { light: '#00ff00', dark: '#000000' }
+    } as unknown as Calendar
+
+    const result = getEffectiveColor(
+      theme,
+      calendar,
+      undefined,
+      bookingLinkColor
+    )
+
+    expect(result.light).toBe('#ff0000')
+    expect(getAccessiblePair).toHaveBeenCalledWith('#ff0000', theme)
+  })
+
+  it('should fall back to calendar color if no booking link color or event colors are provided', () => {
+    const calendar = {
+      color: { light: '#00ff00', dark: '#000000' }
+    } as unknown as Calendar
+
+    const result = getEffectiveColor(theme, calendar)
+
+    expect(result.light).toBe('#00ff00')
+    expect(result.dark).toBe('#000000')
+    expect(getAccessiblePair).not.toHaveBeenCalled()
+  })
+})

--- a/common/src/components/Event/EventChip/DesktopEventChipSchedule.tsx
+++ b/common/src/components/Event/EventChip/DesktopEventChipSchedule.tsx
@@ -5,7 +5,8 @@ import SquareRoundedIcon from '@mui/icons-material/SquareRounded'
 import { Calendar } from '@common/types/CalendarTypes'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { useI18n } from 'twake-i18n'
-import { defaultColors } from '@common/utils/defaultColors'
+import { useAppSelector } from '@common/app/hooks'
+import { getEffectiveColor } from './EventChipUtils'
 import {
   RenderOrganizer,
   RenderVideoJoin,
@@ -35,24 +36,31 @@ export interface DesktopEventChipScheduleProps extends EventChipScheduleProps {
 
 export const DesktopEventChipSchedule: React.FC<
   DesktopEventChipScheduleProps
-> = ({
-  arg,
-  calendars,
-  tempcalendars,
-  timezone,
-  dayData,
-  upcommingEventId
-}) => {
+> = ({ arg, timezone, dayData, upcommingEventId }) => {
   const { t } = useI18n()
   const theme = useTheme()
+  const calendars = useAppSelector(state => state.calendars.list)
+  const tempcalendars = useAppSelector(state => state.calendars.templist)
 
   const ext = arg.event.extendedProps as CalendarEvent
-  const { temp } = arg.event._def.extendedProps
+  const { temp, colors, bookingLinkPublicId } = arg.event._def.extendedProps
   const isRecurrent = !!ext.repetition
   const videoUrl = ext.x_openpass_videoconference
   const calendarsSource = temp ? tempcalendars : calendars
   const calendar = calendarsSource[ext.calId]
-  const calendarColor = calendar?.color?.light ?? defaultColors[0].light
+
+  const bookingLinks = useAppSelector(state => state.bookingLinks.list)
+  const bookingLinkColor = bookingLinks?.find(
+    bl => bl.publicId === bookingLinkPublicId
+  )?.color
+
+  const effectiveColor = getEffectiveColor(
+    theme,
+    calendar,
+    colors as Record<string, string> | string | undefined,
+    bookingLinkColor
+  )
+  const calendarColor = effectiveColor.light
 
   return (
     <Box

--- a/common/src/components/Event/EventChip/EventChip.tsx
+++ b/common/src/components/Event/EventChip/EventChip.tsx
@@ -5,15 +5,18 @@ import {
   Card,
   CardContent,
   CardHeader,
-  Typography
+  Typography,
+  useTheme
 } from '@linagora/twake-mui'
-import { useRef } from 'react'
+import React, { useRef } from 'react'
+import { useAppSelector } from '@common/app/hooks'
 import { stringAvatar } from '@common/components/Event/utils/eventUtils'
 import { ErrorEventChip } from './ErrorEventChip'
 import {
   DisplayedIcons,
   EventChipProps,
   getBestColor,
+  getEffectiveColor,
   getCardStyle,
   getEventDuration,
   getEventTimes,
@@ -33,18 +36,29 @@ export const EVENT_DURATION = {
   LONG: 60
 } as const
 
-export const EventChip: React.FC<EventChipProps> = ({
-  arg,
-  calendars,
-  tempcalendars,
-  errorHandler
-}) => {
+export const EventChip: React.FC<EventChipProps> = ({ arg, errorHandler }) => {
   const cardRef = useRef<HTMLDivElement>(null)
   const showCompact = useCompactMode(cardRef)
+  const theme = useTheme()
+
+  const calendars = useAppSelector(state => state.calendars.list)
+  const tempcalendars = useAppSelector(state => state.calendars.templist)
 
   const event = arg.event
   const props = event._def.extendedProps
-  const { calId, temp, attendee: attendees = [], class: classification } = props
+  const {
+    calId,
+    temp,
+    attendee: attendees = [],
+    class: classification,
+    colors,
+    bookingLinkPublicId
+  } = props
+
+  const bookingLinks = useAppSelector(state => state.bookingLinks.list)
+  const bookingLinkColor = bookingLinks?.find(
+    bl => bl.publicId === bookingLinkPublicId
+  )?.color
 
   // ponytail: strip the invisible video-conference footer (visio join link +
   // "do not edit" block) so it doesn't leak into the grid preview.
@@ -78,12 +92,13 @@ export const EventChip: React.FC<EventChipProps> = ({
     const displayPartstat = ownerAttendee?.partstat || 'ACCEPTED'
 
     // Color and contrast logic
-    const bestColor = getBestColor(
-      (calendar.color as { light: string; dark: string }) ?? {
-        light: '#fff',
-        dark: '#000'
-      }
+    const effectiveColor = getEffectiveColor(
+      theme,
+      calendar,
+      colors as Record<string, string> | string | undefined,
+      bookingLinkColor
     )
+    const bestColor = getBestColor(effectiveColor)
 
     // Icon display configuration
     const IconDisplayed: IconDisplayConfig = {
@@ -107,7 +122,7 @@ export const EventChip: React.FC<EventChipProps> = ({
     const titleStyle = getTitleStyle(
       bestColor,
       displayPartstat,
-      calendar,
+      effectiveColor,
       isPrivate
     )
 
@@ -115,7 +130,7 @@ export const EventChip: React.FC<EventChipProps> = ({
       bestColor,
       eventLength,
       displayPartstat,
-      calendar,
+      effectiveColor,
       isPrivate
     )
 

--- a/common/src/components/Event/EventChip/EventChipUtils.tsx
+++ b/common/src/components/Event/EventChip/EventChipUtils.tsx
@@ -2,7 +2,8 @@ import { EventErrorHandler } from '@common/components/Error/EventErrorHandler'
 import { Calendar } from '@common/types/CalendarTypes'
 import { userAttendee } from '@common/features/User/models/attendee'
 import { EventContentArg } from '@fullcalendar/core'
-import { getContrastRatio } from '@linagora/twake-mui'
+import { Theme, getContrastRatio } from '@linagora/twake-mui'
+import { getAccessiblePair } from '@common/utils/getAccessiblePair'
 import CancelIcon from '@mui/icons-material/Cancel'
 import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined'
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
@@ -14,8 +15,8 @@ const COMPACT_WIDTH_THRESHOLD = 100
 
 export interface EventChipProps {
   arg: EventContentArg
-  calendars: Record<string, Calendar>
-  tempcalendars: Record<string, Calendar>
+  calendars?: Record<string, Calendar>
+  tempcalendars?: Record<string, Calendar>
   errorHandler: EventErrorHandler
 }
 export interface IconDisplayConfig {
@@ -54,10 +55,49 @@ export function getOwnerAttendee(
   return attendees.find(att => ownerEmails.has(att.cal_address.toLowerCase()))
 }
 
+export function getEffectiveColor(
+  theme: Theme,
+  calendar?: Calendar,
+  eventColors?: Record<string, string> | string,
+  bookingLinkColor?: string
+): { light: string; dark: string } {
+  if (bookingLinkColor) {
+    return {
+      light: bookingLinkColor,
+      dark: getAccessiblePair(bookingLinkColor, theme)
+    }
+  }
+
+  if (eventColors) {
+    if (typeof eventColors === 'string') {
+      return { light: eventColors, dark: getAccessiblePair(eventColors, theme) }
+    }
+    if (eventColors.light || eventColors.dark) {
+      const light = eventColors.light || eventColors.dark || '#fff'
+      return {
+        light,
+        dark: eventColors.dark || getAccessiblePair(light, theme)
+      }
+    }
+    // If it's a record with other keys (like booking color), take the first string value
+    const values = Object.values(eventColors).filter(v => typeof v === 'string')
+    if (values.length > 0) {
+      return { light: values[0], dark: getAccessiblePair(values[0], theme) }
+    }
+  }
+
+  return (
+    (calendar?.color as { light: string; dark: string }) ?? {
+      light: '#fff',
+      dark: '#000'
+    }
+  )
+}
+
 export function getTitleStyle(
   bestColor: string,
   partstat?: string,
-  calendar?: Calendar,
+  effectiveColor?: { light: string; dark: string },
   isPrivate?: boolean
 ): React.CSSProperties {
   const baseStyle: React.CSSProperties = {
@@ -79,12 +119,12 @@ export function getTitleStyle(
     case 'TENTATIVE':
       return baseStyle
     case 'ACCEPTED':
-      return { ...baseStyle, color: calendar?.color?.dark }
+      return { ...baseStyle, color: effectiveColor?.dark }
     case 'NEEDS-ACTION':
       return baseStyle
     default:
       if (isPrivate) {
-        return { ...baseStyle, color: calendar?.color?.dark }
+        return { ...baseStyle, color: effectiveColor?.dark }
       }
       return baseStyle
   }
@@ -133,7 +173,7 @@ export function getCardStyle(
   bestColor: string,
   eventLength: number,
   partstat?: string,
-  calendar?: Calendar,
+  effectiveColor?: { light: string; dark: string },
   isPrivate?: boolean
 ): React.CSSProperties {
   const baseStyle: React.CSSProperties = getCardVariantStyle(
@@ -157,16 +197,16 @@ export function getCardStyle(
     case 'ACCEPTED':
       return {
         ...baseStyle,
-        backgroundColor: calendar?.color?.light,
-        color: calendar?.color?.dark,
+        backgroundColor: effectiveColor?.light,
+        color: effectiveColor?.dark,
         border: '1px solid white'
       }
     default:
       if (isPrivate) {
         return {
           ...baseStyle,
-          backgroundColor: calendar?.color?.light,
-          color: calendar?.color?.dark,
+          backgroundColor: effectiveColor?.light,
+          color: effectiveColor?.dark,
           border: '1px solid white'
         }
       }

--- a/common/src/components/Event/EventChip/MobileEventChipSchedule.tsx
+++ b/common/src/components/Event/EventChip/MobileEventChipSchedule.tsx
@@ -11,6 +11,8 @@ import {
 import { RenderMobileEventCard } from '@common/features/Search/mobileSearchResultsComponents'
 import { SearchEventResult } from '@common/features/Search/types/SearchEventResult'
 import { useI18n } from 'twake-i18n'
+import { getEffectiveColor } from './EventChipUtils'
+import { useAppSelector } from '@common/app/hooks'
 
 export interface MobileEventChipScheduleProps extends EventChipScheduleProps {
   arg: EventContentArg
@@ -55,22 +57,29 @@ const parseEventToSearchResult = (
 
 export const MobileEventChipSchedule: React.FC<
   MobileEventChipScheduleProps
-> = ({
-  arg,
-  calendars,
-  tempcalendars,
-  timezone,
-  dayData,
-  upcommingEventId
-}) => {
+> = ({ arg, timezone, dayData, upcommingEventId }) => {
   const { t } = useI18n()
   const theme = useTheme()
+  const calendars = useAppSelector(state => state.calendars.list)
+  const tempcalendars = useAppSelector(state => state.calendars.templist)
 
   const ext = arg.event.extendedProps as CalendarEvent
-  const { temp } = arg.event._def.extendedProps
+  const { temp, colors, bookingLinkPublicId } = arg.event._def.extendedProps
   const calendarsSource = temp ? tempcalendars : calendars
   const calendar = calendarsSource[ext.calId]
   const videoUrl = ext.x_openpass_videoconference
+
+  const bookingLinks = useAppSelector(state => state.bookingLinks.list)
+  const bookingLinkColor = bookingLinks?.find(
+    bl => bl.publicId === bookingLinkPublicId
+  )?.color
+
+  const effectiveColor = getEffectiveColor(
+    theme,
+    calendar,
+    colors as Record<string, string> | string | undefined,
+    bookingLinkColor
+  )
 
   if (!calendar) return null
 
@@ -101,6 +110,7 @@ export const MobileEventChipSchedule: React.FC<
       <RenderMobileEventCard
         eventData={eventData}
         calendar={calendar}
+        effectiveColor={effectiveColor}
         timeZone={timezone}
         customSubHeader={(titleStyle: React.CSSProperties) => (
           <RenderListEventTime

--- a/common/src/features/Calendars/reducers/updateCalColorReducer.ts
+++ b/common/src/features/Calendars/reducers/updateCalColorReducer.ts
@@ -13,6 +13,11 @@ export const updateCalColorReducer = (create: ReducerCreators<CalendarState>) =>
       const cal = state.list[action.payload.id]
       if (cal) {
         cal.color = action.payload.color
+        if (cal.events) {
+          Object.values(cal.events).forEach(event => {
+            event.color = action.payload.color
+          })
+        }
       }
     }
   )

--- a/common/src/features/Calendars/services/patchCalendarAsync.ts
+++ b/common/src/features/Calendars/services/patchCalendarAsync.ts
@@ -36,9 +36,28 @@ export const patchCalendarThunk = (create: ReducerCreators<CalendarState>) =>
       pending: state => {
         state.pending = true
       },
-      fulfilled: state => {
+      fulfilled: (state, action) => {
         state.pending = false
         state.error = null
+
+        const { calId, patch } = action.payload
+
+        const applyPatch = (cal: (typeof state.list)[string] | undefined) => {
+          if (!cal) return
+          if (patch.name !== undefined) cal.name = patch.name
+          if (patch.desc !== undefined) cal.description = patch.desc
+          if (patch.color !== undefined) {
+            cal.color = patch.color
+            if (cal.events) {
+              Object.values(cal.events).forEach(event => {
+                event.color = patch.color
+              })
+            }
+          }
+        }
+
+        applyPatch(state.list[calId])
+        applyPatch(state.templist[calId])
       },
       rejected: (state, action) => {
         state.pending = false

--- a/common/src/features/Search/mobileSearchResultsComponents.tsx
+++ b/common/src/features/Search/mobileSearchResultsComponents.tsx
@@ -3,7 +3,6 @@ import {
   getTitleStyle
 } from '@common/components/Event/EventChip/EventChipUtils'
 import { Calendar } from '@common/types/CalendarTypes'
-import { defaultColors } from '@common/utils/defaultColors'
 import { Box, Card, CardHeader, Typography } from '@linagora/twake-mui'
 import React from 'react'
 import { useI18n } from 'twake-i18n'
@@ -20,6 +19,7 @@ interface MobileEventCardProps {
   calendar: Calendar | undefined
   timeZone: string
   customSubHeader?: (titleStyle: React.CSSProperties) => React.ReactNode
+  effectiveColor?: { light: string; dark: string }
 }
 
 export const RenderMobileDate: React.FC<MobileDateProps> = ({
@@ -39,15 +39,18 @@ export const RenderMobileDate: React.FC<MobileDateProps> = ({
   </Box>
 )
 
-const getCardSx = (calendar: Calendar): React.CSSProperties => ({
+const getCardSx = (effectiveColor: {
+  light: string
+  dark: string
+}): React.CSSProperties => ({
   height: 'stretch',
   minHeight: '58px',
   width: '100%',
   borderRadius: '8px',
   padding: 1,
   boxShadow: 'none',
-  backgroundColor: calendar.color?.light,
-  color: calendar.color?.dark,
+  backgroundColor: effectiveColor.light,
+  color: effectiveColor.dark,
   border: '1px solid',
   borderColor: 'background.paper',
   display: 'flex'
@@ -72,7 +75,8 @@ export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
   eventData,
   calendar,
   timeZone,
-  customSubHeader
+  customSubHeader,
+  effectiveColor
 }) => {
   const { t } = useI18n()
 
@@ -81,15 +85,13 @@ export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
   const { start, allDay, summary, uid } = eventData.data
   const startDate = new Date(start)
 
-  const bestColor = calendar.color
-    ? getBestColor(calendar.color as { light: string; dark: string })
-    : defaultColors[0].dark
-  const titleStyle = getTitleStyle(
-    bestColor,
-    'ACCEPTED',
-    calendar ?? ({} as Calendar),
-    false
-  )
+  const resolvedColor = effectiveColor ??
+    (calendar.color as { light: string; dark: string }) ?? {
+      light: '#fff',
+      dark: '#000'
+    }
+  const bestColor = getBestColor(resolvedColor)
+  const titleStyle = getTitleStyle(bestColor, 'ACCEPTED', resolvedColor, false)
 
   const defaultSubHeader = !allDay && (
     <Typography style={getSubheaderStyle(titleStyle.color)}>
@@ -104,7 +106,7 @@ export const RenderMobileEventCard: React.FC<MobileEventCardProps> = ({
   return (
     <Card
       variant="outlined"
-      sx={getCardSx(calendar)}
+      sx={getCardSx(resolvedColor)}
       data-testid={`event-card-${uid}`}
     >
       <CardHeader


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1303

### Change:

A booking link is created with a custom color, but the event generated from the booking does not apply the color of the booking link. It's using the color of the selected calendar.

What we expect is that the event will prioritize applying the booking link color first.

Also, events created directly in the calendar should not be affected.


https://github.com/user-attachments/assets/4beb5467-c2a5-40a8-9c5e-acf33bc40cc8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event cards now use booking-link, event, and calendar colors with improved accessible color handling.
  * Calendar color changes now update associated events automatically across calendar views and search results.

* **Bug Fixes**
  * Improved consistency of event colors across desktop, mobile, and search displays.
  * Added fallback color handling when booking-link or event colors are unavailable.

* **Tests**
  * Added coverage for booking-link color selection and calendar color fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->