### PR TITLE
[#1113] added private event caption to access tab

### DIFF
--- a/common/src/components/Calendar/AccessTab.tsx
+++ b/common/src/components/Calendar/AccessTab.tsx
@@ -109,6 +109,12 @@ export function AccessTab({
         onChange={onUsersWithAccessChange}
         onInvitesLoaded={onInvitesLoaded}
       />
+      <Typography
+        variant="body2"
+        sx={{ color: 'text.secondary', mt: 1, lineHeight: 1.5 }}
+      >
+        {t('calendarPopover.access.privateEventsNotice')}
+      </Typography>
 
       {!!window.DAV_BASE_URL && !isResource && (
         <FieldWithLabel label={t('calendar.caldav_access')} isExpanded={false}>

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -107,7 +107,8 @@
       "viewAllEvents": "View all events",
       "editor": "Editor",
       "owner": "Owner",
-      "administrator": "Administrator"
+      "administrator": "Administrator",
+      "privateEventsNotice": "Only the owner of a calendar can see its private events."
     }
   },
   "colorPicker": {

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -107,7 +107,8 @@
       "viewAllEvents": "Voir tous les événements",
       "editor": "Éditeur",
       "owner": "Propriétaire",
-      "administrator": "Administrateur"
+      "administrator": "Administrateur",
+      "privateEventsNotice": "Seul le propriétaire d'un calendrier peut voir ses événements privés."
     }
   },
   "colorPicker": {

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -107,7 +107,8 @@
       "viewAllEvents": "Просмотр всех событий",
       "editor": "Редактор",
       "owner": "Владелец",
-      "administrator": "Администратор"
+      "administrator": "Администратор",
+      "privateEventsNotice": "Только владелец календаря может видеть его частные события."
     }
   },
   "colorPicker": {

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -107,7 +107,8 @@
       "viewAllEvents": "Xem tất cả sự kiện",
       "editor": "Biên tập viên",
       "owner": "Chủ sở hữu",
-      "administrator": "Quản trị viên"
+      "administrator": "Quản trị viên",
+      "privateEventsNotice": "Chỉ chủ sở hữu của lịch mới có thể xem các sự kiện riêng tư của lịch đó."
     }
   },
   "colorPicker": {


### PR DESCRIPTION
resolves #1113 
<img width="575" height="709" alt="image" src="https://github.com/user-attachments/assets/90ff535f-dfcd-40ca-8791-4c215aa0b5da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational notice in calendar access settings explaining that only calendar owners can view private events.
* **Localization**
  * Added or updated translations for the private-events notice and calendar administrator role in English, French, Russian, and Vietnamese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->