### PR TITLE
[#1291] fix modal position when anchorEl changes

### DIFF
--- a/common/src/components/Dialog/ResponsiveDialog.tsx
+++ b/common/src/components/Dialog/ResponsiveDialog.tsx
@@ -21,7 +21,7 @@ import { useIsInIframe } from '@common/contexts/EmbeddingContext'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import CloseIcon from '@mui/icons-material/Close'
 import OpenInFullIcon from '@mui/icons-material/OpenInFull'
-import React, { ReactNode, useContext, useId, useMemo } from 'react'
+import React, { ReactNode, useContext, useId, useMemo, useState } from 'react'
 import useDynamicPosition from './useDynamicPosition'
 
 /**
@@ -233,8 +233,34 @@ function ResponsiveDialog({
     dialogId: titleId
   })
 
+  // Once we have a position, freeze it for the lifetime of this open session.
+  // This prevents re-renders triggered by chip movement (e.g. all-day toggle)
+  // from updating left/top in the sx prop and jumping the dialog.
+  const [lockedPosition, setLockedPosition] = useState<{
+    top?: number
+    bottom?: number
+    left: number
+  } | null>(null)
+
+  React.useEffect(() => {
+    if (!open) {
+      setLockedPosition(null)
+    }
+  }, [open])
+
+  React.useEffect(() => {
+    if (open && position && !lockedPosition) {
+      setLockedPosition(position)
+    }
+  }, [open, position, lockedPosition])
+
+  // No ResizeObserver clamping needed here.  useDynamicPosition now returns
+  // `bottom` instead of `top` when the anchor sits in the bottom half of the
+  // viewport.  CSS `bottom` pinning makes the dialog grow upward naturally as
+  // its height increases, without any JS resize tracking.
+
   const isDynamic = !isExpanded && !isMobile && Boolean(dynamicPositioning)
-  const isPendingPosition = isDynamic && !position
+  const isPendingPosition = isDynamic && !lockedPosition
   const hideBackdrop = isExpanded || isPendingPosition
 
   const baseSx: SxProps<Theme> | undefined = isMobile
@@ -245,7 +271,7 @@ function ResponsiveDialog({
           transition: hideBackdrop ? 'none !important' : undefined,
           pointerEvents: hideBackdrop ? 'none' : undefined
         },
-        ...(position && !isExpanded
+        ...(lockedPosition && !isExpanded
           ? {
               '& .MuiDialog-container': {
                 display: 'flex',
@@ -255,7 +281,7 @@ function ResponsiveDialog({
             }
           : {}),
         '& .MuiDialog-paper': {
-          overflowY: 'hidden',
+          overflowY: 'visible',
           maxWidth: isExpanded ? '100%' : normalMaxWidth,
           width: '100%',
           height: isExpanded
@@ -264,12 +290,22 @@ function ResponsiveDialog({
           maxHeight: isExpanded && isInIframe ? '100%' : undefined,
           margin: isExpanded
             ? `${isInIframe ? 0 : headerHeight} 0 0 0`
-            : position
+            : lockedPosition
               ? '0 !important'
               : '32px',
-          position: position && !isExpanded ? 'fixed' : undefined,
-          left: position && !isExpanded ? `${position.left}px` : undefined,
-          top: position && !isExpanded ? `${position.top}px` : undefined,
+          position: lockedPosition && !isExpanded ? 'fixed' : undefined,
+          left:
+            lockedPosition && !isExpanded
+              ? `${lockedPosition.left}px`
+              : undefined,
+          top:
+            lockedPosition && !isExpanded && lockedPosition.top !== undefined
+              ? `${lockedPosition.top}px`
+              : undefined,
+          bottom:
+            lockedPosition && !isExpanded && lockedPosition.bottom !== undefined
+              ? `${lockedPosition.bottom}px`
+              : undefined,
           visibility: isPendingPosition ? 'hidden' : undefined,
           opacity: isPendingPosition ? 0 : undefined,
           boxShadow: isExpanded ? 'none !important' : undefined,

--- a/common/src/components/Dialog/useDynamicPosition.ts
+++ b/common/src/components/Dialog/useDynamicPosition.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 
 export interface DynamicPosition {
-  top: number
+  top?: number
+  bottom?: number
   left: number
 }
 
@@ -223,6 +224,17 @@ const calculateDynamicPosition = (
     bottomPadding: DEFAULT_BOTTOM_PADDING
   })
 
+  const anchorCenterY = anchorRect.top + anchorRect.height / 2
+  const viewportCenterY = window.innerHeight / 2
+
+  // When the anchor is in the bottom half of the viewport we pin the dialog
+  // by its bottom edge so that as content grows it expands upward (towards the
+  // available space) instead of downward off-screen.
+  if (anchorCenterY > viewportCenterY) {
+    const bottom = window.innerHeight - top - dialogHeight
+    return { bottom, left }
+  }
+
   return { top, left }
 }
 
@@ -244,27 +256,9 @@ const clearPositionFromDOM = (dialogId?: string): void => {
 const applyPositionToDOM = (pos: DynamicPosition, dialogId?: string): void => {
   const paperEl = getDialogPaperElement(dialogId)
   if (!paperEl) return
-  paperEl.style.top = `${pos.top}px`
-  paperEl.style.left = `${pos.left}px`
-  // Clear any drag transform so the clamped position is the true visual position.
+  if (pos.top !== undefined) paperEl.style.top = `${pos.top}px`
+  if (pos.left !== undefined) paperEl.style.left = `${pos.left}px`
   paperEl.style.transform = ''
-}
-
-const setupResizeObserver = (
-  callback: () => void,
-  dialogId?: string
-): (() => void) | undefined => {
-  if (typeof ResizeObserver === 'undefined') return undefined
-
-  const paperEl = getDialogPaperElement(dialogId)
-  if (!paperEl) return undefined
-
-  const resizeObserver = new ResizeObserver(callback)
-  resizeObserver.observe(paperEl)
-
-  return (): void => {
-    resizeObserver.disconnect()
-  }
 }
 
 const getInitialPosition = (
@@ -309,7 +303,6 @@ const useDynamicPosition = (
     let isSubscribed = true
     let rafId: number | null = null
     let timerId: ReturnType<typeof setTimeout> | null = null
-    let cleanupResizeObserver: (() => void) | undefined
 
     const updatePos = (): void => {
       if (!isSubscribed) return
@@ -333,16 +326,11 @@ const useDynamicPosition = (
         dialogId
       )
       if (pos) {
-        // In case of repositionning and the dialog size changes, we clear the transform
         applyPositionToDOM(pos, dialogId)
         setPosition(pos)
         setLastPosition(pos)
       } else {
         rafId = requestAnimationFrame(updatePos)
-      }
-
-      if (!cleanupResizeObserver) {
-        cleanupResizeObserver = setupResizeObserver(updatePos, dialogId)
       }
     }
 
@@ -361,7 +349,6 @@ const useDynamicPosition = (
       if (rafId) cancelAnimationFrame(rafId)
       if (timerId) clearTimeout(timerId)
       window.removeEventListener('resize', updatePos)
-      cleanupResizeObserver?.()
     }
   }, [isEnabled, anchorEl, headerHeight, dialogId])
 


### PR DESCRIPTION
resolves #1291 and #1337 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dialogs remain stable during chip movement and other screen updates while open.
  * Improved positioning keeps dialogs visible when their anchor is near the bottom of the viewport.
  * Dialog content can extend beyond previous boundaries, reducing clipping in certain layouts.
  * Dialog placement updates more reliably when anchors change or positioning is recalculated.
  * Positioning resets correctly when dialogs close or dynamic positioning is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->