### PR TITLE
#1340 fix bug cannot save event's personal settings

### DIFF
--- a/common/src/components/Event/EventFormFieldPersonalSettings.tsx
+++ b/common/src/components/Event/EventFormFieldPersonalSettings.tsx
@@ -9,10 +9,10 @@ import { EventFormFieldsSpecific } from './components/EventFormFieldsSpecific'
 import { EventFormValues } from './EventFormFields.types'
 import { CalendarSelectField } from './fields/CalendarSelectField'
 import { userAttendee } from '@common/features/User/models/attendee'
+import { useI18n } from 'twake-i18n'
 
 export function EventFormFieldPersonalSettings({
   v,
-  t,
   typeOfAction,
   setCalendarid,
   userPersonalCalendars,
@@ -24,7 +24,6 @@ export function EventFormFieldPersonalSettings({
   user
 }: {
   v: EventFormValues
-  t: (key: string, options?: object) => string
   typeOfAction: string | undefined
   setCalendarid: (v: string) => void
   userPersonalCalendars: Calendar[]
@@ -35,6 +34,8 @@ export function EventFormFieldPersonalSettings({
   isOrganizer: boolean
   user: userAttendee
 }): React.ReactNode {
+  const { t } = useI18n()
+
   const setAlarmsWithUser = useCallback(
     (alarms: Valarms) => {
       // Guard: don't stamp alarms if user has no valid cal_address

--- a/common/src/components/EventPreview/EventPreviewModal.tsx
+++ b/common/src/components/EventPreview/EventPreviewModal.tsx
@@ -62,7 +62,8 @@ const EventPreviewModal: React.FC<{
     handleDuplicateClick,
     calendarid,
     handleCalendarMove,
-    userPersonalCalendars
+    userPersonalCalendars,
+    handleSettingsEditClick
   } = useEventPreviewState(eventId, calId, tempEvent, open, onClose)
 
   useEffect(
@@ -185,9 +186,7 @@ const EventPreviewModal: React.FC<{
         userEmail={user.email}
         onClose={() => setToggleActionMenu(null)}
         onDuplicate={handleDuplicateClick}
-        onEdit={() => {
-          setOpenSettingsUpdateModal(true)
-        }}
+        onEdit={handleSettingsEditClick}
       />
 
       {/* Recurring edit/delete mode picker */}

--- a/common/src/components/EventPreview/useEventPreviewState.ts
+++ b/common/src/components/EventPreview/useEventPreviewState.ts
@@ -64,6 +64,7 @@ interface UseEventPreviewStateReturn {
   resolvedTypeOfAction: 'solo' | 'all' | undefined
   handleEditClick: () => void
   handleEditInOrganizerCalendar: () => void
+  handleSettingsEditClick: () => void
   handleDeleteClick: () => Promise<void>
   handleDuplicateClick: () => void
   calendarid: string
@@ -236,6 +237,20 @@ export function useEventPreviewState(
     }
   }
 
+  const handleSettingsEditClick = (): void => {
+    setUpdateModalCalId(calId)
+    if (isRecurring) {
+      setAfterChoiceFunc(() => (): void => {
+        setHidePreview(true)
+        setOpenSettingsUpdateModal(true)
+      })
+      setOpenEditModePopup('edit')
+    } else {
+      setHidePreview(true)
+      setOpenSettingsUpdateModal(true)
+    }
+  }
+
   const handleDeleteClick = async (): Promise<void> => {
     if (isRecurring) {
       setAfterChoiceFunc(
@@ -339,6 +354,7 @@ export function useEventPreviewState(
     // Handlers
     handleEditClick,
     handleEditInOrganizerCalendar,
+    handleSettingsEditClick,
     handleDeleteClick,
     handleDuplicateClick,
 

--- a/common/src/features/Events/EventSettingsUpdateModal.tsx
+++ b/common/src/features/Events/EventSettingsUpdateModal.tsx
@@ -12,6 +12,9 @@ import { EventActions } from './EventActions'
 import { useEventOrganizer } from './useEventOrganizer'
 import { useEventSettingsUpdateModal } from './useEventSettingsUpdateModal'
 import { userAttendee } from '../User/models/attendee'
+import moment from 'moment'
+import { formatLocalDateTime } from '@common/components/Event/utils/dateTimeFormatters'
+import { EventFormValues } from '@common/components/Event/EventFormFields.types'
 
 export interface EventSettingsUpdateModalProps {
   eventId: string
@@ -24,6 +27,76 @@ export interface EventSettingsUpdateModalProps {
   anchorEl?: HTMLElement | null
 }
 
+function getCurrentUser(
+  calList: Record<string, { owner?: { emails?: string[] } }>,
+  calId: string
+): userAttendee | undefined {
+  const email = calList[calId]?.owner?.emails?.[0]
+  return email ? userAttendee.fromEmailField(email) : undefined
+}
+
+function getOriginalEvent(params: {
+  typeOfAction?: 'solo' | 'all'
+  masterEvent: CalendarEvent | null
+  cachedEvent?: CalendarEvent
+  fallbackEvent: CalendarEvent
+}): CalendarEvent {
+  if (params.typeOfAction === 'all' && params.masterEvent) {
+    return params.masterEvent
+  }
+  return params.cachedEvent || params.fallbackEvent
+}
+
+function mergeUserAlarms(
+  originalAlarms: Valarms | undefined,
+  editableAlarms: ReturnType<Valarms['getAllAlarmsForAttendee']>,
+  currentUser?: userAttendee
+): Valarms {
+  const formAlarms = Valarms.fromList(editableAlarms)
+  if (originalAlarms && currentUser) {
+    return originalAlarms.mergeForPersonalSettingsUpdate(
+      formAlarms,
+      currentUser
+    )
+  }
+  return formAlarms
+}
+
+function computeUpdatedFormValues(params: {
+  formValues: EventFormValues
+  mergedAlarms: Valarms
+  originalEvent: CalendarEvent
+  typeOfAction?: 'solo' | 'all'
+}): EventFormValues {
+  const { formValues, mergedAlarms, originalEvent, typeOfAction } = params
+  if (typeOfAction !== 'all') {
+    return {
+      ...formValues,
+      alarms: mergedAlarms
+    }
+  }
+
+  const updateData = {
+    ...formValues,
+    start: formatLocalDateTime(
+      moment.tz(originalEvent.start, originalEvent.timezone).toDate(),
+      originalEvent.timezone
+    ),
+    alarms: mergedAlarms
+  }
+
+  if (originalEvent.end) {
+    updateData.end = formatLocalDateTime(
+      moment.tz(originalEvent.end, originalEvent.timezone).toDate(),
+      originalEvent.timezone
+    )
+  }
+
+  return updateData
+}
+
+const toggleShowMore = (s: boolean): boolean => !s
+
 const EventSettingsUpdateModalInternal: React.FC<
   EventSettingsUpdateModalProps & { event: CalendarEvent }
 > = props => {
@@ -33,11 +106,7 @@ const EventSettingsUpdateModalInternal: React.FC<
 
   const calList = useAppSelector(state => state.calendars.list)
   const userOrganizer = useAppSelector(state => state.user.organiserData)
-
-  const currentUserEmail = calList[props.calId]?.owner?.emails?.[0]
-  const currentUser = currentUserEmail
-    ? userAttendee.fromEmailField(currentUserEmail)
-    : undefined
+  const currentUser = getCurrentUser(calList, props.calId)
 
   const { isOrganizer } = useEventOrganizer({
     calendarid: props.calId,
@@ -53,7 +122,8 @@ const EventSettingsUpdateModalInternal: React.FC<
     initialValues,
     handleClose,
     handleSubmit,
-    tempContext
+    tempContext,
+    masterEvent
   } = useEventSettingsUpdateModal(props)
 
   const { formValues, setAlarms, setBusy, setEventClass, setCalendarid } =
@@ -67,29 +137,30 @@ const EventSettingsUpdateModalInternal: React.FC<
       onAllDayChange: () => {}
     })
 
-  // Extract all alarms the current user is part of (personal + global)
   const editableAlarms = useMemo(() => {
-    if (!currentUser) return []
-    return formValues.alarms.getAllAlarmsForAttendee(currentUser)
+    return currentUser
+      ? formValues.alarms.getAllAlarmsForAttendee(currentUser)
+      : []
   }, [formValues.alarms, currentUser])
 
   const handleSave = useCallback(async () => {
-    // Get the original event to preserve other attendees' alarms
-    const originalEvent =
-      calList[props.calId]?.events?.[props.eventId] || props.event
-    const originalAlarms = originalEvent?.alarms
-
-    // Merge form alarms back with original, handling global alarm unsubscription
-    const formAlarms = Valarms.fromList(editableAlarms)
-    const mergedAlarms =
-      originalAlarms && currentUser
-        ? originalAlarms.mergeForPersonalSettingsUpdate(formAlarms, currentUser)
-        : formAlarms
-
-    const valuesWithMergedAlarms = {
-      ...formValues,
-      alarms: mergedAlarms
-    }
+    const originalEvent = getOriginalEvent({
+      typeOfAction,
+      masterEvent,
+      cachedEvent: calList[props.calId]?.events?.[props.eventId],
+      fallbackEvent: props.event
+    })
+    const mergedAlarms = mergeUserAlarms(
+      originalEvent.alarms,
+      editableAlarms,
+      currentUser
+    )
+    const valuesWithMergedAlarms = computeUpdatedFormValues({
+      formValues,
+      mergedAlarms,
+      originalEvent,
+      typeOfAction
+    })
 
     await handleSubmit(valuesWithMergedAlarms)
   }, [
@@ -100,7 +171,9 @@ const EventSettingsUpdateModalInternal: React.FC<
     props.calId,
     props.eventId,
     props.event,
-    currentUser
+    currentUser,
+    masterEvent,
+    typeOfAction
   ])
 
   const actions = (
@@ -109,7 +182,7 @@ const EventSettingsUpdateModalInternal: React.FC<
       isEdit
       onClose={handleClose}
       onSave={handleSave}
-      onExpanded={() => setShowMore((s: boolean) => !s)}
+      onExpanded={() => setShowMore(toggleShowMore)}
     />
   )
   return (
@@ -125,10 +198,8 @@ const EventSettingsUpdateModalInternal: React.FC<
       <EventFormFieldPersonalSettings
         v={{
           ...formValues,
-          // Show all alarms the user is part of (personal + global)
           alarms: Valarms.fromList(editableAlarms)
         }}
-        t={t}
         typeOfAction={typeOfAction}
         setCalendarid={setCalendarid}
         userPersonalCalendars={userPersonalCalendars}

--- a/common/src/features/Events/hooks/submitUpdateHelpers/performUpdateAction.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/performUpdateAction.ts
@@ -49,6 +49,7 @@ export async function performUpdateAction(
 
     if (typeOfAction === 'all') {
       await handleUpdateRecurringSeries(params)
+      return
     }
   } catch (error) {
     handleUpdateError({

--- a/common/src/features/Events/useEventSettingsUpdateModal.tsx
+++ b/common/src/features/Events/useEventSettingsUpdateModal.tsx
@@ -29,6 +29,7 @@ export function useEventSettingsUpdateModal(
   handleSubmit: (values: EventFormValues) => Promise<void>
   handleSave: () => Promise<void>
   tempContext: EventFormContext
+  masterEvent: CalendarEvent | null
 } {
   const { eventId, calId, open, onClose, onCloseAll, event, typeOfAction } =
     props
@@ -92,6 +93,7 @@ export function useEventSettingsUpdateModal(
     setShowMore,
     formRef,
     effectiveEvent,
+    masterEvent,
     initialValues,
     handleClose,
     handleSubmit,


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1340

### Change:

When updating the personal settings of a recurring event, the settings are not saved. This is because we missed the type of action (`solo` | `all`). 

https://github.com/user-attachments/assets/833e70bd-4254-4d16-ab33-94abf8a8d26d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event settings updates for recurring events, including more reliable editing flows.
  - “All events” updates now use the original event details and preserve timezone-adjusted start and end times.
  - Improved alarm handling and form value processing when saving event setting changes.
  - Event preview editing now routes consistently through the appropriate settings workflow.
  - Improved handling of settings edits from event previews, including recurring-event choices.
  - Simplified personal settings translation handling for more consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->