### PR TITLE
ISSUE-1100. fix(alarm): Attendee personal alarm is removed after organizer updates global alarm

### DIFF
--- a/common/src/components/Event/EventFormFieldPersonalSettings.tsx
+++ b/common/src/components/Event/EventFormFieldPersonalSettings.tsx
@@ -48,6 +48,7 @@ export function EventFormFieldPersonalSettings({
             return alarm
           }
           return new VAlarm({
+            uid: alarm.uid,
             trigger: alarm.trigger,
             action: alarm.action,
             attendees: [user],

--- a/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
+++ b/common/src/features/Events/hooks/submitUpdateHelpers/utils.ts
@@ -62,6 +62,7 @@ export function buildUpdatedAlarms(
       }
       // New alarm without attendees - add defaults
       return new VAlarm({
+        uid: alarm.uid,
         trigger: alarm.trigger,
         action: alarm.action,
         attendees: alarmAttendees,

--- a/common/src/features/Events/utils/parseCalendarEvent.ts
+++ b/common/src/features/Events/utils/parseCalendarEvent.ts
@@ -265,6 +265,9 @@ type AlarmPropertyHandler = (
 ) => void
 
 const ALARM_PROPERTY_HANDLERS: Record<string, AlarmPropertyHandler> = {
+  uid: (alarm, value) => {
+    alarm.uid = safeString(value)
+  },
   action: (alarm, value) => {
     alarm.action = safeString(value)
   },

--- a/common/src/types/VAlarm.ts
+++ b/common/src/types/VAlarm.ts
@@ -9,6 +9,7 @@ export const DEFAULT_ALARM_DESCRIPTION =
   'This is an automatic alarm sent by Twake Calendar'
 
 export interface AlarmData {
+  uid?: string
   trigger: string
   action: string
   attendees?: userAttendee[]
@@ -17,13 +18,22 @@ export interface AlarmData {
 }
 
 export class VAlarm implements AlarmData {
+  uid?: string
   trigger: string
   action: string
   attendees?: userAttendee[]
   summary?: string
   description?: string
 
-  constructor({ trigger, action, attendees, summary, description }: AlarmData) {
+  constructor({
+    uid,
+    trigger,
+    action,
+    attendees,
+    summary,
+    description
+  }: AlarmData) {
+    this.uid = uid
     this.trigger = normalizeAlarmTrigger(trigger)
     this.action = action
     this.attendees = attendees
@@ -49,6 +59,7 @@ export class VAlarm implements AlarmData {
         )
       }
       return new VAlarm({
+        uid: obj.uid,
         trigger: obj.trigger ?? '',
         action: obj.action ?? '',
         attendees,
@@ -64,6 +75,9 @@ export class VAlarm implements AlarmData {
       ['trigger', {}, 'duration', this.trigger],
       ['action', {}, 'text', this.action]
     ]
+    if (this.uid) {
+      props.unshift(['uid', {}, 'text', this.uid])
+    }
     if (this.attendees) {
       for (const attendee of this.attendees) {
         props.push(['attendee', {}, 'cal-address', attendee.asMailto()])

--- a/common/src/types/Valarms.ts
+++ b/common/src/types/Valarms.ts
@@ -25,6 +25,7 @@ export class Valarms {
       (valarms?.getAlarms() ?? []).map(
         alarm =>
           new VAlarm({
+            uid: alarm.uid,
             trigger: alarm.trigger,
             action: alarm.action,
             attendees: alarm.attendees ?? defaults.attendees,
@@ -165,6 +166,7 @@ export class Valarms {
     )
     if (!remaining.length) return null
     return new VAlarm({
+      uid: alarm.uid,
       trigger: alarm.trigger,
       action: alarm.action,
       attendees: remaining,
@@ -187,11 +189,10 @@ export class Valarms {
     if (!attendee) return formAlarms
 
     const attendeeEmail = this.normalizeEmail(attendee.cal_address)
-    const selectedTriggers = new Set(formAlarms.getAlarms().map(a => a.trigger))
 
     const selectedAlarms = this.processSelectedAlarms(formAlarms)
     const deselectedAlarms = this.processDeselectedAlarms(
-      selectedTriggers,
+      formAlarms,
       attendeeEmail
     )
 
@@ -214,21 +215,28 @@ export class Valarms {
 
   private processSelectedAlarms(formAlarms: Valarms): VAlarm[] {
     return formAlarms.getAlarms().map(formAlarm => {
-      const originalAlarm = this._alarms.find(
-        a => a.trigger === formAlarm.trigger
-      )
+      const originalAlarm = formAlarm.uid
+        ? this._alarms.find(a => a.uid === formAlarm.uid)
+        : this._alarms.find(a => !a.uid && a.trigger === formAlarm.trigger)
       return originalAlarm ?? formAlarm
     })
   }
 
   private processDeselectedAlarms(
-    selectedTriggers: Set<string>,
+    formAlarms: Valarms,
     attendeeEmail: string
   ): VAlarm[] {
     const result: VAlarm[] = []
 
     for (const alarm of this._alarms) {
-      if (selectedTriggers.has(alarm.trigger)) continue
+      const isSelected = alarm.uid
+        ? formAlarms.getAlarms().some(formAlarm => formAlarm.uid === alarm.uid)
+        : formAlarms
+            .getAlarms()
+            .some(
+              formAlarm => !formAlarm.uid && formAlarm.trigger === alarm.trigger
+            )
+      if (isSelected) continue
 
       const processedAlarm = this.processDeselectedAlarm(alarm, attendeeEmail)
       if (processedAlarm) {


### PR DESCRIPTION
resolve https://github.com/linagora/twake-calendar-frontend/issues/1100

## How
- Parse `UID` from VALARM components.
- Preserve VALARM UIDs while rebuilding event alarms.
- Serialize preserved UIDs in outgoing jCal payloads.
- Based on these preserved UIDs, esn-sabre applies the appropriate VALARM merge logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved alarm identifiers when alarms are edited or rebuilt.
  * Alarm identifiers are now correctly read from and written to calendar data.
  * Improved alarm matching during personal settings updates, reducing incorrect replacements when alarms share the same trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->