### PR TITLE
#1334 resolve issue of propose new time

### DIFF
--- a/__test__/features/Events/makeCounterProposalPayload.test.ts
+++ b/__test__/features/Events/makeCounterProposalPayload.test.ts
@@ -1,0 +1,262 @@
+import { makeCounterProposalPayload } from '@calendar/common/src/features/Events/transformers/makeCounterProposalPayload'
+import { parseFetchedEvent } from '@calendar/common/src/features/Events/transformers/parseFetchedEvent'
+import { CalendarEvent } from '@common/types/EventsTypes'
+import { userAttendee } from '@common/features/User/models/attendee'
+import { userOrganiser } from '@common/features/User/userDataTypes'
+
+function createBaseMockEvent(
+  overrides: Partial<CalendarEvent> = {}
+): CalendarEvent {
+  return {
+    URL: 'http://example.com/event',
+    calId: 'cal-1',
+    uid: 'event-uuid-1',
+    start: '2026-09-04T10:00:00',
+    end: '2026-09-04T11:00:00',
+    timezone: 'Europe/Paris',
+    attendee: [
+      new userAttendee({
+        cal_address: 'attendee@example.com',
+        cn: 'Attendee'
+      })
+    ],
+    organizer: new userOrganiser({
+      cal_address: 'organizer@example.com',
+      cn: 'Organizer'
+    }),
+    ...overrides
+  } as CalendarEvent
+}
+
+const defaultProposalParams = {
+  senderEmail: 'attendee@example.com',
+  recipientEmail: 'organizer@example.com',
+  proposedStart: '2026-09-04T14:00:00',
+  proposedEnd: '2026-09-04T15:00:00'
+}
+
+describe('makeCounterProposalPayload', () => {
+  it('should generate a valid counter proposal ICS with timezone', () => {
+    const event = createBaseMockEvent()
+
+    const payload = makeCounterProposalPayload({
+      ...defaultProposalParams,
+      event,
+      message: 'Can we reschedule?'
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.method).toBe('COUNTER')
+    expect(payload.sender).toBe('attendee@example.com')
+    expect(payload.recipient).toBe('organizer@example.com')
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical).toContain('COMMENT:Can we reschedule?')
+  })
+
+  it('should handle event when event has no timezone (fallback to Etc/UTC)', () => {
+    const event = createBaseMockEvent({
+      timezone: undefined
+    })
+
+    const payload = makeCounterProposalPayload({
+      ...defaultProposalParams,
+      event
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical).toContain('TZID:Etc/UTC')
+  })
+
+  it('should handle all-day event correctly', () => {
+    const event = createBaseMockEvent({
+      allday: true,
+      start: '2026-09-04',
+      end: '2026-09-05'
+    })
+
+    const payload = makeCounterProposalPayload({
+      event,
+      senderEmail: defaultProposalParams.senderEmail,
+      recipientEmail: defaultProposalParams.recipientEmail,
+      proposedStart: '2026-09-06',
+      proposedEnd: '2026-09-07'
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical).toContain('VALUE=DATE:20260906')
+  })
+
+  it('should handle attendee with undefined optional properties without crashing', () => {
+    const event = createBaseMockEvent({
+      attendee: [
+        Object.assign(new userAttendee(), {
+          cal_address: 'attendee@example.com',
+          cn: undefined,
+          rsvp: undefined,
+          role: undefined,
+          cutype: undefined
+        })
+      ]
+    })
+
+    const payload = makeCounterProposalPayload({
+      ...defaultProposalParams,
+      event
+    })
+
+    expect(payload).toBeDefined()
+  })
+
+  it('should handle attendee with boolean rsvp (true/false) without crashing', () => {
+    const event = createBaseMockEvent({
+      attendee: [
+        Object.assign(new userAttendee(), {
+          cal_address: 'attendee@example.com',
+          rsvp: true as unknown as 'TRUE'
+        })
+      ]
+    })
+
+    const payload = makeCounterProposalPayload({
+      ...defaultProposalParams,
+      event
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical).toContain('RSVP=TRUE')
+  })
+
+  it('should handle passthrough properties with boolean or numeric parameters without crashing', () => {
+    const event = createBaseMockEvent({
+      passthroughProps: [
+        [
+          'x-custom-prop',
+          { 'x-boolean': true, 'x-count': 42 },
+          'text',
+          'custom-value'
+        ]
+      ]
+    })
+
+    const payload = makeCounterProposalPayload({
+      ...defaultProposalParams,
+      event
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical).toContain('X-CUSTOM-PROP')
+  })
+
+  it('should handle user exact ICS event without errors', () => {
+    const userIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.7//EN
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/Paris
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:4ae1c2fe-462a-47c5-9678-4b56948e8ba7
+DTSTART;TZID=Europe/Paris:20260903T090000
+SEQUENCE:3
+X-OPENPAAS-VIDEOCONFERENCE:https://meet.linagora.com/qni-mdhd-ecb
+SUMMARY:vvvv
+DTEND;TZID=Europe/Paris:20260903T100000
+ORGANIZER;CN=Twake CALENDAR-DEV-2:mailto:twake-calendar-dev-2@linagora.com
+DESCRIPTION:-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~ :~:~:~:~:~:~:~:~::~:~::-\\nJoin Visio : https://meet.linagora.com/qni-mdhd- ecb\\n\\nPlease do not edit this section.\\n-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~ :~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+ATTENDEE;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;ROLE=REQ-PARTICIPANT;CUTYPE=INDIVIDUAL;CN=The Manh LE:mailto:tmle@linagora.com
+ATTENDEE;PARTSTAT=ACCEPTED;RSVP=FALSE;ROLE=CHAIR;CUTYPE=INDIVIDUAL;CN=Twake CALENDAR-DEV-2:mailto:twake-calendar-dev-2@linagora.com
+CONFERENCE;VALUE=URI;FEATURE=AUDIO,VIDEO;LABEL=Join video call:https://meet.linagora.com/qni-mdhd-ecb
+DTSTAMP:20260904T063908Z
+TRANSP:OPAQUE
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR`
+
+    const parsedEvent = parseFetchedEvent(
+      {
+        uid: '4ae1c2fe-462a-47c5-9678-4b56948e8ba7',
+        URL: '/test.ics',
+        calId: 'cal-1'
+      } as CalendarEvent,
+      userIcs
+    )
+
+    const payload = makeCounterProposalPayload({
+      event: parsedEvent,
+      senderEmail: 'tmle@linagora.com',
+      recipientEmail: 'twake-calendar-dev-2@linagora.com',
+      proposedStart: '2026-09-04T14:00:00',
+      proposedEnd: '2026-09-04T15:00:00',
+      message: 'test proposal'
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical.length).toBeGreaterThan(0)
+  })
+
+  it('should handle conference property with feature array without throwing val.replace error', () => {
+    const event: CalendarEvent = {
+      URL: 'http://example.com/event',
+      calId: 'cal-1',
+      uid: '4ae1c2fe-462a-47c5-9678-4b56948e8ba7',
+      start: '2026-09-04T10:00:00',
+      end: '2026-09-04T11:00:00',
+      timezone: 'Europe/Paris',
+      attendee: [
+        new userAttendee({
+          cal_address: 'tmle@linagora.com',
+          cn: 'The Manh LE'
+        })
+      ],
+      organizer: new userOrganiser({
+        cal_address: 'twake-calendar-dev-2@linagora.com',
+        cn: 'Twake CALENDAR-DEV-2'
+      }),
+      passthroughProps: [
+        [
+          'conference',
+          {
+            feature: ['AUDIO', 'VIDEO'],
+            label: 'Join video call'
+          },
+          'uri',
+          'https://meet.linagora.com/qni-mdhd-ecb'
+        ]
+      ]
+    }
+
+    const payload = makeCounterProposalPayload({
+      event,
+      senderEmail: 'tmle@linagora.com',
+      recipientEmail: 'twake-calendar-dev-2@linagora.com',
+      proposedStart: '2026-09-04T14:00:00',
+      proposedEnd: '2026-09-04T15:00:00',
+      message: 'test'
+    })
+
+    expect(payload).toBeDefined()
+    expect(payload.ical).toContain('METHOD:COUNTER')
+    expect(payload.ical).toContain('CONFERENCE')
+    expect(payload.ical).toContain('FEATURE')
+  })
+})

--- a/common/src/features/Events/transformers/makeCounterProposalPayload.ts
+++ b/common/src/features/Events/transformers/makeCounterProposalPayload.ts
@@ -5,6 +5,63 @@ import { CounterProposalPayload } from '@common/features/Events/EventDao'
 import { CalendarEvent } from '@common/types/EventsTypes'
 import { makeTimezone, makeVevent } from '@common/features/Events/utils'
 
+import { resolveTimezone } from '@common/utils/timezone'
+
+import {
+  VCalComponent,
+  VObjectProperty
+} from '@common/features/Calendars/types/CalendarData'
+
+function sanitizePrimitive(val: unknown): string {
+  if (typeof val === 'boolean') return val ? 'TRUE' : 'FALSE'
+  if (typeof val === 'number') return String(val)
+  return typeof val === 'string' ? val : ''
+}
+
+function sanitizeParamValue(
+  key: string,
+  val: unknown
+): string | string[] | undefined {
+  if (val === undefined || val === null) return undefined
+
+  if (Array.isArray(val)) {
+    const isKnownMultiValue = Boolean(
+      (
+        ICAL.design.defaultSet.param as Record<
+          string,
+          { multiValue?: string } | undefined
+        >
+      )[key.toLowerCase()]?.multiValue
+    )
+    const mapped = val.map(sanitizePrimitive)
+    return isKnownMultiValue ? mapped : mapped.join(',')
+  }
+
+  return sanitizePrimitive(val)
+}
+
+function sanitizeProps(props: VObjectProperty[] = []): VObjectProperty[] {
+  return props.map(prop => {
+    const [propName, params, type, value] = prop
+    if (!params || typeof params !== 'object') return prop
+
+    const sanitizedParams: Record<string, string | string[]> = {}
+    for (const [key, val] of Object.entries(params)) {
+      const sanitized = sanitizeParamValue(key, val)
+      if (sanitized !== undefined) {
+        sanitizedParams[key] = sanitized
+      }
+    }
+
+    return [propName, sanitizedParams, type, value]
+  })
+}
+
+function sanitizeJCal(component: VCalComponent): VCalComponent {
+  const [name, props, subcomponents] = component
+  return [name, sanitizeProps(props), (subcomponents || []).map(sanitizeJCal)]
+}
+
 export function makeCounterProposalPayload({
   event,
   senderEmail,
@@ -20,9 +77,14 @@ export function makeCounterProposalPayload({
   proposedEnd: string
   message?: string
 }): CounterProposalPayload {
+  const resolvedTz = resolveTimezone(event.timezone || 'Etc/UTC')
+  const timezone = TIMEZONES.zones[resolvedTz] ? resolvedTz : 'Etc/UTC'
+  const timezoneData = TIMEZONES.zones[resolvedTz] ?? TIMEZONES.zones['Etc/UTC']
+
   // Build the counter event with proposed dates
   const counterEvent: CalendarEvent = {
     ...event,
+    timezone,
     start: proposedStart,
     end: proposedEnd,
     sequence: event.sequence ?? 0
@@ -38,22 +100,25 @@ export function makeCounterProposalPayload({
     vevent[1].push(['comment', {}, 'text', message])
   }
   // Build vtimezone
-  const timezoneData = TIMEZONES.zones[counterEvent.timezone]
   const vtimezone = makeTimezone(timezoneData, counterEvent)
 
   // Assemble full vcalendar with METHOD:COUNTER
-  const jcal = [
+  const jcal: VCalComponent = [
     'vcalendar',
     [
       ['version', {}, 'text', '2.0'],
       ['prodid', {}, 'text', '-//OpenPaaS//OpenPaaS//EN'],
       ['method', {}, 'text', 'COUNTER']
     ],
-    [vevent, vtimezone.component.jCal]
+    [
+      vevent as unknown as VCalComponent,
+      vtimezone.component.jCal as unknown as VCalComponent
+    ]
   ]
 
   // Serialize to raw ICS
-  const counterICS = new ICAL.Component(jcal).toString()
+  const counterICS = new ICAL.Component(sanitizeJCal(jcal)).toString()
+
   const payload: CounterProposalPayload = {
     ical: counterICS,
     sender: senderEmail,

--- a/common/src/features/User/models/attendee.ts
+++ b/common/src/features/User/models/attendee.ts
@@ -99,15 +99,22 @@ export class userAttendee implements UserAttendeeData {
   }
 
   asJcal(): VObjectProperty {
+    const rsvp =
+      typeof this.rsvp === 'boolean'
+        ? this.rsvp
+          ? 'TRUE'
+          : 'FALSE'
+        : String(this.rsvp ?? 'FALSE').toUpperCase()
+
     const params: Record<string, string> = {
-      partstat: this.partstat,
-      rsvp: this.rsvp,
-      role: this.role,
-      cutype: this.cutype
+      partstat: String(this.partstat ?? 'NEEDS-ACTION'),
+      rsvp,
+      role: String(this.role ?? 'REQ-PARTICIPANT'),
+      cutype: String(this.cutype ?? 'INDIVIDUAL')
     }
 
     if (this.cn) {
-      params.cn = this.cn
+      params.cn = String(this.cn)
     }
 
     return ['attendee', params, 'cal-address', this.asMailto()]


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1334

### Change:

When proposing a new time, an error occurs in `ICAL.Component`. This is because the `rsvp` in `attendee` is missing, so the function `ICAL.Component` could not parse the `undefined` value.

To resolve this issue, I added a sanitize function. It helps to parse the value in jCal, return an empty string instead of undefined.


https://github.com/user-attachments/assets/ad3fe1d5-35e3-438f-b802-70b2cc9ecfa4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved calendar counter-proposal generation across time zones, including events without timezone information.
  - Fixed serialization of all-day events, attendee responses, optional attendee details, and conference information.
  - Improved compatibility with real-world calendar data by normalizing event properties before generating ICS content.
  - Prevented errors when attendee RSVP values are provided as either boolean or text values.

- **Tests**
  - Added comprehensive coverage for time zones, attendee details, RSVP values, and parsed calendar events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->