### PR TITLE
Toward a better usage of regexp

### DIFF
--- a/common/src/components/Event/utils/detectUrls.tsx
+++ b/common/src/components/Event/utils/detectUrls.tsx
@@ -10,16 +10,7 @@ export function detectUrls(text: string): JSX.Element[] {
 
   text.replace(urlRegex, (match, _, offset: number) => {
     // Strip trailing punctuation, but preserve balanced parentheses (e.g. Wikipedia)
-    let url = match
-
-    while (/[.,;:!?)]$/.test(url)) {
-      if (url.endsWith(')')) {
-        const openCount = countChar(url, '(')
-        const closeCount = countChar(url, ')')
-        if (closeCount <= openCount) break
-      }
-      url = url.slice(0, -1)
-    }
+    const url = trimTrailingPunctuation(match)
 
     const trailing = match.slice(url.length)
 
@@ -67,6 +58,34 @@ export function detectUrls(text: string): JSX.Element[] {
   return parts
 }
 
-function countChar(value: string, char: '(' | ')'): number {
-  return (value.match(new RegExp(`\\${char}`, 'g')) || []).length
+const TRAILING_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?', ')'])
+
+/**
+ * Drops the punctuation a URL picked up from the surrounding sentence, keeping
+ * a closing parenthesis that balances an opening one inside the URL.
+ *
+ * Counts the parentheses once and updates them as characters are dropped: the
+ * previous version re-counted (and recompiled a RegExp) on every iteration,
+ * which is quadratic in the length of the match, and `location` reaches here
+ * straight from the event.
+ */
+function trimTrailingPunctuation(match: string): string {
+  let openCount = 0
+  let closeCount = 0
+  for (const char of match) {
+    if (char === '(') openCount++
+    else if (char === ')') closeCount++
+  }
+
+  let end = match.length
+  while (end > 0 && TRAILING_PUNCTUATION.has(match[end - 1])) {
+    if (match[end - 1] === ')') {
+      // A closing parenthesis that matches an opening one belongs to the URL.
+      if (closeCount <= openCount) break
+      closeCount--
+    }
+    end--
+  }
+
+  return end === match.length ? match : match.slice(0, end)
 }

--- a/common/src/components/EventPreview/utils/parseDuration.ts
+++ b/common/src/components/EventPreview/utils/parseDuration.ts
@@ -1,3 +1,5 @@
+const MAX_DURATION_LENGTH = 64
+
 /**
  * Parses an ISO 8601 duration string (e.g., -PT20M, -PT1H, P1D, -PT15M)
  * and formats it using the translation function `t`.
@@ -6,6 +8,13 @@ export function translateDuration(
   durationStr: string,
   t: (key: string, options?: Record<string, unknown>) => string
 ): string {
+  // RFC 5545 durations are a couple of dozen characters at most. The unit
+  // lookups below are unanchored `(\d+)X` scans, which backtrack quadratically
+  // over a long digit run, so refuse oversized input rather than parse it.
+  if (durationStr.length > MAX_DURATION_LENGTH) {
+    return durationStr
+  }
+
   // First, check if there is an exact translation key matching this trigger
   const exactKey = `event.form.notifications.${durationStr}`
   const exactTranslation = t(exactKey)

--- a/common/src/utils/EventDescriptionBuilder.tsx
+++ b/common/src/utils/EventDescriptionBuilder.tsx
@@ -14,18 +14,44 @@ export class EventDescriptionBuilder {
     this.attachments = attachments
   }
 
+  /**
+   * Removes every `SEPARATOR ... SEPARATOR` footer block, along with the blank
+   * lines surrounding it.
+   *
+   * Deliberately scan-based rather than regex-based: the previous
+   * `\n*SEP[\s\S]*?SEP\n*` pattern backtracked over its leading `\n*` on
+   * every position of a newline run, which is quadratic in the description
+   * length (a remote attendee could freeze the UI thread with a description
+   * made of one separator preceded by a long run of newlines).
+   */
   public removeFooter(): this {
-    if (this.text.includes(EVENT_FOOTER_SEPARATOR)) {
-      const escapedSeparator = EVENT_FOOTER_SEPARATOR.replace(
-        /[-/\\^$*+?.()|[\]{}]/g,
-        '\\$&'
-      )
-      const regex = new RegExp(
-        `\\n*${escapedSeparator}[\\s\\S]*?${escapedSeparator}\\n*`,
-        'g'
-      )
-      this.text = this.text.replace(regex, '\n').trimEnd()
+    if (!this.text.includes(EVENT_FOOTER_SEPARATOR)) {
+      return this
     }
+
+    const sepLength = EVENT_FOOTER_SEPARATOR.length
+    let result = ''
+    let cursor = 0
+
+    for (;;) {
+      const start = this.text.indexOf(EVENT_FOOTER_SEPARATOR, cursor)
+      if (start === -1) break
+      const end = this.text.indexOf(EVENT_FOOTER_SEPARATOR, start + sepLength)
+      if (end === -1) break
+
+      let from = start
+      while (from > cursor && this.text[from - 1] === '\n') from--
+      let to = end + sepLength
+      while (to < this.text.length && this.text[to] === '\n') to++
+
+      result += this.text.slice(cursor, from)
+      // The newline only joins what surrounds the removed block; a footer that
+      // opens the description has nothing to join it to.
+      if (result) result += '\n'
+      cursor = to
+    }
+
+    this.text = (result + this.text.slice(cursor)).trimEnd()
     return this
   }
 

--- a/common/src/utils/__test__/EventDescriptionBuilder.test.tsx
+++ b/common/src/utils/__test__/EventDescriptionBuilder.test.tsx
@@ -37,6 +37,34 @@ describe('EventDescriptionBuilder', () => {
       const builder = new EventDescriptionBuilder(text).removeFooter()
       expect(builder.buildHtml()).toBe(text)
     })
+
+    it('should remove every footer block when several are present', () => {
+      const text = `Notes\n\n${EVENT_FOOTER_SEPARATOR}\nJoin Visio: a\n${EVENT_FOOTER_SEPARATOR}\n\nMore\n\n${EVENT_FOOTER_SEPARATOR}\nJoin Visio: b\n${EVENT_FOOTER_SEPARATOR}\n\nTail`
+      const builder = new EventDescriptionBuilder(text).removeFooter()
+      expect(builder.buildHtml()).toBe('Notes\nMore\nTail')
+    })
+
+    it('should leave an unterminated separator untouched', () => {
+      const text = `Notes\n\n${EVENT_FOOTER_SEPARATOR}\nJoin Visio: a`
+      const builder = new EventDescriptionBuilder(text).removeFooter()
+      expect(builder.buildHtml()).toBe(text)
+    })
+
+    it('should not leave a leading newline when the footer opens the description', () => {
+      const text = `${EVENT_FOOTER_SEPARATOR}\nJoin Visio: a\n${EVENT_FOOTER_SEPARATOR}\n\nMeeting notes`
+      const builder = new EventDescriptionBuilder(text).removeFooter()
+      expect(builder.buildHtml()).toBe('Meeting notes')
+    })
+
+    // Regression guard for the quadratic backtracking the scan-based
+    // implementation replaced. No wall-clock assertion: the previous
+    // implementation needed ~40s on this input and so blows the suite timeout
+    // on its own, whereas a threshold would be a coin flip on a loaded CI box.
+    it('should stay usable on a long run of newlines before a separator', () => {
+      const text = `${'\n'.repeat(400000)}${EVENT_FOOTER_SEPARATOR}`
+      const builder = new EventDescriptionBuilder(text).removeFooter()
+      expect(builder.buildHtml()).toBe(text.trimEnd())
+    })
   })
 
   describe('withFooter', () => {


### PR DESCRIPTION
```
  ┌────────┬─────────────────────────────────┐
  │ taille │              temps              │
  ├────────┼─────────────────────────────────┤
  │ 8 Ko   │ 634 ms                          │
  ├────────┼─────────────────────────────────┤
  │ 16 Ko  │ 2,9 s                           │
  ├────────┼─────────────────────────────────┤
  │ 59 Ko  │ 62 s de thread principal bloqué │
  └────────┴─────────────────────────────────┘
```
 
Repeated https://example.com/

Similarily

```
  ┌──────────────────────────────┬─────────────────┐
  │            input             │      time       │
  ├──────────────────────────────┼─────────────────┤
  │ 40 000 newlines + one SEP    │ 423 ms          │
  ├──────────────────────────────┼─────────────────┤
  │ 160 000 newlines + one SEP   │ 6.8 s           │
  ├──────────────────────────────┼─────────────────┤
  │ 1 000 000 newlines + one SEP │ killed at 2 min │
  └──────────────────────────────┴─────────────────┘
```

UseREGEXP with caution, KIDS!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL detection when links are followed by punctuation or unbalanced parentheses.
  * Preserved oversized duration text instead of attempting to translate or parse it.
  * Improved event description footer removal, including multiple footer sections, incomplete separators, and descriptions with many newlines.
  * Improved performance when processing lengthy event descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->