### PR TITLE
#1348 warning when adding duplicated participant

### DIFF
--- a/common/src/components/Attendees/AttendeeOptionsList.tsx
+++ b/common/src/components/Attendees/AttendeeOptionsList.tsx
@@ -1,7 +1,9 @@
 import { ListItem, ListItemAvatar, ListItemText } from '@linagora/twake-mui'
 import React, { HTMLAttributes } from 'react'
+import { Typography, Box } from '@linagora/twake-mui'
 import { AttendeeAvatar } from './AttendeeAvatar'
 import { User } from './types'
+import { useI18n } from 'twake-i18n'
 
 export interface AttendeeOptionsListProps extends HTMLAttributes<HTMLLIElement> {
   options: User[]
@@ -15,32 +17,61 @@ export const AttendeeOptionsList: React.FC<AttendeeOptionsListProps> = ({
   selectedUsers,
   ...props
 }) => {
+  const { t } = useI18n()
   return (
     <>
       {options.map(option => {
-        if (selectedUsers.find(u => u.email === option.email)) return null
+        const isSelected = !!selectedUsers.find(u => u.email === option.email)
         const isNotShowEmail = ['resource', 'team-calendar'].includes(
           option.objectType || ''
         )
         return (
           <ListItem
             key={option.email}
-            onClick={() => onOptionClick?.(option)}
+            onClick={() => !isSelected && onOptionClick?.(option)}
             disableGutters
-            sx={{ cursor: 'pointer', py: 1 }}
+            sx={{
+              cursor: isSelected ? 'default' : 'pointer',
+              py: 1,
+              flexDirection: 'column',
+              alignItems: 'flex-start'
+            }}
             {...props}
           >
-            <ListItemAvatar>
-              <AttendeeAvatar option={option} />
-            </ListItemAvatar>
-            <ListItemText
-              primary={option.displayName || option.email}
-              secondary={!isNotShowEmail ? option.email : undefined}
-              slotProps={{
-                primary: { variant: 'body2' },
-                secondary: { variant: 'caption' }
+            <Box
+              sx={{
+                display: 'flex',
+                width: '100%',
+                alignItems: 'center',
+                opacity: isSelected ? 0.6 : 1
               }}
-            />
+            >
+              <ListItemAvatar>
+                <AttendeeAvatar option={option} />
+              </ListItemAvatar>
+              <ListItemText
+                primary={option.displayName || option.email}
+                secondary={!isNotShowEmail ? option.email : undefined}
+                slotProps={{
+                  primary: { variant: 'body2' },
+                  secondary: { variant: 'caption' }
+                }}
+              />
+            </Box>
+            {isSelected && (
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'warning.dark',
+                  display: 'block',
+                  mt: 0.5,
+                  textAlign: 'left',
+                  width: '100%'
+                }}
+              >
+                {t('peopleSearch.emailAlreadyAdded')}
+              </Typography>
+            )}
           </ListItem>
         )
       })}

--- a/common/src/components/Attendees/AttendeeSearch.tsx
+++ b/common/src/components/Attendees/AttendeeSearch.tsx
@@ -195,6 +195,7 @@ export const AttendeeSearch: React.FC<{
       onChange={handleOnChange}
       freeSolo
       enableEmailAutocompleteAndCommit={enableEmailAutocompleteAndCommit}
+      showWarningOnDuplicate
     />
   )
 }

--- a/common/src/components/Attendees/PeopleSearch.tsx
+++ b/common/src/components/Attendees/PeopleSearch.tsx
@@ -60,6 +60,7 @@ export interface PeopleSearchProps {
   inputStyles?: SxProps
   enableEmailAutocompleteAndCommit?: boolean
   autoHighlight?: boolean
+  showWarningOnDuplicate?: boolean
 }
 
 const autocompleteSx = {
@@ -202,7 +203,8 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
   inputValue,
   inputStyles,
   enableEmailAutocompleteAndCommit,
-  autoHighlight = true
+  autoHighlight = true,
+  showWarningOnDuplicate
 }) => {
   const { t } = useI18n()
   const searchPlaceholder = placeholder ?? t('peopleSearch.placeholder')
@@ -216,7 +218,8 @@ export const PeopleSearch: React.FC<PeopleSearchProps> = ({
     selectedUsers,
     onChange,
     freeSolo,
-    enableEmailAutocompleteAndCommit
+    enableEmailAutocompleteAndCommit,
+    showWarningOnDuplicate
   })
 
   const highlightedOptionRef = useRef<User | null>(null)

--- a/common/src/components/Attendees/usePeopleSearchState.ts
+++ b/common/src/components/Attendees/usePeopleSearchState.ts
@@ -23,6 +23,7 @@ interface UsePeopleSearchStateProps {
   onChange: (event: SyntheticEvent, users: User[]) => void
   freeSolo?: boolean
   enableEmailAutocompleteAndCommit?: boolean
+  showWarningOnDuplicate?: boolean
 }
 
 interface UsePeopleSearchStateReturn {
@@ -102,8 +103,15 @@ const useHandleBlurCommit = (
 ): ((event: SyntheticEvent) => void) => {
   return useCallback(
     (event: SyntheticEvent) => {
-      const result = validateAndAddUser(query.trim(), selectedUsers, t)
+      const trimmed = query.trim()
+      if (!trimmed) return
+      const result = validateAndAddUser(trimmed, selectedUsers, t)
       if (result.error !== null) {
+        if (!trimmed.includes('@')) {
+          setQuery('')
+          setInputError(null)
+          return
+        }
         setInputError(result.error)
         return
       }
@@ -122,6 +130,7 @@ const useHandleBlurCommit = (
 const useHandleAutocompleteChange = (
   onChange: (event: SyntheticEvent, users: User[]) => void,
   setInputError: (val: string | null) => void,
+  setQuery: (val: string) => void,
   t: (key: string) => string
 ): ((event: SyntheticEvent, value: (string | User)[]) => void) => {
   return useCallback(
@@ -133,8 +142,9 @@ const useHandleAutocompleteChange = (
       }
       setInputError(null)
       onChange(event, dedupeByEmail(value.map(normaliseUser)))
+      setQuery('')
     },
-    [onChange, setInputError, t]
+    [onChange, setInputError, setQuery, t]
   )
 }
 
@@ -315,6 +325,7 @@ const usePeopleSearchHandlers = ({
   const handleAutocompleteChange = useHandleAutocompleteChange(
     onChange,
     setInputError,
+    setQuery,
     t
   )
 
@@ -359,6 +370,52 @@ const usePeopleSearchHandlers = ({
   }
 }
 
+interface UseDisplayOptionsProps {
+  options: User[]
+  query: string
+  selectedUsers: User[]
+  enableEmailAutocompleteAndCommit?: boolean
+  showWarningOnDuplicate?: boolean
+}
+
+const useDisplayOptions = ({
+  options,
+  query,
+  selectedUsers,
+  enableEmailAutocompleteAndCommit,
+  showWarningOnDuplicate
+}: UseDisplayOptionsProps): User[] => {
+  return useMemo(() => {
+    let baseOptions = options
+
+    const shouldAddEmailOption =
+      baseOptions.length === 0 &&
+      Boolean(query) &&
+      enableEmailAutocompleteAndCommit
+
+    if (shouldAddEmailOption) {
+      const email = EmailAddress.parse(query.trim())
+      if (email) {
+        baseOptions = [{ email: email.value, displayName: email.value } as User]
+      }
+    }
+
+    if (!showWarningOnDuplicate) {
+      baseOptions = baseOptions.filter(
+        opt => !selectedUsers.find(u => u.email === opt.email)
+      )
+    }
+
+    return baseOptions
+  }, [
+    options,
+    query,
+    enableEmailAutocompleteAndCommit,
+    showWarningOnDuplicate,
+    selectedUsers
+  ])
+}
+
 export const usePeopleSearchState = ({
   objectTypes,
   showCurrentUser,
@@ -368,7 +425,8 @@ export const usePeopleSearchState = ({
   selectedUsers,
   onChange,
   freeSolo,
-  enableEmailAutocompleteAndCommit
+  enableEmailAutocompleteAndCommit,
+  showWarningOnDuplicate = false
 }: UsePeopleSearchStateProps): UsePeopleSearchStateReturn => {
   const { t } = useI18n()
   const currentUser = useAppSelector(state => state.user?.userData)
@@ -410,23 +468,13 @@ export const usePeopleSearchState = ({
     enableEmailAutocompleteAndCommit
   })
 
-  const displayOptions = useMemo(() => {
-    if (!enableEmailAutocompleteAndCommit) {
-      return userSearch.options
-    }
-    if (userSearch.options.length === 0 && userSearch.query) {
-      const email = EmailAddress.parse(userSearch.query.trim())
-      if (email && !selectedUsers.some(u => u.email === email.value)) {
-        return [{ email: email.value, displayName: email.value } as User]
-      }
-    }
-    return userSearch.options
-  }, [
-    userSearch.options,
-    userSearch.query,
+  const displayOptions = useDisplayOptions({
+    options: userSearch.options,
+    query: userSearch.query,
     selectedUsers,
-    enableEmailAutocompleteAndCommit
-  ])
+    enableEmailAutocompleteAndCommit,
+    showWarningOnDuplicate
+  })
 
   return {
     ...userSearch,

--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -250,6 +250,7 @@
   "peopleSearch": {
     "label": "Start typing a name or email",
     "placeholder": "Start typing a name or email",
+    "emailAlreadyAdded": "This email has already been added",
     "availabilityPlaceholder": "Check availability",
     "invalidEmail": "%{email} is not a valid email address",
     "searchError": "Unable to fetch contacts right now. Please try again.",

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -250,6 +250,7 @@
   "peopleSearch": {
     "label": "Commencez à saisir un nom ou un e-mail",
     "placeholder": "Commencez à saisir un nom ou un e-mail",
+    "emailAlreadyAdded": "Cet e-mail a déjà été ajouté",
     "availabilityPlaceholder": "Vérifier la disponibilité",
     "invalidEmail": "%{email} n'est pas une adresse e-mail valide",
     "searchError": "Impossible de récupérer les contacts pour le moment. Veuillez réessayer.",

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -250,6 +250,7 @@
   "peopleSearch": {
     "label": "Поиск по имени или email",
     "placeholder": "Введите имя или email",
+    "emailAlreadyAdded": "Этот email уже добавлен",
     "availabilityPlaceholder": "Поск людей",
     "invalidEmail": "%{email} — некорректный адрес",
     "searchError": "Не удалось загрузить контакты. Попробуйте ещё раз.",

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -250,6 +250,7 @@
   "peopleSearch": {
     "label": "Nhập tên hoặc email",
     "placeholder": "Nhập tên hoặc email",
+    "emailAlreadyAdded": "Email này đã được thêm",
     "availabilityPlaceholder": "Kiểm tra tình trạng phòng trống",
     "invalidEmail": "%{email} không phải địa chỉ email hợp lệ",
     "searchError": "Không thể lấy danh bạ. Vui lòng thử lại.",


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1348

### Change:

When adding a participant, if it has already been added, no indicator of the duplication. To make it clearer, we need to add a warning when entering duplicated participant.


https://github.com/user-attachments/assets/2423b72f-59cf-4094-8fab-458e6e8d6534



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Already-selected people remain visible in attendee search results.
  * Selected entries appear with reduced emphasis and an “already added” warning.
  * Selected entries cannot be added again.
  * Duplicate-warning behavior is available in attendee search.
  * The warning is translated in English, French, Russian, and Vietnamese.

* **Bug Fixes**
  * Empty or non-email input is cleared without an unnecessary error.
  * Selecting an attendee now clears the search field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->