### PR TITLE
#1349 change placeholder of adding participants input

### DIFF
--- a/common/src/locales/en.json
+++ b/common/src/locales/en.json
@@ -187,7 +187,7 @@
       "repeat": "Repeat",
       "timezone": "Timezone",
       "timezonePlaceholder": "Select timezone",
-      "addGuestsPlaceholder": "Add guests",
+      "addGuestsPlaceholder": "Add participants",
       "participants": "Participants",
       "videoMeeting": "Video meeting",
       "meetCopied": "Meeting link copied!",

--- a/common/src/locales/fr.json
+++ b/common/src/locales/fr.json
@@ -187,7 +187,7 @@
       "repeat": "Répéter",
       "timezone": "Fuseau horaire",
       "timezonePlaceholder": "Sélectionner un fuseau horaire",
-      "addGuestsPlaceholder": "Ajouter des invités",
+      "addGuestsPlaceholder": "Ajouter des participants",
       "participants": "Participants",
       "videoMeeting": "Visioconférence",
       "meetCopied": "Lien de la visio copié!",

--- a/common/src/locales/ru.json
+++ b/common/src/locales/ru.json
@@ -187,7 +187,7 @@
       "repeat": "Повторять",
       "timezone": "Часовой пояс",
       "timezonePlaceholder": "Выберите часовой пояс",
-      "addGuestsPlaceholder": "Добавить гостей",
+      "addGuestsPlaceholder": "Добавить участников",
       "participants": "Участники",
       "videoMeeting": "Видеовстреча",
       "meetCopied": "Ссылка на встречу скопирована",

--- a/common/src/locales/vi.json
+++ b/common/src/locales/vi.json
@@ -187,7 +187,7 @@
       "repeat": "Lặp lại",
       "timezone": "Múi giờ",
       "timezonePlaceholder": "Chọn múi giờ",
-      "addGuestsPlaceholder": "Thêm khách",
+      "addGuestsPlaceholder": "Thêm người tham gia",
       "participants": "Người tham gia",
       "videoMeeting": "Cuộc họp video",
       "meetCopied": "Đã sao chép liên kết họp!",

--- a/e2e/src/test/java/com/linagora/calendar/e2e/pages/EventFormModal.java
+++ b/e2e/src/test/java/com/linagora/calendar/e2e/pages/EventFormModal.java
@@ -339,7 +339,7 @@ public class EventFormModal {
      */
     public EventFormModal addGuest(String email) {
         for (int attempt = 1; attempt <= 3; attempt++) {
-            Locator guests = page.getByPlaceholder("Add guests");
+            Locator guests = page.getByPlaceholder("Add participants");
             guests.click();
             guests.fill("");
             guests.pressSequentially(email, new Locator.PressSequentiallyOptions().setDelay(30));
@@ -460,7 +460,7 @@ public class EventFormModal {
 
     /** Types a guest without validating, to cover what happens when the field loses focus. */
     public EventFormModal typeGuest(String email) {
-        Locator guests = page.getByPlaceholder("Add guests");
+        Locator guests = page.getByPlaceholder("Add participants");
         guests.click();
         guests.pressSequentially(email, new Locator.PressSequentiallyOptions().setDelay(30));
         return this;


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/1349

### Change:

<img width="537" height="72" alt="image" src="https://github.com/user-attachments/assets/0ea1ec8b-3525-412c-be5f-6999aed477a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the event form placeholder for adding attendees in English, French, Russian, and Vietnamese for clearer terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->