### PR TITLE
#409 remove animation loop of loading app component

### DIFF
--- a/common/src/components/Loading/Loading.tsx
+++ b/common/src/components/Loading/Loading.tsx
@@ -3,7 +3,7 @@ import { DotLottieReact } from '@lottiefiles/dotlottie-react'
 import { Box } from '@linagora/twake-mui'
 import twakeLogo from '@common/static/twake-workplace.svg'
 
-export function Loading() {
+export const Loading: React.FC = () => {
   return (
     <Box
       data-testid="loading"
@@ -22,7 +22,6 @@ export function Loading() {
     >
       <DotLottieReact
         src="/loadercalendar.lottie"
-        loop
         autoplay
         style={{ width: '175px' }}
       />


### PR DESCRIPTION
### Related to:

https://github.com/linagora/twake-calendar-frontend/issues/409

### Change:

After investigation, the redirect does not cause the page to load twice.

Based on the loading animation in Figma, it is related to the looping of the `DotLottieReact`.

My solution is to remove the loop from the animation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the loading component implementation without changing its visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->